### PR TITLE
feat(meetings): add "instant meet" button — moderator-only

### DIFF
--- a/src/pages/meetings/__tests__/locale-rendering.test.tsx
+++ b/src/pages/meetings/__tests__/locale-rendering.test.tsx
@@ -114,6 +114,18 @@ vi.mock('../../../hooks/useTranslation', () => ({
   useTranslation: () => mockTranslation,
 }));
 
+vi.mock('../../../hooks/useAuth', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    idToken: 'tok',
+    email: 'a@b.co',
+    name: 'alice',
+    groups: [],
+    isModerator: false,
+    signOut: () => {},
+  }),
+}));
+
 import App from '../app';
 
 describe('Meetings page locale rendering', () => {

--- a/src/pages/meetings/components/__tests__/meetings-table.test.tsx
+++ b/src/pages/meetings/components/__tests__/meetings-table.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AuthContext } from '../../../../contexts/auth-context';
+import type { AuthState } from '../../../../contexts/auth-context';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyProps = Record<string, any>;
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+vi.mock('@cloudscape-design/components/table', () => ({
+  default: ({ header }: AnyProps) =>
+    React.createElement('div', { 'data-testid': 'table' }, header),
+}));
+vi.mock('@cloudscape-design/components/header', () => ({
+  default: ({ children, actions }: AnyProps) =>
+    React.createElement('div', null,
+      React.createElement('h1', null, children),
+      actions
+    ),
+}));
+vi.mock('@cloudscape-design/components/button', () => ({
+  default: ({ children, onClick, href }: AnyProps) =>
+    React.createElement('button', { onClick, 'data-href': href }, children),
+}));
+vi.mock('@cloudscape-design/components/space-between', () => ({
+  default: ({ children }: AnyProps) => React.createElement('div', null, children),
+}));
+vi.mock('@cloudscape-design/components/pagination', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'pagination' }),
+}));
+vi.mock('@cloudscape-design/components/modal', () => ({
+  default: ({ children, visible, header }: AnyProps) =>
+    visible
+      ? React.createElement('div', { 'data-testid': 'modal' },
+          React.createElement('div', { 'data-testid': 'modal-header' }, header),
+          children
+        )
+      : null,
+}));
+vi.mock('../jitsi-embed', () => ({
+  default: ({ roomName }: AnyProps) =>
+    React.createElement('div', { 'data-testid': 'jitsi-embed-stub', 'data-room': roomName }),
+}));
+vi.mock('@cloudscape-design/components/text-filter', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'text-filter' }),
+}));
+vi.mock('@cloudscape-design/components/collection-preferences', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'collection-preferences' }),
+}));
+vi.mock('@cloudscape-design/components/box', () => ({
+  default: ({ children }: AnyProps) => React.createElement('div', null, children),
+}));
+vi.mock('@cloudscape-design/collection-hooks', () => ({
+  useCollection: (_items: unknown[], _opts: AnyProps) => ({
+    items: [],
+    filterProps: { filteringText: '', onChange: vi.fn() },
+    actions: { setFiltering: vi.fn() },
+    filteredItemsCount: 0,
+    paginationProps: { currentPageIndex: 1, pagesCount: 1, onChange: vi.fn() },
+    collectionProps: { selectedItems: [], onSelectionChange: vi.fn(), sortingColumn: null, sortingDescending: false, onSortingChange: vi.fn() },
+  }),
+}));
+vi.mock('../../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ locale: 'us', t: (k: string) => k }),
+}));
+
+import VariationsTable from '../meetings-table';
+
+function authState(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    isAuthenticated: true,
+    idToken: 'tok',
+    email: 'a@b.co',
+    name: 'alice',
+    groups: [],
+    isModerator: false,
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderWithAuth(state: AuthState) {
+  return render(
+    <AuthContext.Provider value={state}>
+      <VariationsTable meetings={[]} />
+    </AuthContext.Provider>,
+  );
+}
+
+describe('VariationsTable — instant meet button visibility', () => {
+  beforeEach(() => {
+    // Stub crypto.getRandomValues for deterministic room names in tests
+    vi.spyOn(crypto, 'getRandomValues').mockImplementation((arr) => {
+      if (arr instanceof Uint8Array) {
+        arr[0] = 0xab;
+        arr[1] = 0xcd;
+        arr[2] = 0xef;
+      }
+      return arr;
+    });
+  });
+
+  it('moderator sees the "instant meet" button in the header', () => {
+    renderWithAuth(authState({ isModerator: true }));
+    expect(screen.getByText('instant meet')).toBeInTheDocument();
+  });
+
+  it('non-moderator does not see the "instant meet" button', () => {
+    renderWithAuth(authState({ isModerator: false }));
+    expect(screen.queryByText('instant meet')).not.toBeInTheDocument();
+  });
+
+  it('clicking "instant meet" opens modal with a UUID-ish roomName', () => {
+    renderWithAuth(authState({ isModerator: true }));
+
+    // Modal should not be visible before click
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('instant meet'));
+
+    // Modal should now be visible
+    expect(screen.getByTestId('modal')).toBeInTheDocument();
+
+    // JitsiEmbed stub should be rendered with the synthesized room name
+    const embed = screen.getByTestId('jitsi-embed-stub');
+    const roomName = embed.getAttribute('data-room') ?? '';
+    expect(roomName).toMatch(/^instant-[0-9a-f]{6}$/);
+  });
+});

--- a/src/pages/meetings/components/meetings-table.tsx
+++ b/src/pages/meetings/components/meetings-table.tsx
@@ -17,7 +17,15 @@ import Button from '@cloudscape-design/components/button';
 import Modal from '@cloudscape-design/components/modal';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import { useTranslation } from '../../../hooks/useTranslation';
+import { useAuth } from '../../../hooks/useAuth';
 import JitsiEmbed from './jitsi-embed';
+
+function generateInstantRoomName(): string {
+  const bytes = new Uint8Array(3);
+  crypto.getRandomValues(bytes);
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `instant-${hex}`;
+}
 
 const getFilterCounterText = (count = 0, t: (key: string) => string) => `${count} ${count === 1 ? t('meetings.filterCounter.match') : t('meetings.filterCounter.matches')}`;
 const getHeaderCounterText = (items: readonly meeting[] = [], selectedItems: readonly meeting[] = []) => {
@@ -94,6 +102,7 @@ export interface VariationTableProps {
 
 export default function VariationTable({ meetings }: VariationTableProps) {
   const { t } = useTranslation();
+  const auth = useAuth();
   const [preferences, setPreferences] = useState<CollectionPreferencesProps['preferences']>({ pageSize: 20 });
   const [activeRoom, setActiveRoom] = useState<meeting | null>(null);
   const { items, filterProps, actions, filteredItemsCount, paginationProps, collectionProps } = useCollection<meeting>(
@@ -142,6 +151,17 @@ export default function VariationTable({ meetings }: VariationTableProps) {
           counter={getHeaderCounterText(meetings, collectionProps.selectedItems)}
           actions={
             <SpaceBetween size="xs" direction="horizontal">
+              {auth.isModerator && (
+                <Button
+                  variant="primary"
+                  onClick={() => {
+                    const roomName = generateInstantRoomName();
+                    setActiveRoom({ name: 'instant meeting (ask participants to join)', presenters: '', happened: 'false', ondemand: 'no', eventlink: '', roomName });
+                  }}
+                >
+                  instant meet
+                </Button>
+              )}
               <Button disabled={collectionProps.selectedItems?.length === 0}>{t('meetings.editButton')}</Button>
               <Button disabled={collectionProps.selectedItems?.length === 0} href="/create-meeting/index.html" variant="primary">
                 {t('meetings.createButton')}


### PR DESCRIPTION
## summary

- adds an "instant meet" `Button variant="primary"` to the meetings table header actions slot, rendered only when `auth.isModerator` is true
- clicking generates a fresh `instant-{6hex}` room name via `crypto.getRandomValues` (no new deps), then calls `setActiveRoom` with a synthetic meeting object — reusing the existing Modal+JitsiEmbed wiring
- modal header reads "instant meeting (ask participants to join)"
- non-moderators see no button at all (conditional render, not disabled)

## files touched

- `src/pages/meetings/components/meetings-table.tsx` — added `useAuth` import + `generateInstantRoomName()` helper + button in header actions
- `src/pages/meetings/components/__tests__/meetings-table.test.tsx` — new file, 3 tests
- `src/pages/meetings/__tests__/locale-rendering.test.tsx` — added `useAuth` mock to fix breakage from hook addition

## test plan

- [x] `npx vitest run` — 213 passed (up from 210), 0 failed
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/pages/meetings src/lib src/contexts src/hooks src/components/require-auth` — 0 errors (1 pre-existing warning in jitsi-embed.tsx not touched)
- [x] `npx vite build` — succeeded

## context7 lookups

none — used only `Button`, `SpaceBetween`, `Header`, `Modal` which were already present in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)