### PR TITLE
fix(deploy): drop continue-on-error mask (closes #80)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,23 +36,17 @@ jobs:
         role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
         role-session-name: GitHubActions-Core-Deploy
         aws-region: ${{ env.AWS_REGION }}
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      continue-on-error: true
-      id: aws-config
-    
+
     - name: Install dependencies
       run: npm install
-    
+
     - name: Build
       run: npm run build
-    
+
     - name: Deploy to S3
-      if: steps.aws-config.outcome == 'success'
       run: |
         aws s3 sync lib/ s3://awsaerospace.org/ --delete --exact-timestamps
-    
+
     - name: Invalidate CloudFront
-      if: steps.aws-config.outcome == 'success'
       run: |
         aws cloudfront create-invalidation --distribution-id ECC3LP1BL2CZS --paths "/*"


### PR DESCRIPTION
Closes #80. Now that the OIDC role + AWS_ROLE_ARN secret are in place, the silent-failure mask is counterproductive.

Setup landed out-of-band (IAM in account 211125425201):
- OIDC provider already existed
- Role arn:aws:iam::211125425201:role/github-actions-cloud-del-norte-website-deploy created with trust scoped to repo:chasko-labs/cloud-del-norte-website:*
- Inline policy: s3:Put/Get/Delete on awsaerospace.org + cloudfront:CreateInvalidation on ECC3LP1BL2CZS
- AWS_ROLE_ARN repo secret set

Workflow verified green via manual workflow_dispatch (run 24853426434) before this cleanup — all steps pass end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)