### PR TITLE
feat(admin): add /admin/ page with pending-user approval table

### DIFF
--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -3,13 +3,16 @@
 import React from 'react';
 import SideNavigation, { SideNavigationProps } from '@cloudscape-design/components/side-navigation';
 import { useTranslation } from '../../hooks/useTranslation';
+import { useAuth } from '../../hooks/useAuth';
 
 export default function Navigation() {
   const { t } = useTranslation();
+  const { isModerator } = useAuth();
 
   const items: SideNavigationProps['items'] = [
     { type: 'link', text: t('navigation.roadmap'), href: '/roadmap/index.html' },
     { type: 'link', text: t('navigation.meetings'), href: '/meetings/index.html' },
+    ...(isModerator ? [{ type: 'link' as const, text: t('navigation.admin'), href: '/admin/index.html' }] : []),
     { type: 'divider' },
     {
       type: 'section',

--- a/src/lib/__tests__/admin.test.ts
+++ b/src/lib/__tests__/admin.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../auth', () => ({
+  getIdToken: vi.fn(),
+  refreshTokens: vi.fn(),
+}));
+
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('admin client', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const { getIdToken, refreshTokens } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReset();
+    (refreshTokens as ReturnType<typeof vi.fn>).mockReset();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('listPendingUsers — throws when not authenticated', async () => {
+    const { getIdToken } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const { listPendingUsers } = await import('../admin');
+    await expect(listPendingUsers()).rejects.toThrow(/not authenticated/);
+  });
+
+  it('listPendingUsers — sends bearer token + returns users array', async () => {
+    const { getIdToken } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReturnValue('id-tok');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse(200, { users: [{ sub: 'abc', email: 'a@b.co', status: 'CONFIRMED', groups: [], createdAt: '2026-01-01' }] }),
+    );
+    const { listPendingUsers } = await import('../admin');
+    const result = await listPendingUsers();
+    expect(result).toHaveLength(1);
+    expect(result[0].email).toBe('a@b.co');
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain('/admin/users?filter=pending');
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: 'Bearer id-tok' });
+  });
+
+  it('listPendingUsers — on 401 refreshes and retries once', async () => {
+    const { getIdToken, refreshTokens } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce('stale')
+      .mockReturnValueOnce('fresh');
+    (refreshTokens as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockResponse(401, {}))
+      .mockResolvedValueOnce(mockResponse(200, { users: [] }));
+    const { listPendingUsers } = await import('../admin');
+    const result = await listPendingUsers();
+    expect(result).toHaveLength(0);
+    expect(refreshTokens).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[1][1]).toMatchObject({
+      headers: { Authorization: 'Bearer fresh' },
+    });
+  });
+
+  it('approveUser — sends POST with correct body', async () => {
+    const { getIdToken } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>).mockReturnValue('id-tok');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse(200, { ok: true, user: { sub: 'abc', email: 'a@b.co', status: 'CONFIRMED', groups: ['members'], createdAt: '2026-01-01' } }),
+    );
+    const { approveUser } = await import('../admin');
+    const result = await approveUser('abc');
+    expect(result.ok).toBe(true);
+    expect(result.user.groups).toContain('members');
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain('/admin/users/abc/approve');
+    expect((init as RequestInit).method).toBe('POST');
+    expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({ group: 'members' });
+  });
+
+  it('approveUser — on 401 refreshes and retries bearer', async () => {
+    const { getIdToken, refreshTokens } = await import('../auth');
+    (getIdToken as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce('stale')
+      .mockReturnValueOnce('fresh');
+    (refreshTokens as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockResponse(401, {}))
+      .mockResolvedValueOnce(
+        mockResponse(200, { ok: true, user: { sub: 'abc', email: 'a@b.co', status: 'CONFIRMED', groups: ['members'], createdAt: '2026-01-01' } }),
+      );
+    const { approveUser } = await import('../admin');
+    const result = await approveUser('abc', 'members');
+    expect(result.ok).toBe(true);
+    expect(refreshTokens).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,66 @@
+import { getIdToken, refreshTokens } from './auth';
+
+const API_BASE = 'https://rwmypxz9z6.execute-api.us-west-2.amazonaws.com';
+
+export interface AdminUser {
+  sub: string;
+  email: string;
+  status: string;
+  groups: string[];
+  createdAt: string;
+}
+
+export interface ListUsersResponse {
+  users: AdminUser[];
+}
+
+export interface ApproveUserResponse {
+  ok: boolean;
+  user: AdminUser;
+}
+
+async function adminRequest(path: string, method: string, body?: unknown): Promise<Response> {
+  const idToken = getIdToken();
+  if (!idToken) throw new Error('not authenticated');
+  return fetch(`${API_BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function withRetry<T>(fn: () => Promise<Response>, parse: (r: Response) => Promise<T>): Promise<T> {
+  let res = await fn();
+  if (res.status === 401) {
+    await refreshTokens();
+    res = await fn();
+    if (res.status === 401) throw new Error('unauthorized after refresh');
+  }
+  if (!res.ok) throw new Error(`admin api error: ${res.status}`);
+  return parse(res);
+}
+
+export async function listPendingUsers(filter: 'pending' | 'members' | 'moderators' | 'banned' = 'pending'): Promise<AdminUser[]> {
+  const result = await withRetry(
+    () => adminRequest(`/admin/users?filter=${filter}`, 'GET'),
+    (r) => r.json() as Promise<ListUsersResponse>,
+  );
+  return result.users;
+}
+
+export async function approveUser(sub: string, group: 'members' | 'moderators' = 'members'): Promise<ApproveUserResponse> {
+  return withRetry(
+    () => adminRequest(`/admin/users/${encodeURIComponent(sub)}/approve`, 'POST', { group }),
+    (r) => r.json() as Promise<ApproveUserResponse>,
+  );
+}
+
+export async function banUser(sub: string): Promise<ApproveUserResponse> {
+  return withRetry(
+    () => adminRequest(`/admin/users/${encodeURIComponent(sub)}/ban`, 'POST'),
+    (r) => r.json() as Promise<ApproveUserResponse>,
+  );
+}

--- a/src/locales/__tests__/translation-coverage.test.ts
+++ b/src/locales/__tests__/translation-coverage.test.ts
@@ -88,6 +88,8 @@ describe('translation coverage', () => {
       'roadmap.title',                                // "Roadmap" - universally understood term
       'roadmap.breadcrumb',                           // "Roadmap" - universally understood term
       'roadmap.idea',                                 // "Idea" - same in Spanish
+      'navigation.admin',                             // "Admin" - technical term used in both locales
+      'admin.breadcrumb',                             // "Admin" - technical term
     ]);
 
     // Helper to get value by dot-notation key

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -19,6 +19,7 @@
     "home": "User Group Home",
     "roadmap": "Roadmap",
     "meetings": "Meetings",
+    "admin": "Admin",
     "resources": "Resources",
     "techDebtCountdowns": "Tech Debt Countdowns",
     "designSystem": "Design System",
@@ -326,6 +327,20 @@
       "speedRatingMapping": "💨 Speed Rating",
       "speedRatingMappingValue": "stats.movespeed ÷ 20"
     }
+  },
+  "admin": {
+    "breadcrumb": "Admin",
+    "pageTitle": "admin — pending users",
+    "tableHeader": "pending users",
+    "loadingText": "loading users",
+    "emptyTitle": "no pending users",
+    "emptySubtitle": "all confirmed users have been assigned to a group",
+    "columnEmail": "email",
+    "columnStatus": "status",
+    "columnCreated": "created",
+    "columnActions": "actions",
+    "approveButton": "approve",
+    "errorHeader": "failed to load users"
   },
   "roadmap": {
     "title": "Roadmap",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -19,6 +19,7 @@
     "home": "Inicio del Grupo",
     "roadmap": "Roadmap",
     "meetings": "Juntas",
+    "admin": "Admin",
     "resources": "Recursos",
     "techDebtCountdowns": "Conteos de Deuda Técnica",
     "designSystem": "Sistema de Diseño",
@@ -326,6 +327,20 @@
       "speedRatingMapping": "💨 Clasificación de Velocidad",
       "speedRatingMappingValue": "stats.movespeed ÷ 20  // código"
     }
+  },
+  "admin": {
+    "breadcrumb": "Admin",
+    "pageTitle": "admin — usuarios pendientes",
+    "tableHeader": "usuarios pendientes",
+    "loadingText": "cargando usuarios",
+    "emptyTitle": "sin usuarios pendientes",
+    "emptySubtitle": "todos los usuarios confirmados tienen un grupo asignado",
+    "columnEmail": "correo",
+    "columnStatus": "estado",
+    "columnCreated": "creado",
+    "columnActions": "acciones",
+    "approveButton": "aprobar",
+    "errorHeader": "error al cargar usuarios"
   },
   "roadmap": {
     "title": "Roadmap",

--- a/src/pages/admin/__tests__/app.test.tsx
+++ b/src/pages/admin/__tests__/app.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { AuthContext } from '../../../contexts/auth-context';
+import type { AuthState } from '../../../contexts/auth-context';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyProps = Record<string, any>;
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+vi.mock('../../../lib/auth', () => ({
+  beginLogin: vi.fn(),
+  signOut: vi.fn(),
+  getIdToken: vi.fn(() => null),
+  decodeToken: vi.fn(),
+  refreshTokens: vi.fn(),
+}));
+
+vi.mock('../../../lib/admin', () => ({
+  listPendingUsers: vi.fn(),
+  approveUser: vi.fn(),
+}));
+
+vi.mock('../../../layouts/shell', () => ({
+  default: ({ children }: AnyProps) => React.createElement('div', { 'data-testid': 'shell' }, children),
+}));
+vi.mock('../../../components/navigation', () => ({
+  default: () => React.createElement('nav', { 'data-testid': 'navigation' }),
+}));
+vi.mock('../../../components/breadcrumbs', () => ({
+  default: () => React.createElement('nav', { 'aria-label': 'breadcrumbs' }),
+}));
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ locale: 'us', t: (k: string) => k }),
+}));
+
+import App from '../app';
+
+function state(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    isAuthenticated: false,
+    idToken: null,
+    email: null,
+    name: null,
+    groups: [],
+    isModerator: false,
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('/admin auth gating + table', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/admin', search: '' },
+      writable: true,
+    });
+  });
+
+  it('moderator → renders table with mocked pending users', async () => {
+    const { listPendingUsers } = await import('../../../lib/admin');
+    (listPendingUsers as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { sub: 'sub-1', email: 'alice@example.com', status: 'CONFIRMED', groups: [], createdAt: '2026-01-01T00:00:00Z' },
+      { sub: 'sub-2', email: 'bob@example.com', status: 'CONFIRMED', groups: [], createdAt: '2026-02-01T00:00:00Z' },
+    ]);
+
+    render(
+      <AuthContext.Provider value={state({ isAuthenticated: true, idToken: 'id', email: 'mod@example.com', groups: ['moderators'], isModerator: true })}>
+        <App />
+      </AuthContext.Provider>,
+    );
+
+    await waitFor(() => expect(screen.getByText('alice@example.com')).toBeInTheDocument());
+    expect(screen.getByText('bob@example.com')).toBeInTheDocument();
+  });
+
+  it('moderator → clicking approve calls approveUser', async () => {
+    const { listPendingUsers, approveUser } = await import('../../../lib/admin');
+    (listPendingUsers as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { sub: 'sub-1', email: 'alice@example.com', status: 'CONFIRMED', groups: [], createdAt: '2026-01-01T00:00:00Z' },
+    ]);
+    (approveUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      user: { sub: 'sub-1', email: 'alice@example.com', status: 'CONFIRMED', groups: ['members'], createdAt: '2026-01-01T00:00:00Z' },
+    });
+
+    render(
+      <AuthContext.Provider value={state({ isAuthenticated: true, idToken: 'id', email: 'mod@example.com', groups: ['moderators'], isModerator: true })}>
+        <App />
+      </AuthContext.Provider>,
+    );
+
+    await waitFor(() => screen.getByText('alice@example.com'));
+    const approveBtn = screen.getByRole('button', { name: /admin.approveButton/i });
+    fireEvent.click(approveBtn);
+    await waitFor(() => expect(approveUser).toHaveBeenCalledWith('sub-1', 'members'));
+  });
+
+  it('non-moderator → RequireAuth shows access denied, not table', async () => {
+    render(
+      <AuthContext.Provider value={state({ isAuthenticated: true, idToken: 'id', email: 'member@example.com', groups: ['members'], isModerator: false })}>
+        <App />
+      </AuthContext.Provider>,
+    );
+    // RequireAuth with requireGroup="moderators" renders the access denied alert
+    await waitFor(() => expect(screen.getByText(/moderator access required/i)).toBeInTheDocument());
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('unauthenticated → triggers beginLogin, renders spinner not table', async () => {
+    const { beginLogin } = await import('../../../lib/auth');
+    render(
+      <AuthContext.Provider value={state()}>
+        <App />
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(beginLogin).toHaveBeenCalled());
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('load error → shows error alert', async () => {
+    const { listPendingUsers } = await import('../../../lib/admin');
+    (listPendingUsers as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network failure'));
+
+    render(
+      <AuthContext.Provider value={state({ isAuthenticated: true, idToken: 'id', email: 'mod@example.com', groups: ['moderators'], isModerator: true })}>
+        <App />
+      </AuthContext.Provider>,
+    );
+
+    await waitFor(() => expect(screen.getByText('network failure')).toBeInTheDocument());
+  });
+});

--- a/src/pages/admin/app.tsx
+++ b/src/pages/admin/app.tsx
@@ -1,0 +1,160 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import Alert from '@cloudscape-design/components/alert';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Table from '@cloudscape-design/components/table';
+
+import Breadcrumbs from '../../components/breadcrumbs';
+import Navigation from '../../components/navigation';
+import ShellLayout from '../../layouts/shell';
+import { RequireAuth } from '../../components/require-auth';
+import { listPendingUsers, approveUser, type AdminUser } from '../../lib/admin';
+import { initializeTheme, applyTheme, setStoredTheme, type Theme } from '../../utils/theme';
+import { initializeLocale, applyLocale, setStoredLocale, type Locale } from '../../utils/locale';
+import { useTranslation } from '../../hooks/useTranslation';
+
+function BreadcrumbsContent() {
+  const { t } = useTranslation();
+  return <Breadcrumbs active={{ text: t('admin.breadcrumb'), href: '/admin/index.html' }} />;
+}
+
+function AdminTable() {
+  const { t } = useTranslation();
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [approvingIds, setApprovingIds] = useState<Set<string>>(new Set());
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await listPendingUsers('pending');
+      setUsers(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleApprove = useCallback(
+    async (user: AdminUser) => {
+      setApprovingIds((prev) => new Set(prev).add(user.sub));
+      try {
+        await approveUser(user.sub, 'members');
+        setUsers((prev) => prev.filter((u) => u.sub !== user.sub));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'approve failed');
+      } finally {
+        setApprovingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(user.sub);
+          return next;
+        });
+      }
+    },
+    [],
+  );
+
+  return (
+    <SpaceBetween size="m">
+      {error && (
+        <Alert type="error" header={t('admin.errorHeader')} dismissible onDismiss={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+      <Table
+        loading={loading}
+        loadingText={t('admin.loadingText')}
+        items={users}
+        columnDefinitions={[
+          {
+            id: 'email',
+            header: t('admin.columnEmail'),
+            cell: (u) => u.email,
+            isRowHeader: true,
+          },
+          {
+            id: 'status',
+            header: t('admin.columnStatus'),
+            cell: (u) => u.status,
+          },
+          {
+            id: 'createdAt',
+            header: t('admin.columnCreated'),
+            cell: (u) => new Date(u.createdAt).toLocaleDateString(),
+          },
+          {
+            id: 'actions',
+            header: t('admin.columnActions'),
+            cell: (u) => (
+              <Button
+                variant="primary"
+                loading={approvingIds.has(u.sub)}
+                onClick={() => { void handleApprove(u); }}
+              >
+                {t('admin.approveButton')}
+              </Button>
+            ),
+          },
+        ]}
+        empty={
+          <Box margin={{ vertical: 'xs' }} textAlign="center" color="inherit">
+            <SpaceBetween size="s">
+              <Box variant="strong">{t('admin.emptyTitle')}</Box>
+              <Box variant="p" color="inherit">
+                {t('admin.emptySubtitle')}
+              </Box>
+            </SpaceBetween>
+          </Box>
+        }
+        header={
+          <Header counter={loading ? undefined : `(${users.length})`}>
+            {t('admin.tableHeader')}
+          </Header>
+        }
+      />
+    </SpaceBetween>
+  );
+}
+
+export default function App() {
+  const [theme, setTheme] = useState<Theme>(() => initializeTheme());
+  const [locale, setLocale] = useState<Locale>(() => initializeLocale());
+
+  const handleThemeChange = (newTheme: Theme) => {
+    setTheme(newTheme);
+    applyTheme(newTheme);
+    setStoredTheme(newTheme);
+  };
+
+  const handleLocaleChange = (newLocale: Locale) => {
+    setLocale(newLocale);
+    applyLocale(newLocale);
+    setStoredLocale(newLocale);
+  };
+
+  return (
+    <ShellLayout
+      contentType="table"
+      theme={theme}
+      onThemeChange={handleThemeChange}
+      locale={locale}
+      onLocaleChange={handleLocaleChange}
+      pageTitle="admin.pageTitle"
+      breadcrumbs={<BreadcrumbsContent />}
+      navigation={<Navigation />}
+    >
+      <RequireAuth requireGroup="moderators">
+        <AdminTable />
+      </RequireAuth>
+    </ShellLayout>
+  );
+}

--- a/src/pages/admin/index.html
+++ b/src/pages/admin/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="light dark" />
+  <title>Cloud Del Norte - admin</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/admin/main.tsx"></script>
+</body>
+
+</html>

--- a/src/pages/admin/main.tsx
+++ b/src/pages/admin/main.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import '@cloudscape-design/global-styles/index.css';
+import '../../styles/tokens.css';
+
+import App from './app';
+
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         'maintenance-calendar': resolve(__dirname, './src/pages/maintenance-calendar/index.html'),
         theme: resolve(__dirname, './src/pages/theme/index.html'),
         'auth/callback': resolve(__dirname, './src/pages/auth/callback/index.html'),
+        admin: resolve(__dirname, './src/pages/admin/index.html'),
       },
     },
   },


### PR DESCRIPTION
## summary

- `src/pages/admin/index.html` + `main.tsx` + `app.tsx` — MPA entry matching auth/callback shape; `<RequireAuth requireGroup="moderators">` wraps a Cloudscape `<Table>` listing pending users with loading/empty/error states; per-row **approve** button (variant=primary) calls `approveUser(sub, 'members')`
- `src/lib/admin.ts` — new module: `listPendingUsers(filter)`, `approveUser(sub, group)`, `banUser(sub)`; bearer auth with 401 refresh+retry (mirrors jitsi-token pattern)
- `src/components/navigation/index.tsx` — adds Admin link to SideNavigation only when `isModerator` (conditional concat into items array)
- `vite.config.ts` — `admin` entry added to `rollupOptions.input`
- `src/locales/en-US.json`, `es-MX.json` — `admin.*` and `navigation.admin` keys added to both locales
- `src/locales/__tests__/translation-coverage.test.ts` — `navigation.admin` and `admin.breadcrumb` added to allowlist (technical terms identical in both locales)

## tests

- `src/pages/admin/__tests__/app.test.tsx` — 5 tests: moderator→table renders users, approve click calls approveUser, non-moderator→RequireAuth denied, unauthenticated→beginLogin+no table, load error→Alert visible
- `src/lib/__tests__/admin.test.ts` — 4 tests: not authenticated→throws, bearer header sent, 401 refresh+retry, approveUser POST body shape

total: 9 new tests — all 223 pass, 0 failures

## cloudscape API notes

- `Table` `loading` prop shows built-in spinner; `empty` slot renders when `items.length === 0` post-load
- `Alert` header is not a semantic heading — tests use `getByText` not `getByRole('heading')`
- no new runtime deps; Cloudscape Table, Alert, Header, Button, Box, SpaceBetween all already present in the bundle

## test plan

- [ ] deploy CDK (meet repo) first — admin API routes must exist before frontend calls them
- [ ] navigate to `/admin/` as moderator — expect pending users table
- [ ] navigate to `/admin/` as member — expect "moderator access required" alert
- [ ] click Approve — expect user removed from pending list + Cognito group updated
- [ ] verify Admin nav link appears in sidebar for moderator, absent for non-moderator

🤖 Generated with [Claude Code](https://claude.com/claude-code)