### PR TITLE
feat(auth): gate /meetings + /create-meeting (#88, #89)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
-lib/
+/lib/
 dist/
 *.log
 .DS_Store

--- a/src/components/require-auth/__tests__/index.test.tsx
+++ b/src/components/require-auth/__tests__/index.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { AuthState } from '../../../contexts/auth-context';
+
+vi.mock('../../../lib/auth', () => ({
+  beginLogin: vi.fn(),
+  signOut: vi.fn(),
+  // Passed through but not used in these tests:
+  getIdToken: vi.fn(() => null),
+  decodeToken: vi.fn(),
+  refreshTokens: vi.fn(),
+}));
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+import { AuthContext } from '../../../contexts/auth-context';
+import { RequireAuth } from '../index';
+
+function wrap(value: AuthState, children: React.ReactNode) {
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+function authedState(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    isAuthenticated: true,
+    idToken: 'id',
+    email: 'a@b.co',
+    name: 'A',
+    groups: ['members'],
+    isModerator: false,
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+function unauthedState(): AuthState {
+  return {
+    isAuthenticated: false,
+    idToken: null,
+    email: null,
+    name: null,
+    groups: [],
+    isModerator: false,
+    signOut: vi.fn(),
+  };
+}
+
+describe('RequireAuth', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/meetings', search: '?x=1' },
+      writable: true,
+    });
+    const { beginLogin } = await import('../../../lib/auth');
+    (beginLogin as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it('renders children when authenticated and no requireGroup', () => {
+    render(wrap(authedState(), <RequireAuth><div>inside</div></RequireAuth>));
+    expect(screen.getByText('inside')).toBeInTheDocument();
+  });
+
+  it('unauthenticated → calls beginLogin with pathname+search and renders spinner fallback', async () => {
+    const { beginLogin } = await import('../../../lib/auth');
+    const { container } = render(
+      wrap(unauthedState(), <RequireAuth><div>protected</div></RequireAuth>),
+    );
+    await waitFor(() => {
+      expect(beginLogin).toHaveBeenCalledWith('/meetings?x=1');
+    });
+    expect(screen.queryByText('protected')).not.toBeInTheDocument();
+    expect(container.textContent).toMatch(/redirecting to sign-in/i);
+  });
+
+  it('unauthenticated with custom fallback renders fallback', async () => {
+    const { beginLogin } = await import('../../../lib/auth');
+    render(
+      wrap(
+        unauthedState(),
+        <RequireAuth fallback={<div>custom-fb</div>}><div>protected</div></RequireAuth>,
+      ),
+    );
+    await waitFor(() => {
+      expect(beginLogin).toHaveBeenCalled();
+    });
+    expect(screen.getByText('custom-fb')).toBeInTheDocument();
+  });
+
+  it('authed but missing requireGroup → denied alert with sign-out button', () => {
+    const { container } = render(
+      wrap(
+        authedState({ groups: ['members'] }),
+        <RequireAuth requireGroup="moderators"><div>secret</div></RequireAuth>,
+      ),
+    );
+    expect(screen.queryByText('secret')).not.toBeInTheDocument();
+    expect(container.textContent).toMatch(/moderators/i);
+    expect(container.textContent).toMatch(/sign out/i);
+  });
+
+  it('authed with requireGroup match → renders children', () => {
+    render(
+      wrap(
+        authedState({ groups: ['moderators', 'members'], isModerator: true }),
+        <RequireAuth requireGroup="moderators"><div>admin-only</div></RequireAuth>,
+      ),
+    );
+    expect(screen.getByText('admin-only')).toBeInTheDocument();
+  });
+});

--- a/src/components/require-auth/index.tsx
+++ b/src/components/require-auth/index.tsx
@@ -1,0 +1,52 @@
+import React, { ReactNode, useEffect } from 'react';
+import Alert from '@cloudscape-design/components/alert';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import { beginLogin } from '../../lib/auth';
+import { useAuth } from '../../hooks/useAuth';
+
+export interface RequireAuthProps {
+  children: ReactNode;
+  requireGroup?: string;
+  fallback?: ReactNode;
+}
+
+export function RequireAuth({ children, requireGroup, fallback }: RequireAuthProps) {
+  const auth = useAuth();
+
+  useEffect(() => {
+    if (!auth.isAuthenticated) {
+      const returnTo = window.location.pathname + window.location.search;
+      void beginLogin(returnTo);
+    }
+  }, [auth.isAuthenticated]);
+
+  if (!auth.isAuthenticated) {
+    if (fallback) return <>{fallback}</>;
+    return (
+      <Box padding="xxl" textAlign="center">
+        <SpaceBetween size="l" alignItems="center">
+          <Spinner size="large" />
+          <Box variant="p">redirecting to sign-in…</Box>
+        </SpaceBetween>
+      </Box>
+    );
+  }
+
+  if (requireGroup && !auth.groups.includes(requireGroup)) {
+    return (
+      <Box padding="xxl">
+        <Alert type="warning" header="moderator access required">
+          this page requires {requireGroup} group membership.
+          <Box padding={{ top: 's' }}>
+            <Button onClick={auth.signOut}>sign out</Button>
+          </Box>
+        </Alert>
+      </Box>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/contexts/__tests__/auth-context.test.tsx
+++ b/src/contexts/__tests__/auth-context.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, renderHook } from '@testing-library/react';
+
+// Build a JWT with the given payload. Signature is unused — the module never verifies.
+function buildJwt(payload: Record<string, unknown>): string {
+  const b64 = (s: string) =>
+    btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  const header = b64(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+  const body = b64(JSON.stringify(payload));
+  return `${header}.${body}.sig`;
+}
+
+function seedSession(payload: Record<string, unknown>, { expired = false } = {}) {
+  const exp = Math.floor(Date.now() / 1000) + (expired ? -60 : 3600);
+  const iat = Math.floor(Date.now() / 1000) - 60;
+  const jwt = buildJwt({ exp, iat, ...payload });
+  sessionStorage.setItem('cdn.idToken', jwt);
+  sessionStorage.setItem('cdn.accessToken', 'ac');
+  sessionStorage.setItem('cdn.expiresAt', String(expired ? Date.now() - 1000 : Date.now() + 3_600_000));
+  return jwt;
+}
+
+describe('AuthProvider + useAuth', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('exposes unauthenticated state when no token present', async () => {
+    const { AuthProvider } = await import('../auth-context');
+    const { useAuth } = await import('../../hooks/useAuth');
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.idToken).toBeNull();
+    expect(result.current.email).toBeNull();
+    expect(result.current.groups).toEqual([]);
+    expect(result.current.isModerator).toBe(false);
+  });
+
+  it('decodes claims and exposes email, name, groups', async () => {
+    seedSession({
+      email: 'ada@example.test',
+      name: 'Ada Lovelace',
+      'cognito:groups': ['members'],
+    });
+    const { AuthProvider } = await import('../auth-context');
+    const { useAuth } = await import('../../hooks/useAuth');
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.email).toBe('ada@example.test');
+    expect(result.current.name).toBe('Ada Lovelace');
+    expect(result.current.groups).toEqual(['members']);
+    expect(result.current.isModerator).toBe(false);
+  });
+
+  it('sets isModerator when moderators group claim present', async () => {
+    seedSession({
+      email: 'mod@example.test',
+      'cognito:groups': ['moderators', 'members'],
+    });
+    const { AuthProvider } = await import('../auth-context');
+    const { useAuth } = await import('../../hooks/useAuth');
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+    expect(result.current.isModerator).toBe(true);
+  });
+
+  it('falls back to cognito:username when name claim missing', async () => {
+    seedSession({
+      email: 'x@example.test',
+      'cognito:username': 'xuser',
+    });
+    const { AuthProvider } = await import('../auth-context');
+    const { useAuth } = await import('../../hooks/useAuth');
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+    expect(result.current.name).toBe('xuser');
+  });
+
+  it('treats expired token as unauthenticated', async () => {
+    seedSession({ email: 'stale@example.test' }, { expired: true });
+    const { AuthProvider } = await import('../auth-context');
+    const { useAuth } = await import('../../hooks/useAuth');
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    });
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('renders children', async () => {
+    const { AuthProvider } = await import('../auth-context');
+    render(
+      <AuthProvider>
+        <div>child-content</div>
+      </AuthProvider>,
+    );
+    expect(screen.getByText('child-content')).toBeInTheDocument();
+  });
+
+  it('useAuth throws outside provider', async () => {
+    const { useAuth } = await import('../../hooks/useAuth');
+    const caught = vi.fn();
+    function Consumer() {
+      try {
+        useAuth();
+      } catch (e) {
+        caught((e as Error).message);
+      }
+      return null;
+    }
+    render(<Consumer />);
+    expect(caught).toHaveBeenCalledWith(expect.stringContaining('AuthProvider'));
+  });
+});

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -1,0 +1,116 @@
+import React, { createContext, useCallback, useEffect, useRef, useState, ReactNode } from 'react';
+import { decodeToken, getIdToken, refreshTokens, signOut as doSignOut } from '../lib/auth';
+
+export interface AuthState {
+  isAuthenticated: boolean;
+  idToken: string | null;
+  email: string | null;
+  name: string | null;
+  groups: string[];
+  isModerator: boolean;
+  signOut: () => void;
+}
+
+export const AuthContext = createContext<AuthState | null>(null);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+// Refresh when <20% of lifetime remains. Token lifetime read from exp claim.
+const REFRESH_THRESHOLD_RATIO = 0.2;
+const MIN_REFRESH_DELAY_MS = 30_000;
+
+function readState(): AuthState {
+  const idToken = getIdToken();
+  if (!idToken) return emptyState();
+  try {
+    const claims = decodeToken(idToken);
+    const groupsClaim = claims['cognito:groups'];
+    const groups = Array.isArray(groupsClaim) ? (groupsClaim as string[]) : [];
+    const email = typeof claims.email === 'string' ? claims.email : null;
+    const name =
+      typeof claims.name === 'string'
+        ? claims.name
+        : typeof claims['cognito:username'] === 'string'
+          ? (claims['cognito:username'] as string)
+          : null;
+    return {
+      isAuthenticated: true,
+      idToken,
+      email,
+      name,
+      groups,
+      isModerator: groups.includes('moderators'),
+      signOut: doSignOut,
+    };
+  } catch {
+    return emptyState();
+  }
+}
+
+function emptyState(): AuthState {
+  return {
+    isAuthenticated: false,
+    idToken: null,
+    email: null,
+    name: null,
+    groups: [],
+    isModerator: false,
+    signOut: doSignOut,
+  };
+}
+
+function nextRefreshDelay(idToken: string): number | null {
+  try {
+    const claims = decodeToken(idToken);
+    const exp = typeof claims.exp === 'number' ? claims.exp : null;
+    const iat = typeof claims.iat === 'number' ? claims.iat : null;
+    if (!exp) return null;
+    const lifetimeMs = iat ? (exp - iat) * 1000 : (exp - Math.floor(Date.now() / 1000)) * 1000;
+    const remainingMs = exp * 1000 - Date.now();
+    const threshold = lifetimeMs * REFRESH_THRESHOLD_RATIO;
+    return Math.max(MIN_REFRESH_DELAY_MS, remainingMs - threshold);
+  } catch {
+    return null;
+  }
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [state, setState] = useState<AuthState>(() => readState());
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const refresh = useCallback(() => {
+    setState(readState());
+  }, []);
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.storageArea !== sessionStorage) return;
+      if (e.key && !e.key.startsWith('cdn.')) return;
+      refresh();
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, [refresh]);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (!state.idToken) return;
+    const delay = nextRefreshDelay(state.idToken);
+    if (delay === null) return;
+    timerRef.current = setTimeout(async () => {
+      try {
+        await refreshTokens();
+      } catch {
+        // fall through — readState() will observe the expired token
+      }
+      refresh();
+    }, delay);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [state.idToken, refresh]);
+
+  return <AuthContext.Provider value={state}>{children}</AuthContext.Provider>;
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { AuthContext } from '../contexts/auth-context';
+import type { AuthState } from '../contexts/auth-context';
+
+export function useAuth(): AuthState {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/src/layouts/shell/index.tsx
+++ b/src/layouts/shell/index.tsx
@@ -6,7 +6,10 @@ import TopNavigation from '@cloudscape-design/components/top-navigation';
 import Footer from '../../components/footer';
 import { type Locale, getStoredNavState, setStoredNavState } from '../../utils/locale';
 import { LocaleProvider } from '../../contexts/locale-context';
+import { AuthProvider } from '../../contexts/auth-context';
 import { useTranslation } from '../../hooks/useTranslation';
+import { useAuth } from '../../hooks/useAuth';
+import { beginLogin } from '../../lib/auth';
 
 import './styles.css';
 
@@ -26,6 +29,7 @@ export interface ShellProps {
 
 function ShellContent({ children, contentType, breadcrumbs, tools, navigation, notifications, theme, onThemeChange, locale, onLocaleChange, pageTitle }: ShellProps) {
   const { t } = useTranslation();
+  const auth = useAuth();
   const [animating, setAnimating] = useState(false);
   const [animatingLocale, setAnimatingLocale] = useState(false);
   
@@ -98,7 +102,25 @@ function ShellContent({ children, contentType, breadcrumbs, tools, navigation, n
               text: theme === 'dark' ? '☀️' : '🌙',
               title: theme === 'dark' ? t('shell.switchToLightMode') : t('shell.switchToDarkMode'),
               onClick: handleToggleTheme,
-            }
+            },
+            auth.isAuthenticated
+              ? {
+                  type: 'menu-dropdown',
+                  text: auth.email ?? auth.name ?? 'account',
+                  description: auth.isModerator ? 'moderator' : undefined,
+                  iconName: 'user-profile',
+                  items: [{ id: 'signout', text: 'sign out' }],
+                  onItemClick: (e: { detail: { id: string } }) => {
+                    if (e.detail.id === 'signout') auth.signOut();
+                  },
+                }
+              : {
+                  type: 'button',
+                  text: 'sign in',
+                  onClick: () => {
+                    void beginLogin();
+                  },
+                },
           ]}
           i18nStrings={{
             overflowMenuTriggerText: t('shell.more'),
@@ -134,8 +156,10 @@ function ShellContent({ children, contentType, breadcrumbs, tools, navigation, n
 
 export default function Shell(props: ShellProps) {
   return (
-    <LocaleProvider locale={props.locale ?? 'us'}>
-      <ShellContent {...props} />
-    </LocaleProvider>
+    <AuthProvider>
+      <LocaleProvider locale={props.locale ?? 'us'}>
+        <ShellContent {...props} />
+      </LocaleProvider>
+    </AuthProvider>
   );
 }

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const HOSTED_UI = 'https://cloud-del-norte.auth.us-west-2.amazoncognito.com';
+const CLIENT_ID = '57eikmt418ea6vti2f6h0pl74r';
+
+describe('auth module', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('decodeToken', () => {
+    it('decodes a standard JWT payload', async () => {
+      const { decodeToken } = await import('../auth');
+      // header.payload.sig  — payload = {"sub":"abc","email":"a@b.co"}
+      const jwt = 'h.eyJzdWIiOiJhYmMiLCJlbWFpbCI6ImFAYi5jbyJ9.sig';
+      expect(decodeToken(jwt)).toEqual({ sub: 'abc', email: 'a@b.co' });
+    });
+
+    it('handles base64url padding', async () => {
+      const { decodeToken } = await import('../auth');
+      // {"a":1} base64url is "eyJhIjoxfQ" (no padding)
+      const jwt = 'h.eyJhIjoxfQ.sig';
+      expect(decodeToken(jwt)).toEqual({ a: 1 });
+    });
+
+    it('throws on malformed jwt', async () => {
+      const { decodeToken } = await import('../auth');
+      expect(() => decodeToken('not-a-jwt')).toThrow();
+    });
+  });
+
+  describe('getIdToken / getAccessToken', () => {
+    it('returns null when storage is empty', async () => {
+      const { getIdToken, getAccessToken } = await import('../auth');
+      expect(getIdToken()).toBeNull();
+      expect(getAccessToken()).toBeNull();
+    });
+
+    it('returns null when tokens are expired', async () => {
+      sessionStorage.setItem('cdn.idToken', 'id-123');
+      sessionStorage.setItem('cdn.accessToken', 'ac-123');
+      sessionStorage.setItem('cdn.expiresAt', String(Date.now() - 1000));
+      const { getIdToken, getAccessToken } = await import('../auth');
+      expect(getIdToken()).toBeNull();
+      expect(getAccessToken()).toBeNull();
+    });
+
+    it('returns tokens when not expired', async () => {
+      sessionStorage.setItem('cdn.idToken', 'id-abc');
+      sessionStorage.setItem('cdn.accessToken', 'ac-abc');
+      sessionStorage.setItem('cdn.expiresAt', String(Date.now() + 60_000));
+      const { getIdToken, getAccessToken } = await import('../auth');
+      expect(getIdToken()).toBe('id-abc');
+      expect(getAccessToken()).toBe('ac-abc');
+    });
+  });
+
+  describe('getRefreshToken', () => {
+    it('returns stored refresh token even if access is expired', async () => {
+      sessionStorage.setItem('cdn.refreshToken', 'rf-xyz');
+      sessionStorage.setItem('cdn.expiresAt', String(Date.now() - 1000));
+      const { getRefreshToken } = await import('../auth');
+      expect(getRefreshToken()).toBe('rf-xyz');
+    });
+  });
+
+  describe('beginLogin', () => {
+    it('stores PKCE verifier + returnTo and redirects to Cognito authorize', async () => {
+      const assign = vi.fn();
+      Object.defineProperty(window, 'location', {
+        value: { origin: 'https://example.test', pathname: '/meetings', search: '?x=1', assign },
+        writable: true,
+      });
+      const { beginLogin } = await import('../auth');
+      await beginLogin();
+
+      const raw = sessionStorage.getItem('cdn.loginState');
+      expect(raw).not.toBeNull();
+      const state = JSON.parse(raw as string);
+      expect(state.pkceVerifier).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+      expect(state.returnTo).toBe('/meetings?x=1');
+
+      expect(assign).toHaveBeenCalledTimes(1);
+      const target = assign.mock.calls[0][0] as string;
+      expect(target.startsWith(`${HOSTED_UI}/oauth2/authorize?`)).toBe(true);
+      const params = new URLSearchParams(target.split('?')[1]);
+      expect(params.get('client_id')).toBe(CLIENT_ID);
+      expect(params.get('response_type')).toBe('code');
+      expect(params.get('code_challenge_method')).toBe('S256');
+      expect(params.get('code_challenge')).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(params.get('redirect_uri')).toBe('https://example.test/auth/callback');
+      expect(params.get('scope')).toBe('openid email profile');
+    });
+
+    it('produces a valid SHA-256 challenge of the verifier', async () => {
+      const assign = vi.fn();
+      Object.defineProperty(window, 'location', {
+        value: { origin: 'https://example.test', pathname: '/', search: '', assign },
+        writable: true,
+      });
+      const { beginLogin } = await import('../auth');
+      await beginLogin('/after');
+
+      const state = JSON.parse(sessionStorage.getItem('cdn.loginState') as string);
+      const verifier: string = state.pkceVerifier;
+
+      const target = assign.mock.calls[0][0] as string;
+      const challenge = new URLSearchParams(target.split('?')[1]).get('code_challenge')!;
+
+      const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+      const bytes = new Uint8Array(digest);
+      let bin = '';
+      for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+      const expected = btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+      expect(challenge).toBe(expected);
+    });
+  });
+
+  describe('signOut', () => {
+    it('clears tokens and redirects to Cognito logout', async () => {
+      sessionStorage.setItem('cdn.idToken', 'x');
+      sessionStorage.setItem('cdn.accessToken', 'x');
+      sessionStorage.setItem('cdn.refreshToken', 'x');
+      sessionStorage.setItem('cdn.expiresAt', String(Date.now() + 60_000));
+      const assign = vi.fn();
+      Object.defineProperty(window, 'location', {
+        value: { origin: 'https://example.test', assign },
+        writable: true,
+      });
+      const { signOut } = await import('../auth');
+      signOut();
+
+      expect(sessionStorage.getItem('cdn.idToken')).toBeNull();
+      expect(sessionStorage.getItem('cdn.accessToken')).toBeNull();
+      expect(sessionStorage.getItem('cdn.refreshToken')).toBeNull();
+      expect(sessionStorage.getItem('cdn.expiresAt')).toBeNull();
+      expect(assign).toHaveBeenCalledTimes(1);
+      const target = assign.mock.calls[0][0] as string;
+      expect(target.startsWith(`${HOSTED_UI}/logout?`)).toBe(true);
+      const params = new URLSearchParams(target.split('?')[1]);
+      expect(params.get('client_id')).toBe(CLIENT_ID);
+      expect(params.get('logout_uri')).toBe('https://example.test');
+    });
+  });
+});

--- a/src/lib/__tests__/jitsi-token.test.ts
+++ b/src/lib/__tests__/jitsi-token.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../auth', () => ({
+  getIdToken: vi.fn(),
+  refreshTokens: vi.fn(),
+}));
+
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('jitsi-token', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const { getIdToken, refreshTokens } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReset();
+    (refreshTokens as ReturnType<typeof vi.fn>).mockReset();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws when not authenticated', async () => {
+    const { getIdToken } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const { fetchJitsiToken, clearJitsiTokenCache } = await import('../jitsi-token');
+    clearJitsiTokenCache();
+    await expect(fetchJitsiToken()).rejects.toThrow(/not authenticated/);
+  });
+
+  it('happy path returns parsed response and sends bearer token', async () => {
+    const { getIdToken } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReturnValue('id-abc');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse(200, {
+        token: 'jitsi-jwt',
+        domain: 'meet.clouddelnorte.org',
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    );
+    const { fetchJitsiToken, clearJitsiTokenCache } = await import('../jitsi-token');
+    clearJitsiTokenCache();
+
+    const res = await fetchJitsiToken();
+    expect(res.token).toBe('jitsi-jwt');
+    expect(res.domain).toBe('meet.clouddelnorte.org');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toBe('https://rwmypxz9z6.execute-api.us-west-2.amazonaws.com/token/jitsi');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: 'Bearer id-abc' });
+  });
+
+  it('throws BannedUserError on 403', async () => {
+    const { getIdToken } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReturnValue('id-x');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse(403, { message: 'banned' }));
+    const { fetchJitsiToken, BannedUserError, clearJitsiTokenCache } = await import('../jitsi-token');
+    clearJitsiTokenCache();
+    await expect(fetchJitsiToken()).rejects.toBeInstanceOf(BannedUserError);
+  });
+
+  it('on 401 refreshes and retries once', async () => {
+    const { getIdToken, refreshTokens } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce('stale')
+      .mockReturnValueOnce('fresh');
+    (refreshTokens as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockResponse(401, {}))
+      .mockResolvedValueOnce(
+        mockResponse(200, {
+          token: 'jitsi-jwt-2',
+          domain: 'meet.clouddelnorte.org',
+          expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        }),
+      );
+
+    const { fetchJitsiToken, clearJitsiTokenCache } = await import('../jitsi-token');
+    clearJitsiTokenCache();
+    const res = await fetchJitsiToken();
+    expect(res.token).toBe('jitsi-jwt-2');
+    expect(refreshTokens).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[1][1]).toMatchObject({
+      headers: { Authorization: 'Bearer fresh' },
+    });
+  });
+
+  it('caches the token within expiry window', async () => {
+    const { getIdToken } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReturnValue('id-abc');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse(200, {
+        token: 'cached-jwt',
+        domain: 'meet.clouddelnorte.org',
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    );
+    const { fetchJitsiToken, clearJitsiTokenCache } = await import('../jitsi-token');
+    clearJitsiTokenCache();
+
+    const a = await fetchJitsiToken();
+    const b = await fetchJitsiToken();
+    expect(a).toBe(b);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,168 @@
+// OIDC Authorization Code + PKCE flow against Cognito Hosted UI.
+// Zero runtime dependencies. Tokens live in sessionStorage (tab-scoped).
+// Signatures are NOT verified client-side — token-exchange API and prosody enforce on the server.
+
+const HOSTED_UI = 'https://cloud-del-norte.auth.us-west-2.amazoncognito.com';
+const CLIENT_ID = '57eikmt418ea6vti2f6h0pl74r';
+const SCOPES = 'openid email profile';
+
+const KEY_ID_TOKEN = 'cdn.idToken';
+const KEY_ACCESS_TOKEN = 'cdn.accessToken';
+const KEY_REFRESH_TOKEN = 'cdn.refreshToken';
+const KEY_EXPIRES_AT = 'cdn.expiresAt';
+const KEY_LOGIN_STATE = 'cdn.loginState';
+
+interface LoginState {
+  pkceVerifier: string;
+  returnTo: string;
+}
+
+interface TokenResponse {
+  id_token: string;
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  token_type: string;
+}
+
+function redirectUri(): string {
+  return `${window.location.origin}/auth/callback`;
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function randomVerifier(): string {
+  const bytes = new Uint8Array(48);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+async function pkceChallenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+export async function beginLogin(returnTo?: string): Promise<void> {
+  const verifier = randomVerifier();
+  const challenge = await pkceChallenge(verifier);
+  const state: LoginState = {
+    pkceVerifier: verifier,
+    returnTo: returnTo ?? window.location.pathname + window.location.search,
+  };
+  sessionStorage.setItem(KEY_LOGIN_STATE, JSON.stringify(state));
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: CLIENT_ID,
+    redirect_uri: redirectUri(),
+    scope: SCOPES,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  });
+  window.location.assign(`${HOSTED_UI}/oauth2/authorize?${params.toString()}`);
+}
+
+export async function handleCallback(): Promise<{ returnTo: string }> {
+  const url = new URL(window.location.href);
+  const code = url.searchParams.get('code');
+  const error = url.searchParams.get('error');
+  if (error) throw new Error(`oidc error: ${error}`);
+  if (!code) throw new Error('oidc callback missing code');
+
+  const raw = sessionStorage.getItem(KEY_LOGIN_STATE);
+  if (!raw) throw new Error('oidc callback missing login state');
+  const state = JSON.parse(raw) as LoginState;
+  sessionStorage.removeItem(KEY_LOGIN_STATE);
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: CLIENT_ID,
+    code,
+    redirect_uri: redirectUri(),
+    code_verifier: state.pkceVerifier,
+  });
+  const res = await fetch(`${HOSTED_UI}/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!res.ok) throw new Error(`oidc token exchange failed: ${res.status}`);
+  const tokens = (await res.json()) as TokenResponse;
+  storeTokens(tokens);
+  return { returnTo: state.returnTo || '/' };
+}
+
+function storeTokens(tokens: TokenResponse): void {
+  sessionStorage.setItem(KEY_ID_TOKEN, tokens.id_token);
+  sessionStorage.setItem(KEY_ACCESS_TOKEN, tokens.access_token);
+  if (tokens.refresh_token) sessionStorage.setItem(KEY_REFRESH_TOKEN, tokens.refresh_token);
+  sessionStorage.setItem(KEY_EXPIRES_AT, String(Date.now() + tokens.expires_in * 1000));
+}
+
+function isExpired(): boolean {
+  const raw = sessionStorage.getItem(KEY_EXPIRES_AT);
+  if (!raw) return true;
+  return Date.now() >= Number(raw);
+}
+
+export function getIdToken(): string | null {
+  if (isExpired()) return null;
+  return sessionStorage.getItem(KEY_ID_TOKEN);
+}
+
+export function getAccessToken(): string | null {
+  if (isExpired()) return null;
+  return sessionStorage.getItem(KEY_ACCESS_TOKEN);
+}
+
+export function getRefreshToken(): string | null {
+  return sessionStorage.getItem(KEY_REFRESH_TOKEN);
+}
+
+export async function refreshTokens(): Promise<void> {
+  const refresh = getRefreshToken();
+  if (!refresh) throw new Error('no refresh token');
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: CLIENT_ID,
+    refresh_token: refresh,
+  });
+  const res = await fetch(`${HOSTED_UI}/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!res.ok) throw new Error(`oidc refresh failed: ${res.status}`);
+  const tokens = (await res.json()) as TokenResponse;
+  // Cognito refresh response omits refresh_token — preserve existing.
+  if (!tokens.refresh_token) tokens.refresh_token = refresh;
+  storeTokens(tokens);
+}
+
+export function signOut(): void {
+  sessionStorage.removeItem(KEY_ID_TOKEN);
+  sessionStorage.removeItem(KEY_ACCESS_TOKEN);
+  sessionStorage.removeItem(KEY_REFRESH_TOKEN);
+  sessionStorage.removeItem(KEY_EXPIRES_AT);
+  sessionStorage.removeItem(KEY_LOGIN_STATE);
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    logout_uri: window.location.origin,
+  });
+  window.location.assign(`${HOSTED_UI}/logout?${params.toString()}`);
+}
+
+export function decodeToken(jwt: string): Record<string, unknown> {
+  const parts = jwt.split('.');
+  if (parts.length < 2) throw new Error('malformed jwt');
+  let payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+  const pad = payload.length % 4;
+  if (pad) payload += '='.repeat(4 - pad);
+  const json = atob(payload);
+  return JSON.parse(json) as Record<string, unknown>;
+}

--- a/src/lib/jitsi-token.ts
+++ b/src/lib/jitsi-token.ts
@@ -1,0 +1,58 @@
+import { getIdToken, refreshTokens } from './auth';
+
+const API_BASE = 'https://rwmypxz9z6.execute-api.us-west-2.amazonaws.com';
+const TOKEN_PATH = '/token/jitsi';
+
+export interface JitsiTokenResponse {
+  token: string;
+  domain: string;
+  expiresAt: number;
+}
+
+export class BannedUserError extends Error {
+  constructor(message = 'user is banned') {
+    super(message);
+    this.name = 'BannedUserError';
+  }
+}
+
+let cached: JitsiTokenResponse | null = null;
+
+export function clearJitsiTokenCache(): void {
+  cached = null;
+}
+
+async function requestToken(idToken: string): Promise<Response> {
+  return fetch(`${API_BASE}${TOKEN_PATH}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: '{}',
+  });
+}
+
+export async function fetchJitsiToken(): Promise<JitsiTokenResponse> {
+  if (cached && cached.expiresAt * 1000 > Date.now() + 30_000) return cached;
+
+  let idToken = getIdToken();
+  if (!idToken) throw new Error('not authenticated');
+
+  let res = await requestToken(idToken);
+
+  if (res.status === 401) {
+    await refreshTokens();
+    idToken = getIdToken();
+    if (!idToken) throw new Error('refresh failed — not authenticated');
+    res = await requestToken(idToken);
+    if (res.status === 401) throw new Error('token-exchange unauthorized after refresh');
+  }
+
+  if (res.status === 403) throw new BannedUserError();
+  if (!res.ok) throw new Error(`token-exchange failed: ${res.status}`);
+
+  const body = (await res.json()) as JitsiTokenResponse;
+  cached = body;
+  return body;
+}

--- a/src/pages/auth/callback/__tests__/app.test.tsx
+++ b/src/pages/auth/callback/__tests__/app.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+vi.mock('../../../../lib/auth', () => ({
+  handleCallback: vi.fn(),
+}));
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+async function loadApp() {
+  return (await import('../app')).default;
+}
+
+describe('/auth/callback app', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const { handleCallback } = await import('../../../../lib/auth');
+    (handleCallback as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it('on success calls handleCallback and redirects to returnTo', async () => {
+    const replace = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { replace, href: 'https://example.test/auth/callback?code=xyz' },
+      writable: true,
+    });
+
+    const { handleCallback } = await import('../../../../lib/auth');
+    (handleCallback as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ returnTo: '/meetings' });
+
+    const App = await loadApp();
+    render(<App />);
+
+    await waitFor(() => {
+      expect(handleCallback).toHaveBeenCalledTimes(1);
+      expect(replace).toHaveBeenCalledWith('/meetings');
+    });
+  });
+
+  it('defaults redirect to / when returnTo is empty', async () => {
+    const replace = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { replace, href: 'https://example.test/auth/callback?code=xyz' },
+      writable: true,
+    });
+    const { handleCallback } = await import('../../../../lib/auth');
+    (handleCallback as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ returnTo: '' });
+
+    const App = await loadApp();
+    render(<App />);
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('renders error alert when handleCallback throws (no code)', async () => {
+    const { handleCallback } = await import('../../../../lib/auth');
+    (handleCallback as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('oidc callback missing code'),
+    );
+    const App = await loadApp();
+    const { container } = render(<App />);
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/sign-in failed/i);
+      expect(container.textContent).toMatch(/missing code/i);
+    });
+  });
+
+  it('renders error alert when token exchange fails (PKCE mismatch)', async () => {
+    const { handleCallback } = await import('../../../../lib/auth');
+    (handleCallback as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('oidc token exchange failed: 400'),
+    );
+    const App = await loadApp();
+    const { container } = render(<App />);
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/token exchange failed/i);
+    });
+  });
+});

--- a/src/pages/auth/callback/app.tsx
+++ b/src/pages/auth/callback/app.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import Alert from '@cloudscape-design/components/alert';
+import Box from '@cloudscape-design/components/box';
+import Spinner from '@cloudscape-design/components/spinner';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import { handleCallback } from '../../../lib/auth';
+
+type Status = 'exchanging' | 'redirecting' | 'error';
+
+export default function App() {
+  const [status, setStatus] = useState<Status>('exchanging');
+  const [errorMsg, setErrorMsg] = useState<string>('');
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const { returnTo } = await handleCallback();
+        if (cancelled) return;
+        setStatus('redirecting');
+        window.location.replace(returnTo || '/');
+      } catch (err) {
+        if (cancelled) return;
+        setErrorMsg(err instanceof Error ? err.message : 'sign-in failed');
+        setStatus('error');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (status === 'error') {
+    return (
+      <Box padding="xxl">
+        <Alert type="error" header="sign-in failed">
+          {errorMsg}
+          {' — '}
+          <a href="/">return home</a>
+        </Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box padding="xxl" textAlign="center">
+      <SpaceBetween size="l" alignItems="center">
+        <Spinner size="large" />
+        <Box variant="p">signing you in…</Box>
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/src/pages/auth/callback/index.html
+++ b/src/pages/auth/callback/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="light dark" />
+  <title>Cloud Del Norte - signing in</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/auth/callback/main.tsx"></script>
+</body>
+
+</html>

--- a/src/pages/auth/callback/main.tsx
+++ b/src/pages/auth/callback/main.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import '@cloudscape-design/global-styles/index.css';
+import '../../../styles/tokens.css';
+import App from './app';
+
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/pages/create-meeting/__tests__/auth-gating.test.tsx
+++ b/src/pages/create-meeting/__tests__/auth-gating.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AuthContext } from '../../../contexts/auth-context';
+import type { AuthState } from '../../../contexts/auth-context';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyProps = Record<string, any>;
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+vi.mock('../../../lib/auth', () => ({
+  beginLogin: vi.fn(),
+  signOut: vi.fn(),
+  getIdToken: vi.fn(() => null),
+  decodeToken: vi.fn(),
+  refreshTokens: vi.fn(),
+}));
+
+vi.mock('../../../layouts/shell', () => ({
+  default: ({ children }: AnyProps) => React.createElement('div', null, children),
+}));
+vi.mock('../../../components/navigation', () => ({
+  default: () => React.createElement('nav'),
+}));
+vi.mock('../../../components/breadcrumbs', () => ({
+  default: () => React.createElement('nav', { 'aria-label': 'breadcrumbs' }),
+}));
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ locale: 'us', t: (k: string) => k }),
+}));
+
+// Neutralize form internals — this file tests the auth gate, not the form
+vi.mock('../validation/basic-validation', () => ({
+  useBasicValidation: () => ({
+    isFormSubmitted: false,
+    setIsFormSubmitted: vi.fn(),
+    addErrorField: vi.fn(),
+    focusFirstErrorField: vi.fn(),
+  }),
+  BasicValidationContext: {
+    Provider: ({ children }: AnyProps) => React.createElement('div', null, children),
+  },
+}));
+vi.mock('../components/marketing', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'create-form-inner' }, 'FORM'),
+}));
+vi.mock('../components/shape', () => ({
+  default: () => React.createElement('div'),
+}));
+
+import App from '../app';
+
+function state(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    isAuthenticated: false,
+    idToken: null,
+    email: null,
+    name: null,
+    groups: [],
+    isModerator: false,
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('/create-meeting auth gating', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/create-meeting', search: '' },
+      writable: true,
+    });
+  });
+
+  it('authed moderator → renders form', () => {
+    render(
+      <AuthContext.Provider
+        value={state({
+          isAuthenticated: true,
+          idToken: 'id',
+          email: 'mod@example.test',
+          groups: ['moderators'],
+          isModerator: true,
+        })}
+      >
+        <App />
+      </AuthContext.Provider>,
+    );
+    expect(screen.getByTestId('create-form-inner')).toBeInTheDocument();
+  });
+
+  it('authed non-moderator → renders denied alert, not form', () => {
+    const { container } = render(
+      <AuthContext.Provider
+        value={state({
+          isAuthenticated: true,
+          idToken: 'id',
+          email: 'member@example.test',
+          groups: ['members'],
+        })}
+      >
+        <App />
+      </AuthContext.Provider>,
+    );
+    expect(screen.queryByTestId('create-form-inner')).not.toBeInTheDocument();
+    expect(container.textContent).toMatch(/moderators/i);
+    expect(container.textContent).toMatch(/sign out/i);
+  });
+
+  it('unauthenticated → triggers beginLogin and renders fallback', async () => {
+    const { beginLogin } = await import('../../../lib/auth');
+    const { container } = render(
+      <AuthContext.Provider value={state()}>
+        <App />
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(beginLogin).toHaveBeenCalled());
+    expect(screen.queryByTestId('create-form-inner')).not.toBeInTheDocument();
+    expect(container.textContent).toMatch(/redirecting to sign-in/i);
+  });
+});

--- a/src/pages/create-meeting/__tests__/locale-rendering.test.tsx
+++ b/src/pages/create-meeting/__tests__/locale-rendering.test.tsx
@@ -62,6 +62,11 @@ vi.mock('../components/shape', () => ({
   default: () => React.createElement('div', { 'data-testid': 'shape' }),
 }));
 
+// RequireAuth is exercised in its own unit tests; pass-through here so locale assertions can run.
+vi.mock('../../../components/require-auth', () => ({
+  RequireAuth: ({ children }: AnyProps) => React.createElement(React.Fragment, null, children),
+}));
+
 // Mock validation — avoids useRef/useState complexity in isolated tests
 vi.mock('../validation/basic-validation', () => ({
   useBasicValidation: () => ({

--- a/src/pages/create-meeting/app.tsx
+++ b/src/pages/create-meeting/app.tsx
@@ -12,6 +12,7 @@ import MeetingDetails from './components/marketing';
 import Navigation from '../../components/navigation';
 import Shape from './components/shape';
 import ShellLayout from '../../layouts/shell';
+import { RequireAuth } from '../../components/require-auth';
 import { BasicValidationContext, useBasicValidation } from './validation/basic-validation';
 import ContentLayout from '@cloudscape-design/components/content-layout';
 import { initializeTheme, applyTheme, setStoredTheme, type Theme } from '../../utils/theme';
@@ -106,7 +107,9 @@ export default function App() {
       navigation={<Navigation />}
       tools={<HelpPanelContent />}
     >
-      <FormContent />
+      <RequireAuth requireGroup="moderators">
+        <FormContent />
+      </RequireAuth>
     </ShellLayout>
   );
 }

--- a/src/pages/meetings/__tests__/auth-gating.test.tsx
+++ b/src/pages/meetings/__tests__/auth-gating.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AuthContext } from '../../../contexts/auth-context';
+import type { AuthState } from '../../../contexts/auth-context';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyProps = Record<string, any>;
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+vi.mock('../../../lib/auth', () => ({
+  beginLogin: vi.fn(),
+  signOut: vi.fn(),
+  getIdToken: vi.fn(() => null),
+  decodeToken: vi.fn(),
+  refreshTokens: vi.fn(),
+}));
+
+// Shell passes children through (skip AuthProvider wrap — we provide our own below).
+vi.mock('../../../layouts/shell', () => ({
+  default: ({ children }: AnyProps) => React.createElement('div', null, children),
+}));
+vi.mock('../../../components/navigation', () => ({
+  default: () => React.createElement('nav'),
+}));
+vi.mock('../../../components/breadcrumbs', () => ({
+  default: () => React.createElement('nav', { 'aria-label': 'breadcrumbs' }),
+}));
+vi.mock('../../create-meeting/components/help-panel-home', () => ({
+  HelpPanelHome: () => React.createElement('div'),
+}));
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ locale: 'us', t: (k: string) => k }),
+}));
+vi.mock('../components/meetings-table', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'meetings-table' }, 'TABLE'),
+}));
+
+import App from '../app';
+
+function state(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    isAuthenticated: false,
+    idToken: null,
+    email: null,
+    name: null,
+    groups: [],
+    isModerator: false,
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('/meetings auth gating', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/meetings', search: '' },
+      writable: true,
+    });
+  });
+
+  it('authed member → renders meetings table', () => {
+    render(
+      <AuthContext.Provider value={state({ isAuthenticated: true, idToken: 'id', email: 'a@b.co' })}>
+        <App />
+      </AuthContext.Provider>,
+    );
+    expect(screen.getByTestId('meetings-table')).toBeInTheDocument();
+  });
+
+  it('unauthenticated → renders fallback, not table; triggers beginLogin', async () => {
+    const { beginLogin } = await import('../../../lib/auth');
+    const { container } = render(
+      <AuthContext.Provider value={state()}>
+        <App />
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(beginLogin).toHaveBeenCalled());
+    expect(screen.queryByTestId('meetings-table')).not.toBeInTheDocument();
+    expect(container.textContent).toMatch(/redirecting to sign-in/i);
+  });
+});

--- a/src/pages/meetings/__tests__/locale-rendering.test.tsx
+++ b/src/pages/meetings/__tests__/locale-rendering.test.tsx
@@ -85,6 +85,11 @@ vi.mock('../../create-meeting/components/help-panel-home', () => ({
   HelpPanelHome: () => React.createElement('div', { 'data-testid': 'help-panel' }),
 }));
 
+// RequireAuth is exercised in its own unit tests; pass-through here so locale assertions can run.
+vi.mock('../../../components/require-auth', () => ({
+  RequireAuth: ({ children }: AnyProps) => React.createElement(React.Fragment, null, children),
+}));
+
 // Mock useTranslation with a mutable return value
 const mockTranslation = {
   locale: 'us' as 'us' | 'mx',

--- a/src/pages/meetings/app.tsx
+++ b/src/pages/meetings/app.tsx
@@ -7,6 +7,7 @@ import Breadcrumbs from '../../components/breadcrumbs';
 import Navigation from '../../components/navigation';
 import ShellLayout from '../../layouts/shell';
 import VariationsTable from './components/meetings-table';
+import { RequireAuth } from '../../components/require-auth';
 
 import { variationsData } from './data';
 import { initializeTheme, applyTheme, setStoredTheme, type Theme } from '../../utils/theme';
@@ -46,7 +47,9 @@ export default function App() {
       navigation={<Navigation />}
       tools={<HelpPanelHome />}
     >
-      <VariationsTable meetings={variationsData} />
+      <RequireAuth>
+        <VariationsTable meetings={variationsData} />
+      </RequireAuth>
     </ShellLayout>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         'learning/api': resolve(__dirname, './src/pages/learning/api/index.html'),
         'maintenance-calendar': resolve(__dirname, './src/pages/maintenance-calendar/index.html'),
         theme: resolve(__dirname, './src/pages/theme/index.html'),
+        'auth/callback': resolve(__dirname, './src/pages/auth/callback/index.html'),
       },
     },
   },


### PR DESCRIPTION
Closes #88. Closes #89. Part of epic #81 — P2b integration.

**Stacked on #94** → #93 → #92. Merge order: #92 → #93 → #94 → this PR.

## What

### #88 — /meetings
- `src/pages/meetings/app.tsx` wraps `<VariationsTable>` in `<RequireAuth>`
- Unauthed visitor → redirect to Cognito Hosted UI, spinner fallback renders during transit
- Authed member or moderator → sees existing meetings list

### #89 — /create-meeting
- `src/pages/create-meeting/app.tsx` wraps form in `<RequireAuth requireGroup="moderators">`
- Unauthed → redirect
- Authed member → Cloudscape Alert explaining moderator-only access + sign-out button
- Authed moderator → sees form

## Tests

- `src/pages/meetings/__tests__/auth-gating.test.tsx` — 2 new tests
- `src/pages/create-meeting/__tests__/auth-gating.test.tsx` — 3 new tests
- Existing locale-rendering tests mock `RequireAuth` as pass-through so those suites keep testing locale, not auth

205/205 tests pass, `npx vite build` clean, `tsc --noEmit` clean.

## Test plan

- [x] /meetings authed → table renders
- [x] /meetings unauthed → beginLogin called, spinner fallback
- [x] /create-meeting authed moderator → form renders
- [x] /create-meeting authed non-moderator → denied alert, form hidden
- [x] /create-meeting unauthed → beginLogin called, spinner fallback
- [ ] Real end-to-end click-through against deployed Cognito — deferred

## Out of scope (follow-ups)

- Jitsi iframe embed — #90
- CSP headers — #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)