### PR TITLE
feat(auth): gate /meetings + /create-meeting (#88, #89) — rebased

### DIFF
--- a/src/pages/create-meeting/__tests__/auth-gating.test.tsx
+++ b/src/pages/create-meeting/__tests__/auth-gating.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AuthContext } from '../../../contexts/auth-context';
+import type { AuthState } from '../../../contexts/auth-context';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyProps = Record<string, any>;
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+vi.mock('../../../lib/auth', () => ({
+  beginLogin: vi.fn(),
+  signOut: vi.fn(),
+  getIdToken: vi.fn(() => null),
+  decodeToken: vi.fn(),
+  refreshTokens: vi.fn(),
+}));
+
+vi.mock('../../../layouts/shell', () => ({
+  default: ({ children }: AnyProps) => React.createElement('div', null, children),
+}));
+vi.mock('../../../components/navigation', () => ({
+  default: () => React.createElement('nav'),
+}));
+vi.mock('../../../components/breadcrumbs', () => ({
+  default: () => React.createElement('nav', { 'aria-label': 'breadcrumbs' }),
+}));
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ locale: 'us', t: (k: string) => k }),
+}));
+
+// Neutralize form internals — this file tests the auth gate, not the form
+vi.mock('../validation/basic-validation', () => ({
+  useBasicValidation: () => ({
+    isFormSubmitted: false,
+    setIsFormSubmitted: vi.fn(),
+    addErrorField: vi.fn(),
+    focusFirstErrorField: vi.fn(),
+  }),
+  BasicValidationContext: {
+    Provider: ({ children }: AnyProps) => React.createElement('div', null, children),
+  },
+}));
+vi.mock('../components/marketing', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'create-form-inner' }, 'FORM'),
+}));
+vi.mock('../components/shape', () => ({
+  default: () => React.createElement('div'),
+}));
+
+import App from '../app';
+
+function state(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    isAuthenticated: false,
+    idToken: null,
+    email: null,
+    name: null,
+    groups: [],
+    isModerator: false,
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('/create-meeting auth gating', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/create-meeting', search: '' },
+      writable: true,
+    });
+  });
+
+  it('authed moderator → renders form', () => {
+    render(
+      <AuthContext.Provider
+        value={state({
+          isAuthenticated: true,
+          idToken: 'id',
+          email: 'mod@example.test',
+          groups: ['moderators'],
+          isModerator: true,
+        })}
+      >
+        <App />
+      </AuthContext.Provider>,
+    );
+    expect(screen.getByTestId('create-form-inner')).toBeInTheDocument();
+  });
+
+  it('authed non-moderator → renders denied alert, not form', () => {
+    const { container } = render(
+      <AuthContext.Provider
+        value={state({
+          isAuthenticated: true,
+          idToken: 'id',
+          email: 'member@example.test',
+          groups: ['members'],
+        })}
+      >
+        <App />
+      </AuthContext.Provider>,
+    );
+    expect(screen.queryByTestId('create-form-inner')).not.toBeInTheDocument();
+    expect(container.textContent).toMatch(/moderators/i);
+    expect(container.textContent).toMatch(/sign out/i);
+  });
+
+  it('unauthenticated → triggers beginLogin and renders fallback', async () => {
+    const { beginLogin } = await import('../../../lib/auth');
+    const { container } = render(
+      <AuthContext.Provider value={state()}>
+        <App />
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(beginLogin).toHaveBeenCalled());
+    expect(screen.queryByTestId('create-form-inner')).not.toBeInTheDocument();
+    expect(container.textContent).toMatch(/redirecting to sign-in/i);
+  });
+});

--- a/src/pages/create-meeting/__tests__/locale-rendering.test.tsx
+++ b/src/pages/create-meeting/__tests__/locale-rendering.test.tsx
@@ -62,6 +62,11 @@ vi.mock('../components/shape', () => ({
   default: () => React.createElement('div', { 'data-testid': 'shape' }),
 }));
 
+// RequireAuth is exercised in its own unit tests; pass-through here so locale assertions can run.
+vi.mock('../../../components/require-auth', () => ({
+  RequireAuth: ({ children }: AnyProps) => React.createElement(React.Fragment, null, children),
+}));
+
 // Mock validation — avoids useRef/useState complexity in isolated tests
 vi.mock('../validation/basic-validation', () => ({
   useBasicValidation: () => ({

--- a/src/pages/create-meeting/app.tsx
+++ b/src/pages/create-meeting/app.tsx
@@ -12,6 +12,7 @@ import MeetingDetails from './components/marketing';
 import Navigation from '../../components/navigation';
 import Shape from './components/shape';
 import ShellLayout from '../../layouts/shell';
+import { RequireAuth } from '../../components/require-auth';
 import { BasicValidationContext, useBasicValidation } from './validation/basic-validation';
 import ContentLayout from '@cloudscape-design/components/content-layout';
 import { initializeTheme, applyTheme, setStoredTheme, type Theme } from '../../utils/theme';
@@ -106,7 +107,9 @@ export default function App() {
       navigation={<Navigation />}
       tools={<HelpPanelContent />}
     >
-      <FormContent />
+      <RequireAuth requireGroup="moderators">
+        <FormContent />
+      </RequireAuth>
     </ShellLayout>
   );
 }

--- a/src/pages/meetings/__tests__/auth-gating.test.tsx
+++ b/src/pages/meetings/__tests__/auth-gating.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AuthContext } from '../../../contexts/auth-context';
+import type { AuthState } from '../../../contexts/auth-context';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyProps = Record<string, any>;
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+vi.mock('../../../lib/auth', () => ({
+  beginLogin: vi.fn(),
+  signOut: vi.fn(),
+  getIdToken: vi.fn(() => null),
+  decodeToken: vi.fn(),
+  refreshTokens: vi.fn(),
+}));
+
+// Shell passes children through (skip AuthProvider wrap — we provide our own below).
+vi.mock('../../../layouts/shell', () => ({
+  default: ({ children }: AnyProps) => React.createElement('div', null, children),
+}));
+vi.mock('../../../components/navigation', () => ({
+  default: () => React.createElement('nav'),
+}));
+vi.mock('../../../components/breadcrumbs', () => ({
+  default: () => React.createElement('nav', { 'aria-label': 'breadcrumbs' }),
+}));
+vi.mock('../../create-meeting/components/help-panel-home', () => ({
+  HelpPanelHome: () => React.createElement('div'),
+}));
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ locale: 'us', t: (k: string) => k }),
+}));
+vi.mock('../components/meetings-table', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'meetings-table' }, 'TABLE'),
+}));
+
+import App from '../app';
+
+function state(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    isAuthenticated: false,
+    idToken: null,
+    email: null,
+    name: null,
+    groups: [],
+    isModerator: false,
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('/meetings auth gating', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/meetings', search: '' },
+      writable: true,
+    });
+  });
+
+  it('authed member → renders meetings table', () => {
+    render(
+      <AuthContext.Provider value={state({ isAuthenticated: true, idToken: 'id', email: 'a@b.co' })}>
+        <App />
+      </AuthContext.Provider>,
+    );
+    expect(screen.getByTestId('meetings-table')).toBeInTheDocument();
+  });
+
+  it('unauthenticated → renders fallback, not table; triggers beginLogin', async () => {
+    const { beginLogin } = await import('../../../lib/auth');
+    const { container } = render(
+      <AuthContext.Provider value={state()}>
+        <App />
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(beginLogin).toHaveBeenCalled());
+    expect(screen.queryByTestId('meetings-table')).not.toBeInTheDocument();
+    expect(container.textContent).toMatch(/redirecting to sign-in/i);
+  });
+});

--- a/src/pages/meetings/__tests__/locale-rendering.test.tsx
+++ b/src/pages/meetings/__tests__/locale-rendering.test.tsx
@@ -85,6 +85,11 @@ vi.mock('../../create-meeting/components/help-panel-home', () => ({
   HelpPanelHome: () => React.createElement('div', { 'data-testid': 'help-panel' }),
 }));
 
+// RequireAuth is exercised in its own unit tests; pass-through here so locale assertions can run.
+vi.mock('../../../components/require-auth', () => ({
+  RequireAuth: ({ children }: AnyProps) => React.createElement(React.Fragment, null, children),
+}));
+
 // Mock useTranslation with a mutable return value
 const mockTranslation = {
   locale: 'us' as 'us' | 'mx',

--- a/src/pages/meetings/app.tsx
+++ b/src/pages/meetings/app.tsx
@@ -7,6 +7,7 @@ import Breadcrumbs from '../../components/breadcrumbs';
 import Navigation from '../../components/navigation';
 import ShellLayout from '../../layouts/shell';
 import VariationsTable from './components/meetings-table';
+import { RequireAuth } from '../../components/require-auth';
 
 import { variationsData } from './data';
 import { initializeTheme, applyTheme, setStoredTheme, type Theme } from '../../utils/theme';
@@ -46,7 +47,9 @@ export default function App() {
       navigation={<Navigation />}
       tools={<HelpPanelHome />}
     >
-      <VariationsTable meetings={variationsData} />
+      <RequireAuth>
+        <VariationsTable meetings={variationsData} />
+      </RequireAuth>
     </ShellLayout>
   );
 }


### PR DESCRIPTION
Supersedes #95 (auto-closed when base #94 merged). Closes #88, #89.

Same code, rebased onto main. See #95 for full body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)