### PR TITLE
Add ASL and LSM sign language leader cards

### DIFF
--- a/src/data/leaders.json
+++ b/src/data/leaders.json
@@ -64,6 +64,38 @@
     "retired": true
   },
   {
+    "id": "asl-lead",
+    "name": "ASL Lead Wanted",
+    "role": "American Sign Language Lead",
+    "bio": "Help us make meetups accessible to the deaf and hard-of-hearing community. Coordinate ASL interpreters, advocate for inclusive event planning, and connect us with accessibility resources.",
+    "organization": null,
+    "social": {
+      "github": null,
+      "linkedin": null,
+      "twitter": null,
+      "website": null,
+      "meetup": "https://www.meetup.com/awsugclouddelnorte/"
+    },
+    "placeholder": true,
+    "retired": false
+  },
+  {
+    "id": "lsm-lead",
+    "name": "Se Busca Líder LSM",
+    "role": "Líder de Lengua de Signos Mexicana",
+    "bio": "Ayúdanos a hacer los meetups accesibles para la comunidad sorda y con problemas de audición. Coordina intérpretes de LSM, aboga por planificación de eventos inclusivos, y conéctanos con recursos de accesibilidad.",
+    "organization": null,
+    "social": {
+      "github": null,
+      "linkedin": null,
+      "twitter": null,
+      "website": null,
+      "meetup": "https://www.meetup.com/awsugclouddelnorte/"
+    },
+    "placeholder": true,
+    "retired": false
+  },
+  {
     "id": "open-slot-en",
     "name": "This Could Be You",
     "role": "Future Leader",


### PR DESCRIPTION
## Summary
Adds two new leader placeholder cards to the footer for sign language accessibility roles:

1. **ASL Lead** — American Sign Language Lead (English card)
2. **LSM Lead** — Lengua de Signos Mexicana Lead (Spanish card)

Both cards are marked as "wanted" positions to actively recruit accessibility advocates who can help make meetups inclusive for the deaf and hard-of-hearing community.

## Changes
- ✅ Added ASL lead card with English description
- ✅ Added LSM lead card with Spanish description
- ✅ Cards include calls-to-action (Meetup link) to encourage applications
- ✅ Positioned before generic "Future Leader" cards in footer
- ✅ All tests pass (126/126)
- ✅ Linting clean
- ✅ Build succeeds

## Context
Closes #23

The community is committed to accessibility and wants to feature dedicated roles for coordinating sign language interpreters and advocating for inclusive event planning. These cards signal that commitment and invite qualified leaders to step up.

## Quality Gate
```
✓ npm run lint   — clean
✓ npm test       — 126 tests passed
✓ npm run build  — successful
```

---
**Theren** — Content & Data Specialist