### PR TITLE
feat(auth): RequireAuth + jitsi-token + Shell UI (#84, #86, #87) — rebased

### DIFF
--- a/src/components/require-auth/__tests__/index.test.tsx
+++ b/src/components/require-auth/__tests__/index.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { AuthState } from '../../../contexts/auth-context';
+
+vi.mock('../../../lib/auth', () => ({
+  beginLogin: vi.fn(),
+  signOut: vi.fn(),
+  // Passed through but not used in these tests:
+  getIdToken: vi.fn(() => null),
+  decodeToken: vi.fn(),
+  refreshTokens: vi.fn(),
+}));
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+import { AuthContext } from '../../../contexts/auth-context';
+import { RequireAuth } from '../index';
+
+function wrap(value: AuthState, children: React.ReactNode) {
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+function authedState(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    isAuthenticated: true,
+    idToken: 'id',
+    email: 'a@b.co',
+    name: 'A',
+    groups: ['members'],
+    isModerator: false,
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+function unauthedState(): AuthState {
+  return {
+    isAuthenticated: false,
+    idToken: null,
+    email: null,
+    name: null,
+    groups: [],
+    isModerator: false,
+    signOut: vi.fn(),
+  };
+}
+
+describe('RequireAuth', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/meetings', search: '?x=1' },
+      writable: true,
+    });
+    const { beginLogin } = await import('../../../lib/auth');
+    (beginLogin as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it('renders children when authenticated and no requireGroup', () => {
+    render(wrap(authedState(), <RequireAuth><div>inside</div></RequireAuth>));
+    expect(screen.getByText('inside')).toBeInTheDocument();
+  });
+
+  it('unauthenticated → calls beginLogin with pathname+search and renders spinner fallback', async () => {
+    const { beginLogin } = await import('../../../lib/auth');
+    const { container } = render(
+      wrap(unauthedState(), <RequireAuth><div>protected</div></RequireAuth>),
+    );
+    await waitFor(() => {
+      expect(beginLogin).toHaveBeenCalledWith('/meetings?x=1');
+    });
+    expect(screen.queryByText('protected')).not.toBeInTheDocument();
+    expect(container.textContent).toMatch(/redirecting to sign-in/i);
+  });
+
+  it('unauthenticated with custom fallback renders fallback', async () => {
+    const { beginLogin } = await import('../../../lib/auth');
+    render(
+      wrap(
+        unauthedState(),
+        <RequireAuth fallback={<div>custom-fb</div>}><div>protected</div></RequireAuth>,
+      ),
+    );
+    await waitFor(() => {
+      expect(beginLogin).toHaveBeenCalled();
+    });
+    expect(screen.getByText('custom-fb')).toBeInTheDocument();
+  });
+
+  it('authed but missing requireGroup → denied alert with sign-out button', () => {
+    const { container } = render(
+      wrap(
+        authedState({ groups: ['members'] }),
+        <RequireAuth requireGroup="moderators"><div>secret</div></RequireAuth>,
+      ),
+    );
+    expect(screen.queryByText('secret')).not.toBeInTheDocument();
+    expect(container.textContent).toMatch(/moderators/i);
+    expect(container.textContent).toMatch(/sign out/i);
+  });
+
+  it('authed with requireGroup match → renders children', () => {
+    render(
+      wrap(
+        authedState({ groups: ['moderators', 'members'], isModerator: true }),
+        <RequireAuth requireGroup="moderators"><div>admin-only</div></RequireAuth>,
+      ),
+    );
+    expect(screen.getByText('admin-only')).toBeInTheDocument();
+  });
+});

--- a/src/components/require-auth/index.tsx
+++ b/src/components/require-auth/index.tsx
@@ -1,0 +1,52 @@
+import React, { ReactNode, useEffect } from 'react';
+import Alert from '@cloudscape-design/components/alert';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import { beginLogin } from '../../lib/auth';
+import { useAuth } from '../../hooks/useAuth';
+
+export interface RequireAuthProps {
+  children: ReactNode;
+  requireGroup?: string;
+  fallback?: ReactNode;
+}
+
+export function RequireAuth({ children, requireGroup, fallback }: RequireAuthProps) {
+  const auth = useAuth();
+
+  useEffect(() => {
+    if (!auth.isAuthenticated) {
+      const returnTo = window.location.pathname + window.location.search;
+      void beginLogin(returnTo);
+    }
+  }, [auth.isAuthenticated]);
+
+  if (!auth.isAuthenticated) {
+    if (fallback) return <>{fallback}</>;
+    return (
+      <Box padding="xxl" textAlign="center">
+        <SpaceBetween size="l" alignItems="center">
+          <Spinner size="large" />
+          <Box variant="p">redirecting to sign-in…</Box>
+        </SpaceBetween>
+      </Box>
+    );
+  }
+
+  if (requireGroup && !auth.groups.includes(requireGroup)) {
+    return (
+      <Box padding="xxl">
+        <Alert type="warning" header="moderator access required">
+          this page requires {requireGroup} group membership.
+          <Box padding={{ top: 's' }}>
+            <Button onClick={auth.signOut}>sign out</Button>
+          </Box>
+        </Alert>
+      </Box>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/layouts/shell/index.tsx
+++ b/src/layouts/shell/index.tsx
@@ -6,7 +6,10 @@ import TopNavigation from '@cloudscape-design/components/top-navigation';
 import Footer from '../../components/footer';
 import { type Locale, getStoredNavState, setStoredNavState } from '../../utils/locale';
 import { LocaleProvider } from '../../contexts/locale-context';
+import { AuthProvider } from '../../contexts/auth-context';
 import { useTranslation } from '../../hooks/useTranslation';
+import { useAuth } from '../../hooks/useAuth';
+import { beginLogin } from '../../lib/auth';
 
 import './styles.css';
 
@@ -26,6 +29,7 @@ export interface ShellProps {
 
 function ShellContent({ children, contentType, breadcrumbs, tools, navigation, notifications, theme, onThemeChange, locale, onLocaleChange, pageTitle }: ShellProps) {
   const { t } = useTranslation();
+  const auth = useAuth();
   const [animating, setAnimating] = useState(false);
   const [animatingLocale, setAnimatingLocale] = useState(false);
   
@@ -98,7 +102,25 @@ function ShellContent({ children, contentType, breadcrumbs, tools, navigation, n
               text: theme === 'dark' ? '☀️' : '🌙',
               title: theme === 'dark' ? t('shell.switchToLightMode') : t('shell.switchToDarkMode'),
               onClick: handleToggleTheme,
-            }
+            },
+            auth.isAuthenticated
+              ? {
+                  type: 'menu-dropdown',
+                  text: auth.email ?? auth.name ?? 'account',
+                  description: auth.isModerator ? 'moderator' : undefined,
+                  iconName: 'user-profile',
+                  items: [{ id: 'signout', text: 'sign out' }],
+                  onItemClick: (e: { detail: { id: string } }) => {
+                    if (e.detail.id === 'signout') auth.signOut();
+                  },
+                }
+              : {
+                  type: 'button',
+                  text: 'sign in',
+                  onClick: () => {
+                    void beginLogin();
+                  },
+                },
           ]}
           i18nStrings={{
             overflowMenuTriggerText: t('shell.more'),
@@ -134,8 +156,10 @@ function ShellContent({ children, contentType, breadcrumbs, tools, navigation, n
 
 export default function Shell(props: ShellProps) {
   return (
-    <LocaleProvider locale={props.locale ?? 'us'}>
-      <ShellContent {...props} />
-    </LocaleProvider>
+    <AuthProvider>
+      <LocaleProvider locale={props.locale ?? 'us'}>
+        <ShellContent {...props} />
+      </LocaleProvider>
+    </AuthProvider>
   );
 }

--- a/src/lib/__tests__/jitsi-token.test.ts
+++ b/src/lib/__tests__/jitsi-token.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../auth', () => ({
+  getIdToken: vi.fn(),
+  refreshTokens: vi.fn(),
+}));
+
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('jitsi-token', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const { getIdToken, refreshTokens } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReset();
+    (refreshTokens as ReturnType<typeof vi.fn>).mockReset();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws when not authenticated', async () => {
+    const { getIdToken } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const { fetchJitsiToken, clearJitsiTokenCache } = await import('../jitsi-token');
+    clearJitsiTokenCache();
+    await expect(fetchJitsiToken()).rejects.toThrow(/not authenticated/);
+  });
+
+  it('happy path returns parsed response and sends bearer token', async () => {
+    const { getIdToken } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReturnValue('id-abc');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse(200, {
+        token: 'jitsi-jwt',
+        domain: 'meet.clouddelnorte.org',
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    );
+    const { fetchJitsiToken, clearJitsiTokenCache } = await import('../jitsi-token');
+    clearJitsiTokenCache();
+
+    const res = await fetchJitsiToken();
+    expect(res.token).toBe('jitsi-jwt');
+    expect(res.domain).toBe('meet.clouddelnorte.org');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toBe('https://rwmypxz9z6.execute-api.us-west-2.amazonaws.com/token/jitsi');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: 'Bearer id-abc' });
+  });
+
+  it('throws BannedUserError on 403', async () => {
+    const { getIdToken } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReturnValue('id-x');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse(403, { message: 'banned' }));
+    const { fetchJitsiToken, BannedUserError, clearJitsiTokenCache } = await import('../jitsi-token');
+    clearJitsiTokenCache();
+    await expect(fetchJitsiToken()).rejects.toBeInstanceOf(BannedUserError);
+  });
+
+  it('on 401 refreshes and retries once', async () => {
+    const { getIdToken, refreshTokens } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce('stale')
+      .mockReturnValueOnce('fresh');
+    (refreshTokens as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockResponse(401, {}))
+      .mockResolvedValueOnce(
+        mockResponse(200, {
+          token: 'jitsi-jwt-2',
+          domain: 'meet.clouddelnorte.org',
+          expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        }),
+      );
+
+    const { fetchJitsiToken, clearJitsiTokenCache } = await import('../jitsi-token');
+    clearJitsiTokenCache();
+    const res = await fetchJitsiToken();
+    expect(res.token).toBe('jitsi-jwt-2');
+    expect(refreshTokens).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[1][1]).toMatchObject({
+      headers: { Authorization: 'Bearer fresh' },
+    });
+  });
+
+  it('caches the token within expiry window', async () => {
+    const { getIdToken } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReturnValue('id-abc');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse(200, {
+        token: 'cached-jwt',
+        domain: 'meet.clouddelnorte.org',
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    );
+    const { fetchJitsiToken, clearJitsiTokenCache } = await import('../jitsi-token');
+    clearJitsiTokenCache();
+
+    const a = await fetchJitsiToken();
+    const b = await fetchJitsiToken();
+    expect(a).toBe(b);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/jitsi-token.ts
+++ b/src/lib/jitsi-token.ts
@@ -1,0 +1,58 @@
+import { getIdToken, refreshTokens } from './auth';
+
+const API_BASE = 'https://rwmypxz9z6.execute-api.us-west-2.amazonaws.com';
+const TOKEN_PATH = '/token/jitsi';
+
+export interface JitsiTokenResponse {
+  token: string;
+  domain: string;
+  expiresAt: number;
+}
+
+export class BannedUserError extends Error {
+  constructor(message = 'user is banned') {
+    super(message);
+    this.name = 'BannedUserError';
+  }
+}
+
+let cached: JitsiTokenResponse | null = null;
+
+export function clearJitsiTokenCache(): void {
+  cached = null;
+}
+
+async function requestToken(idToken: string): Promise<Response> {
+  return fetch(`${API_BASE}${TOKEN_PATH}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: '{}',
+  });
+}
+
+export async function fetchJitsiToken(): Promise<JitsiTokenResponse> {
+  if (cached && cached.expiresAt * 1000 > Date.now() + 30_000) return cached;
+
+  let idToken = getIdToken();
+  if (!idToken) throw new Error('not authenticated');
+
+  let res = await requestToken(idToken);
+
+  if (res.status === 401) {
+    await refreshTokens();
+    idToken = getIdToken();
+    if (!idToken) throw new Error('refresh failed — not authenticated');
+    res = await requestToken(idToken);
+    if (res.status === 401) throw new Error('token-exchange unauthorized after refresh');
+  }
+
+  if (res.status === 403) throw new BannedUserError();
+  if (!res.ok) throw new Error(`token-exchange failed: ${res.status}`);
+
+  const body = (await res.json()) as JitsiTokenResponse;
+  cached = body;
+  return body;
+}


### PR DESCRIPTION
Supersedes #94 (auto-closed when base #93 merged). Closes #84, #86, #87.

Same code, rebased onto main. See #94 for full body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)