### PR TITLE
fix(auth): trailing-slash redirect_uri + retry button on callback error

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -93,7 +93,7 @@ describe('auth module', () => {
       expect(params.get('response_type')).toBe('code');
       expect(params.get('code_challenge_method')).toBe('S256');
       expect(params.get('code_challenge')).toMatch(/^[A-Za-z0-9_-]+$/);
-      expect(params.get('redirect_uri')).toBe('https://example.test/auth/callback');
+      expect(params.get('redirect_uri')).toBe('https://example.test/auth/callback/');
       expect(params.get('scope')).toBe('openid email profile');
     });
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -26,7 +26,9 @@ interface TokenResponse {
 }
 
 function redirectUri(): string {
-  return `${window.location.origin}/auth/callback`;
+  // Trailing slash matters: S3 website hosting issues a 302 Location: /auth/callback/
+  // for the non-slash form, and the redirect drops the ?code query param.
+  return `${window.location.origin}/auth/callback/`;
 }
 
 function base64UrlEncode(bytes: Uint8Array): string {

--- a/src/pages/auth/callback/app.tsx
+++ b/src/pages/auth/callback/app.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import Alert from '@cloudscape-design/components/alert';
 import Box from '@cloudscape-design/components/box';
-import Spinner from '@cloudscape-design/components/spinner';
+import Button from '@cloudscape-design/components/button';
 import SpaceBetween from '@cloudscape-design/components/space-between';
-import { handleCallback } from '../../../lib/auth';
+import Spinner from '@cloudscape-design/components/spinner';
+import { beginLogin, handleCallback } from '../../../lib/auth';
 
 type Status = 'exchanging' | 'redirecting' | 'error';
 
@@ -34,9 +35,22 @@ export default function App() {
     return (
       <Box padding="xxl">
         <Alert type="error" header="sign-in failed">
-          {errorMsg}
-          {' — '}
-          <a href="/">return home</a>
+          <SpaceBetween size="s">
+            <Box variant="p">{errorMsg}</Box>
+            <SpaceBetween size="xs" direction="horizontal">
+              <Button
+                variant="primary"
+                onClick={() => {
+                  void beginLogin('/');
+                }}
+              >
+                sign in again
+              </Button>
+              <Button variant="link" href="/">
+                return home
+              </Button>
+            </SpaceBetween>
+          </SpaceBetween>
         </Alert>
       </Box>
     );


### PR DESCRIPTION
Unblocks signup. S3 website hosting drops the ?code query when it 302s from /auth/callback to /auth/callback/. Using the trailing-slash URI avoids the redirect entirely — already registered on the Cognito app client.

Also adds a "sign in again" button to the callback error Alert so users can retry a transient auth failure without hand-navigating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)