### PR TITLE
feat(auth): AuthContext + /auth/callback (#83, #85)

### DIFF
--- a/src/contexts/__tests__/auth-context.test.tsx
+++ b/src/contexts/__tests__/auth-context.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, renderHook } from '@testing-library/react';
+
+// Build a JWT with the given payload. Signature is unused — the module never verifies.
+function buildJwt(payload: Record<string, unknown>): string {
+  const b64 = (s: string) =>
+    btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  const header = b64(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+  const body = b64(JSON.stringify(payload));
+  return `${header}.${body}.sig`;
+}
+
+function seedSession(payload: Record<string, unknown>, { expired = false } = {}) {
+  const exp = Math.floor(Date.now() / 1000) + (expired ? -60 : 3600);
+  const iat = Math.floor(Date.now() / 1000) - 60;
+  const jwt = buildJwt({ exp, iat, ...payload });
+  sessionStorage.setItem('cdn.idToken', jwt);
+  sessionStorage.setItem('cdn.accessToken', 'ac');
+  sessionStorage.setItem('cdn.expiresAt', String(expired ? Date.now() - 1000 : Date.now() + 3_600_000));
+  return jwt;
+}
+
+describe('AuthProvider + useAuth', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('exposes unauthenticated state when no token present', async () => {
+    const { AuthProvider } = await import('../auth-context');
+    const { useAuth } = await import('../../hooks/useAuth');
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.idToken).toBeNull();
+    expect(result.current.email).toBeNull();
+    expect(result.current.groups).toEqual([]);
+    expect(result.current.isModerator).toBe(false);
+  });
+
+  it('decodes claims and exposes email, name, groups', async () => {
+    seedSession({
+      email: 'ada@example.test',
+      name: 'Ada Lovelace',
+      'cognito:groups': ['members'],
+    });
+    const { AuthProvider } = await import('../auth-context');
+    const { useAuth } = await import('../../hooks/useAuth');
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.email).toBe('ada@example.test');
+    expect(result.current.name).toBe('Ada Lovelace');
+    expect(result.current.groups).toEqual(['members']);
+    expect(result.current.isModerator).toBe(false);
+  });
+
+  it('sets isModerator when moderators group claim present', async () => {
+    seedSession({
+      email: 'mod@example.test',
+      'cognito:groups': ['moderators', 'members'],
+    });
+    const { AuthProvider } = await import('../auth-context');
+    const { useAuth } = await import('../../hooks/useAuth');
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+    expect(result.current.isModerator).toBe(true);
+  });
+
+  it('falls back to cognito:username when name claim missing', async () => {
+    seedSession({
+      email: 'x@example.test',
+      'cognito:username': 'xuser',
+    });
+    const { AuthProvider } = await import('../auth-context');
+    const { useAuth } = await import('../../hooks/useAuth');
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+    expect(result.current.name).toBe('xuser');
+  });
+
+  it('treats expired token as unauthenticated', async () => {
+    seedSession({ email: 'stale@example.test' }, { expired: true });
+    const { AuthProvider } = await import('../auth-context');
+    const { useAuth } = await import('../../hooks/useAuth');
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('renders children', async () => {
+    const { AuthProvider } = await import('../auth-context');
+    render(
+      <AuthProvider>
+        <div>child-content</div>
+      </AuthProvider>,
+    );
+    expect(screen.getByText('child-content')).toBeInTheDocument();
+  });
+
+  it('useAuth throws outside provider', async () => {
+    const { useAuth } = await import('../../hooks/useAuth');
+    const caught = vi.fn();
+    function Consumer() {
+      try {
+        useAuth();
+      } catch (e) {
+        caught((e as Error).message);
+      }
+      return null;
+    }
+    render(<Consumer />);
+    expect(caught).toHaveBeenCalledWith(expect.stringContaining('AuthProvider'));
+  });
+});

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -1,0 +1,116 @@
+import React, { createContext, useCallback, useEffect, useRef, useState, ReactNode } from 'react';
+import { decodeToken, getIdToken, refreshTokens, signOut as doSignOut } from '../lib/auth';
+
+export interface AuthState {
+  isAuthenticated: boolean;
+  idToken: string | null;
+  email: string | null;
+  name: string | null;
+  groups: string[];
+  isModerator: boolean;
+  signOut: () => void;
+}
+
+export const AuthContext = createContext<AuthState | null>(null);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+// Refresh when <20% of lifetime remains. Token lifetime read from exp claim.
+const REFRESH_THRESHOLD_RATIO = 0.2;
+const MIN_REFRESH_DELAY_MS = 30_000;
+
+function readState(): AuthState {
+  const idToken = getIdToken();
+  if (!idToken) return emptyState();
+  try {
+    const claims = decodeToken(idToken);
+    const groupsClaim = claims['cognito:groups'];
+    const groups = Array.isArray(groupsClaim) ? (groupsClaim as string[]) : [];
+    const email = typeof claims.email === 'string' ? claims.email : null;
+    const name =
+      typeof claims.name === 'string'
+        ? claims.name
+        : typeof claims['cognito:username'] === 'string'
+          ? (claims['cognito:username'] as string)
+          : null;
+    return {
+      isAuthenticated: true,
+      idToken,
+      email,
+      name,
+      groups,
+      isModerator: groups.includes('moderators'),
+      signOut: doSignOut,
+    };
+  } catch {
+    return emptyState();
+  }
+}
+
+function emptyState(): AuthState {
+  return {
+    isAuthenticated: false,
+    idToken: null,
+    email: null,
+    name: null,
+    groups: [],
+    isModerator: false,
+    signOut: doSignOut,
+  };
+}
+
+function nextRefreshDelay(idToken: string): number | null {
+  try {
+    const claims = decodeToken(idToken);
+    const exp = typeof claims.exp === 'number' ? claims.exp : null;
+    const iat = typeof claims.iat === 'number' ? claims.iat : null;
+    if (!exp) return null;
+    const lifetimeMs = iat ? (exp - iat) * 1000 : (exp - Math.floor(Date.now() / 1000)) * 1000;
+    const remainingMs = exp * 1000 - Date.now();
+    const threshold = lifetimeMs * REFRESH_THRESHOLD_RATIO;
+    return Math.max(MIN_REFRESH_DELAY_MS, remainingMs - threshold);
+  } catch {
+    return null;
+  }
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [state, setState] = useState<AuthState>(() => readState());
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const refresh = useCallback(() => {
+    setState(readState());
+  }, []);
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.storageArea !== sessionStorage) return;
+      if (e.key && !e.key.startsWith('cdn.')) return;
+      refresh();
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, [refresh]);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (!state.idToken) return;
+    const delay = nextRefreshDelay(state.idToken);
+    if (delay === null) return;
+    timerRef.current = setTimeout(async () => {
+      try {
+        await refreshTokens();
+      } catch {
+        // fall through — readState() will observe the expired token
+      }
+      refresh();
+    }, delay);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [state.idToken, refresh]);
+
+  return <AuthContext.Provider value={state}>{children}</AuthContext.Provider>;
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { AuthContext } from '../contexts/auth-context';
+import type { AuthState } from '../contexts/auth-context';
+
+export function useAuth(): AuthState {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/src/pages/auth/callback/__tests__/app.test.tsx
+++ b/src/pages/auth/callback/__tests__/app.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+vi.mock('../../../../lib/auth', () => ({
+  handleCallback: vi.fn(),
+}));
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+async function loadApp() {
+  return (await import('../app')).default;
+}
+
+describe('/auth/callback app', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const { handleCallback } = await import('../../../../lib/auth');
+    (handleCallback as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it('on success calls handleCallback and redirects to returnTo', async () => {
+    const replace = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { replace, href: 'https://example.test/auth/callback?code=xyz' },
+      writable: true,
+    });
+
+    const { handleCallback } = await import('../../../../lib/auth');
+    (handleCallback as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ returnTo: '/meetings' });
+
+    const App = await loadApp();
+    render(<App />);
+
+    await waitFor(() => {
+      expect(handleCallback).toHaveBeenCalledTimes(1);
+      expect(replace).toHaveBeenCalledWith('/meetings');
+    });
+  });
+
+  it('defaults redirect to / when returnTo is empty', async () => {
+    const replace = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { replace, href: 'https://example.test/auth/callback?code=xyz' },
+      writable: true,
+    });
+    const { handleCallback } = await import('../../../../lib/auth');
+    (handleCallback as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ returnTo: '' });
+
+    const App = await loadApp();
+    render(<App />);
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('renders error alert when handleCallback throws (no code)', async () => {
+    const { handleCallback } = await import('../../../../lib/auth');
+    (handleCallback as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('oidc callback missing code'),
+    );
+    const App = await loadApp();
+    const { container } = render(<App />);
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/sign-in failed/i);
+      expect(container.textContent).toMatch(/missing code/i);
+    });
+  });
+
+  it('renders error alert when token exchange fails (PKCE mismatch)', async () => {
+    const { handleCallback } = await import('../../../../lib/auth');
+    (handleCallback as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('oidc token exchange failed: 400'),
+    );
+    const App = await loadApp();
+    const { container } = render(<App />);
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/token exchange failed/i);
+    });
+  });
+});

--- a/src/pages/auth/callback/app.tsx
+++ b/src/pages/auth/callback/app.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import Alert from '@cloudscape-design/components/alert';
+import Box from '@cloudscape-design/components/box';
+import Spinner from '@cloudscape-design/components/spinner';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import { handleCallback } from '../../../lib/auth';
+
+type Status = 'exchanging' | 'redirecting' | 'error';
+
+export default function App() {
+  const [status, setStatus] = useState<Status>('exchanging');
+  const [errorMsg, setErrorMsg] = useState<string>('');
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const { returnTo } = await handleCallback();
+        if (cancelled) return;
+        setStatus('redirecting');
+        window.location.replace(returnTo || '/');
+      } catch (err) {
+        if (cancelled) return;
+        setErrorMsg(err instanceof Error ? err.message : 'sign-in failed');
+        setStatus('error');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (status === 'error') {
+    return (
+      <Box padding="xxl">
+        <Alert type="error" header="sign-in failed">
+          {errorMsg}
+          {' — '}
+          <a href="/">return home</a>
+        </Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box padding="xxl" textAlign="center">
+      <SpaceBetween size="l" alignItems="center">
+        <Spinner size="large" />
+        <Box variant="p">signing you in…</Box>
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/src/pages/auth/callback/index.html
+++ b/src/pages/auth/callback/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="light dark" />
+  <title>Cloud Del Norte - signing in</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/auth/callback/main.tsx"></script>
+</body>
+
+</html>

--- a/src/pages/auth/callback/main.tsx
+++ b/src/pages/auth/callback/main.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import '@cloudscape-design/global-styles/index.css';
+import '../../../styles/tokens.css';
+import App from './app';
+
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         'learning/api': resolve(__dirname, './src/pages/learning/api/index.html'),
         'maintenance-calendar': resolve(__dirname, './src/pages/maintenance-calendar/index.html'),
         theme: resolve(__dirname, './src/pages/theme/index.html'),
+        'auth/callback': resolve(__dirname, './src/pages/auth/callback/index.html'),
       },
     },
   },


### PR DESCRIPTION
Closes #83. Closes #85. Part of epic #81 — P2a foundation.

**Stacked on #92 (#82)** — base is `auth/82-oidc-pkce-module`. Merge order: #92 first, then this PR retargets to main automatically.

## What

### #83 — AuthContext + useAuth
- `src/contexts/auth-context.tsx` — AuthProvider reads ID token via `getIdToken()`, decodes claims, exposes state
- `src/hooks/useAuth.ts` — mirrors `useTranslation`; throws outside provider
- Storage event listener for cross-tab sign-out
- Silent-refresh timer at 80% token lifetime (min 30s delay, uses `iat`/`exp` claims)

AuthState shape:
```ts
{ isAuthenticated, idToken, email, name, groups, isModerator, signOut }
```
`name` falls back to `cognito:username` when `name` claim missing. `isModerator = groups.includes('moderators')`.

### #85 — /auth/callback MPA page
- `src/pages/auth/callback/{index.html,main.tsx,app.tsx}` — new MPA entry
- On mount: `handleCallback()` → `window.location.replace(returnTo || '/')`
- On failure: Cloudscape `<Alert type="error">` with message + return-home link
- During exchange: Cloudscape `<Spinner>` + "signing you in…"
- `vite.config.ts` — added `'auth/callback'` rollup input

## Verification

- `npx vitest run` — 21/21 new tests pass (10 #82 + 7 context + 4 callback)
- `npx tsc --noEmit` — clean for new files
- `npx eslint src/lib src/contexts src/hooks src/pages/auth` — clean
- `npx vite build` — succeeds, `auth/callback-*.js` emitted to `lib/`

## Test plan

- [x] AuthProvider exposes authed/unauthed state correctly
- [x] `isModerator` reflects `cognito:groups`
- [x] Falls back to `cognito:username` when name claim missing
- [x] Expired token → unauthenticated
- [x] `useAuth()` throws outside provider
- [x] Callback: success → redirect to returnTo
- [x] Callback: empty returnTo → redirect to /
- [x] Callback: no code → error alert rendered
- [x] Callback: PKCE/400 → error alert rendered
- [ ] Real end-to-end against Cognito Hosted UI — deferred to integration test

## Out of scope (follow-ups)

- `RequireAuth` wrapper — #84
- jitsi token client — #86
- Nav sign-in/out UI — #87
- Page gates + moderator-only — #88, #89
- CSP headers — #91
- Jitsi iframe embed — #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)