### PR TITLE
fix(test): drop bogus MediaQueryListEvent vitest import

### DIFF
--- a/src/utils/__tests__/theme.test.ts
+++ b/src/utils/__tests__/theme.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type { MediaQueryListEvent } from 'vitest';
+// MediaQueryListEvent is a DOM global — no import needed.
 
 describe('theme utility', () => {
   beforeEach(() => {


### PR DESCRIPTION
Pre-existing TS error that blocked the S3 deploy workflow. Two-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)