### PR TITLE
fix(auth): signOut trailing slash + update meetings data

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -144,7 +144,7 @@ describe('auth module', () => {
       expect(target.startsWith(`${HOSTED_UI}/logout?`)).toBe(true);
       const params = new URLSearchParams(target.split('?')[1]);
       expect(params.get('client_id')).toBe(CLIENT_ID);
-      expect(params.get('logout_uri')).toBe('https://example.test');
+      expect(params.get('logout_uri')).toBe('https://example.test/');
     });
   });
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -154,7 +154,10 @@ export function signOut(): void {
   sessionStorage.removeItem(KEY_LOGIN_STATE);
   const params = new URLSearchParams({
     client_id: CLIENT_ID,
-    logout_uri: window.location.origin,
+    // Trailing slash must match the logout URL registered on the Cognito app
+    // client (https://clouddelnorte.org/). Without it Cognito falls through
+    // to the redirect_uri flow and errors "redirect_uri is not present".
+    logout_uri: `${window.location.origin}/`,
   });
   window.location.assign(`${HOSTED_UI}/logout?${params.toString()}`);
 }

--- a/src/pages/meetings/data.ts
+++ b/src/pages/meetings/data.ts
@@ -418,19 +418,25 @@ export const variationsData: meeting[] = [
   {
     name: 'Create an Alcohol Server Training Program with No Code',
     presenters: 'Bryan Chasko | AWS Hero',
-    happened: 'false',
+    happened: 'true',
     ondemand: 'no',
-    eventlink: 'https://www.meetup.com/awsaerospace/events/302840839',
-    // Pre-generated UUID keeps the room URL unguessable even if the event link is shared publicly.
-    roomName: 'alcohol-server-training-7f3e9c1a'
+    eventlink: 'https://www.meetup.com/awsaerospace/events/302840839'
   },
   {
     name: 'Aerospace CEOs: Looking Forward',
     presenters: 'Brian Barnett | Solstar, Andrew Nelson | RS&H',
+    happened: 'true',
+    ondemand: 'no',
+    eventlink: 'https://www.linkedin.com/posts/arrowhead-research-park_live-with-restream-powered-by-restream-https-activity-7072729359853260800-0TX3'
+  },
+  {
+    name: 'Wednesday Website Work',
+    presenters: 'Bryan Chasko, Jacob Wright',
     happened: 'false',
     ondemand: 'no',
-    eventlink: 'https://www.linkedin.com/posts/arrowhead-research-park_live-with-restream-powered-by-restream-https-activity-7072729359853260800-0TX3',
-    roomName: 'aerospace-ceos-looking-forward-4b2d8e56'
+    eventlink: '',
+    // Pre-generated stable room name keeps the jitsi URL unguessable.
+    roomName: 'wednesday-website-work-c8f21d9b'
   }
 
 ];


### PR DESCRIPTION
Two live bugs surfaced during first-user test. signOut logout_uri now matches the registered URL (trailing slash). Past sample meetings flipped to happened=true; new upcoming 'Wednesday Website Work' row added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)