### PR TITLE
feat(auth): src/lib/auth.ts — OIDC PKCE module (#82)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
-lib/
+/lib/
 dist/
 *.log
 .DS_Store

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const HOSTED_UI = 'https://cloud-del-norte.auth.us-west-2.amazoncognito.com';
+const CLIENT_ID = '57eikmt418ea6vti2f6h0pl74r';
+
+describe('auth module', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('decodeToken', () => {
+    it('decodes a standard JWT payload', async () => {
+      const { decodeToken } = await import('../auth');
+      // header.payload.sig  — payload = {"sub":"abc","email":"a@b.co"}
+      const jwt = 'h.eyJzdWIiOiJhYmMiLCJlbWFpbCI6ImFAYi5jbyJ9.sig';
+      expect(decodeToken(jwt)).toEqual({ sub: 'abc', email: 'a@b.co' });
+    });
+
+    it('handles base64url padding', async () => {
+      const { decodeToken } = await import('../auth');
+      // {"a":1} base64url is "eyJhIjoxfQ" (no padding)
+      const jwt = 'h.eyJhIjoxfQ.sig';
+      expect(decodeToken(jwt)).toEqual({ a: 1 });
+    });
+
+    it('throws on malformed jwt', async () => {
+      const { decodeToken } = await import('../auth');
+      expect(() => decodeToken('not-a-jwt')).toThrow();
+    });
+  });
+
+  describe('getIdToken / getAccessToken', () => {
+    it('returns null when storage is empty', async () => {
+      const { getIdToken, getAccessToken } = await import('../auth');
+      expect(getIdToken()).toBeNull();
+      expect(getAccessToken()).toBeNull();
+    });
+
+    it('returns null when tokens are expired', async () => {
+      sessionStorage.setItem('cdn.idToken', 'id-123');
+      sessionStorage.setItem('cdn.accessToken', 'ac-123');
+      sessionStorage.setItem('cdn.expiresAt', String(Date.now() - 1000));
+      const { getIdToken, getAccessToken } = await import('../auth');
+      expect(getIdToken()).toBeNull();
+      expect(getAccessToken()).toBeNull();
+    });
+
+    it('returns tokens when not expired', async () => {
+      sessionStorage.setItem('cdn.idToken', 'id-abc');
+      sessionStorage.setItem('cdn.accessToken', 'ac-abc');
+      sessionStorage.setItem('cdn.expiresAt', String(Date.now() + 60_000));
+      const { getIdToken, getAccessToken } = await import('../auth');
+      expect(getIdToken()).toBe('id-abc');
+      expect(getAccessToken()).toBe('ac-abc');
+    });
+  });
+
+  describe('getRefreshToken', () => {
+    it('returns stored refresh token even if access is expired', async () => {
+      sessionStorage.setItem('cdn.refreshToken', 'rf-xyz');
+      sessionStorage.setItem('cdn.expiresAt', String(Date.now() - 1000));
+      const { getRefreshToken } = await import('../auth');
+      expect(getRefreshToken()).toBe('rf-xyz');
+    });
+  });
+
+  describe('beginLogin', () => {
+    it('stores PKCE verifier + returnTo and redirects to Cognito authorize', async () => {
+      const assign = vi.fn();
+      Object.defineProperty(window, 'location', {
+        value: { origin: 'https://example.test', pathname: '/meetings', search: '?x=1', assign },
+        writable: true,
+      });
+      const { beginLogin } = await import('../auth');
+      await beginLogin();
+
+      const raw = sessionStorage.getItem('cdn.loginState');
+      expect(raw).not.toBeNull();
+      const state = JSON.parse(raw as string);
+      expect(state.pkceVerifier).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+      expect(state.returnTo).toBe('/meetings?x=1');
+
+      expect(assign).toHaveBeenCalledTimes(1);
+      const target = assign.mock.calls[0][0] as string;
+      expect(target.startsWith(`${HOSTED_UI}/oauth2/authorize?`)).toBe(true);
+      const params = new URLSearchParams(target.split('?')[1]);
+      expect(params.get('client_id')).toBe(CLIENT_ID);
+      expect(params.get('response_type')).toBe('code');
+      expect(params.get('code_challenge_method')).toBe('S256');
+      expect(params.get('code_challenge')).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(params.get('redirect_uri')).toBe('https://example.test/auth/callback');
+      expect(params.get('scope')).toBe('openid email profile');
+    });
+
+    it('produces a valid SHA-256 challenge of the verifier', async () => {
+      const assign = vi.fn();
+      Object.defineProperty(window, 'location', {
+        value: { origin: 'https://example.test', pathname: '/', search: '', assign },
+        writable: true,
+      });
+      const { beginLogin } = await import('../auth');
+      await beginLogin('/after');
+
+      const state = JSON.parse(sessionStorage.getItem('cdn.loginState') as string);
+      const verifier: string = state.pkceVerifier;
+
+      const target = assign.mock.calls[0][0] as string;
+      const challenge = new URLSearchParams(target.split('?')[1]).get('code_challenge')!;
+
+      const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+      const bytes = new Uint8Array(digest);
+      let bin = '';
+      for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+      const expected = btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+      expect(challenge).toBe(expected);
+    });
+  });
+
+  describe('signOut', () => {
+    it('clears tokens and redirects to Cognito logout', async () => {
+      sessionStorage.setItem('cdn.idToken', 'x');
+      sessionStorage.setItem('cdn.accessToken', 'x');
+      sessionStorage.setItem('cdn.refreshToken', 'x');
+      sessionStorage.setItem('cdn.expiresAt', String(Date.now() + 60_000));
+      const assign = vi.fn();
+      Object.defineProperty(window, 'location', {
+        value: { origin: 'https://example.test', assign },
+        writable: true,
+      });
+      const { signOut } = await import('../auth');
+      signOut();
+
+      expect(sessionStorage.getItem('cdn.idToken')).toBeNull();
+      expect(sessionStorage.getItem('cdn.accessToken')).toBeNull();
+      expect(sessionStorage.getItem('cdn.refreshToken')).toBeNull();
+      expect(sessionStorage.getItem('cdn.expiresAt')).toBeNull();
+      expect(assign).toHaveBeenCalledTimes(1);
+      const target = assign.mock.calls[0][0] as string;
+      expect(target.startsWith(`${HOSTED_UI}/logout?`)).toBe(true);
+      const params = new URLSearchParams(target.split('?')[1]);
+      expect(params.get('client_id')).toBe(CLIENT_ID);
+      expect(params.get('logout_uri')).toBe('https://example.test');
+    });
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,168 @@
+// OIDC Authorization Code + PKCE flow against Cognito Hosted UI.
+// Zero runtime dependencies. Tokens live in sessionStorage (tab-scoped).
+// Signatures are NOT verified client-side — token-exchange API and prosody enforce on the server.
+
+const HOSTED_UI = 'https://cloud-del-norte.auth.us-west-2.amazoncognito.com';
+const CLIENT_ID = '57eikmt418ea6vti2f6h0pl74r';
+const SCOPES = 'openid email profile';
+
+const KEY_ID_TOKEN = 'cdn.idToken';
+const KEY_ACCESS_TOKEN = 'cdn.accessToken';
+const KEY_REFRESH_TOKEN = 'cdn.refreshToken';
+const KEY_EXPIRES_AT = 'cdn.expiresAt';
+const KEY_LOGIN_STATE = 'cdn.loginState';
+
+interface LoginState {
+  pkceVerifier: string;
+  returnTo: string;
+}
+
+interface TokenResponse {
+  id_token: string;
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  token_type: string;
+}
+
+function redirectUri(): string {
+  return `${window.location.origin}/auth/callback`;
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function randomVerifier(): string {
+  const bytes = new Uint8Array(48);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+async function pkceChallenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+export async function beginLogin(returnTo?: string): Promise<void> {
+  const verifier = randomVerifier();
+  const challenge = await pkceChallenge(verifier);
+  const state: LoginState = {
+    pkceVerifier: verifier,
+    returnTo: returnTo ?? window.location.pathname + window.location.search,
+  };
+  sessionStorage.setItem(KEY_LOGIN_STATE, JSON.stringify(state));
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: CLIENT_ID,
+    redirect_uri: redirectUri(),
+    scope: SCOPES,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  });
+  window.location.assign(`${HOSTED_UI}/oauth2/authorize?${params.toString()}`);
+}
+
+export async function handleCallback(): Promise<{ returnTo: string }> {
+  const url = new URL(window.location.href);
+  const code = url.searchParams.get('code');
+  const error = url.searchParams.get('error');
+  if (error) throw new Error(`oidc error: ${error}`);
+  if (!code) throw new Error('oidc callback missing code');
+
+  const raw = sessionStorage.getItem(KEY_LOGIN_STATE);
+  if (!raw) throw new Error('oidc callback missing login state');
+  const state = JSON.parse(raw) as LoginState;
+  sessionStorage.removeItem(KEY_LOGIN_STATE);
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: CLIENT_ID,
+    code,
+    redirect_uri: redirectUri(),
+    code_verifier: state.pkceVerifier,
+  });
+  const res = await fetch(`${HOSTED_UI}/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!res.ok) throw new Error(`oidc token exchange failed: ${res.status}`);
+  const tokens = (await res.json()) as TokenResponse;
+  storeTokens(tokens);
+  return { returnTo: state.returnTo || '/' };
+}
+
+function storeTokens(tokens: TokenResponse): void {
+  sessionStorage.setItem(KEY_ID_TOKEN, tokens.id_token);
+  sessionStorage.setItem(KEY_ACCESS_TOKEN, tokens.access_token);
+  if (tokens.refresh_token) sessionStorage.setItem(KEY_REFRESH_TOKEN, tokens.refresh_token);
+  sessionStorage.setItem(KEY_EXPIRES_AT, String(Date.now() + tokens.expires_in * 1000));
+}
+
+function isExpired(): boolean {
+  const raw = sessionStorage.getItem(KEY_EXPIRES_AT);
+  if (!raw) return true;
+  return Date.now() >= Number(raw);
+}
+
+export function getIdToken(): string | null {
+  if (isExpired()) return null;
+  return sessionStorage.getItem(KEY_ID_TOKEN);
+}
+
+export function getAccessToken(): string | null {
+  if (isExpired()) return null;
+  return sessionStorage.getItem(KEY_ACCESS_TOKEN);
+}
+
+export function getRefreshToken(): string | null {
+  return sessionStorage.getItem(KEY_REFRESH_TOKEN);
+}
+
+export async function refreshTokens(): Promise<void> {
+  const refresh = getRefreshToken();
+  if (!refresh) throw new Error('no refresh token');
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: CLIENT_ID,
+    refresh_token: refresh,
+  });
+  const res = await fetch(`${HOSTED_UI}/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!res.ok) throw new Error(`oidc refresh failed: ${res.status}`);
+  const tokens = (await res.json()) as TokenResponse;
+  // Cognito refresh response omits refresh_token — preserve existing.
+  if (!tokens.refresh_token) tokens.refresh_token = refresh;
+  storeTokens(tokens);
+}
+
+export function signOut(): void {
+  sessionStorage.removeItem(KEY_ID_TOKEN);
+  sessionStorage.removeItem(KEY_ACCESS_TOKEN);
+  sessionStorage.removeItem(KEY_REFRESH_TOKEN);
+  sessionStorage.removeItem(KEY_EXPIRES_AT);
+  sessionStorage.removeItem(KEY_LOGIN_STATE);
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    logout_uri: window.location.origin,
+  });
+  window.location.assign(`${HOSTED_UI}/logout?${params.toString()}`);
+}
+
+export function decodeToken(jwt: string): Record<string, unknown> {
+  const parts = jwt.split('.');
+  if (parts.length < 2) throw new Error('malformed jwt');
+  let payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+  const pad = payload.length % 4;
+  if (pad) payload += '='.repeat(4 - pad);
+  const json = atob(payload);
+  return JSON.parse(json) as Record<string, unknown>;
+}


### PR DESCRIPTION
Closes #82. Part of epic #81 — P2a foundation.

## What

- `src/lib/auth.ts` (168 LOC) — zero-dep OIDC Authorization Code + PKCE module against Cognito Hosted UI
- `src/lib/__tests__/auth.test.ts` (150 LOC) — 10 vitest cases
- `.gitignore` — scope `lib/` → `/lib/` so vite's root build output stays ignored but `src/lib/` isn't

## Exports

```ts
beginLogin(returnTo?): Promise<void>
handleCallback(): Promise<{ returnTo: string }>
getIdToken() / getAccessToken() / getRefreshToken(): string | null
refreshTokens(): Promise<void>
signOut(): void
decodeToken(jwt): Record<string, unknown>
```

## Design

- PKCE S256 via `crypto.subtle.digest` + `crypto.getRandomValues`, base64url
- Tokens in `sessionStorage` (tab-scoped): `cdn.idToken`, `cdn.accessToken`, `cdn.refreshToken`, `cdn.expiresAt`
- Pre-redirect state in `cdn.loginState` (verifier + returnTo)
- Signatures **not** verified client-side — server enforces on token-exchange API + prosody
- Cognito refresh response omits `refresh_token`; module preserves the existing one

## Verification

- `npx vitest run src/lib/__tests__/auth.test.ts` — 10/10 pass
- `npx tsc --noEmit` clean for `src/lib`
- No runtime dependencies added to package.json

## Test plan

- [x] PKCE challenge is valid base64url SHA-256 of verifier
- [x] `getIdToken()` returns null when missing/expired
- [x] `decodeToken()` handles base64url padding + rejects malformed
- [x] `beginLogin()` stores verifier + returnTo then redirects to Cognito authorize
- [x] `signOut()` clears storage + redirects to Cognito /logout
- [ ] Real end-to-end flow against Cognito — deferred until #85 callback page lands

## Out of scope (follow-up issues)

- React `AuthContext` / `useAuth` — #83
- `RequireAuth` wrapper — #84
- `/auth/callback` MPA page — #85
- jitsi token client — #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)