### PR TITLE
feat: integrate AWS Device Farm browser testing

### DIFF
--- a/.woodpecker/device-farm.yml
+++ b/.woodpecker/device-farm.yml
@@ -1,0 +1,27 @@
+# woodpecker ci — device farm browser testing
+# repo: chasko-labs/cloud-del-norte-website
+# runs after build on push to main and on pull requests
+
+depends_on:
+  - ci
+
+when:
+  - event: [push, pull_request]
+    branch: main
+
+steps:
+  - name: device-farm-test
+    image: amazon/aws-cli:2.15.0
+    secrets: [device_farm_role_arn, device_farm_project_arn, device_farm_artifacts_bucket]
+    environment:
+      AWS_ROLE_ARN:
+        from_secret: device_farm_role_arn
+      DEVICE_FARM_PROJECT_ARN:
+        from_secret: device_farm_project_arn
+      DEVICE_FARM_ARTIFACTS_BUCKET:
+        from_secret: device_farm_artifacts_bucket
+    commands:
+      - yum install -y jq
+      - chmod +x .woodpecker/scripts/run-tests.sh .woodpecker/scripts/collect-artifacts.sh
+      - .woodpecker/scripts/run-tests.sh
+      - .woodpecker/scripts/collect-artifacts.sh

--- a/.woodpecker/scripts/collect-artifacts.sh
+++ b/.woodpecker/scripts/collect-artifacts.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUN_ARN=$(cat /tmp/device_farm_run_arn)
+DEST="s3://${DEVICE_FARM_ARTIFACTS_BUCKET}/runs/${CI_BUILD_NUMBER}/"
+
+# List and download artifacts
+for TYPE in LOG SCREENSHOT FILE; do
+  ARTIFACTS=$(aws devicefarm list-artifacts \
+    --arn "$RUN_ARN" \
+    --type "$TYPE" \
+    --query 'artifacts[].url' \
+    --output text)
+
+  for URL in $ARTIFACTS; do
+    FILENAME=$(basename "$URL" | cut -d'?' -f1)
+    curl -sSf -o "/tmp/${TYPE}_${FILENAME}" "$URL"
+    aws s3 cp "/tmp/${TYPE}_${FILENAME}" "${DEST}${TYPE}/${FILENAME}"
+  done
+done
+
+echo "Artifacts uploaded to ${DEST}"

--- a/.woodpecker/scripts/run-tests.sh
+++ b/.woodpecker/scripts/run-tests.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Assume CI role via OIDC
+eval "$(aws sts assume-role-with-web-identity \
+  --role-arn "$AWS_ROLE_ARN" \
+  --role-session-name "woodpecker-${CI_BUILD_NUMBER}" \
+  --web-identity-token "$CI_OIDC_TOKEN" \
+  --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+  --output text | awk '{printf "export AWS_ACCESS_KEY_ID=%s\nexport AWS_SECRET_ACCESS_KEY=%s\nexport AWS_SESSION_TOKEN=%s\n",$1,$2,$3}')"
+
+TEST_PACKAGE="${TEST_PACKAGE_PATH:-tests.zip}"
+
+# Create upload slot
+UPLOAD=$(aws devicefarm create-upload \
+  --project-arn "$DEVICE_FARM_PROJECT_ARN" \
+  --name "$(basename "$TEST_PACKAGE")" \
+  --type "WEB_APP" \
+  --output json)
+
+UPLOAD_ARN=$(echo "$UPLOAD" | jq -r '.upload.arn')
+UPLOAD_URL=$(echo "$UPLOAD" | jq -r '.upload.url')
+
+# Upload test package
+curl -sSf -T "$TEST_PACKAGE" "$UPLOAD_URL"
+
+# Wait for upload processing
+for i in $(seq 1 30); do
+  STATUS=$(aws devicefarm get-upload --arn "$UPLOAD_ARN" --query 'upload.status' --output text)
+  [ "$STATUS" = "SUCCEEDED" ] && break
+  [ "$STATUS" = "FAILED" ] && echo "Upload failed" && exit 1
+  sleep 2
+done
+
+# Schedule run
+RUN=$(aws devicefarm schedule-run \
+  --project-arn "$DEVICE_FARM_PROJECT_ARN" \
+  --app-arn "$UPLOAD_ARN" \
+  --test type=BUILTIN_FUZZ \
+  --output json)
+
+RUN_ARN=$(echo "$RUN" | jq -r '.run.arn')
+echo "Run started: $RUN_ARN"
+
+# Poll until complete (timeout 30 min)
+for i in $(seq 1 180); do
+  RESULT=$(aws devicefarm get-run --arn "$RUN_ARN" --output json)
+  STATUS=$(echo "$RESULT" | jq -r '.run.status')
+  [ "$STATUS" = "COMPLETED" ] && break
+  [ "$STATUS" = "ERRORED" ] && echo "Run errored" && exit 1
+  sleep 10
+done
+
+# Check result
+OUTCOME=$(echo "$RESULT" | jq -r '.run.result')
+echo "Run result: $OUTCOME"
+
+# Export for collect-artifacts.sh
+echo "$RUN_ARN" > /tmp/device_farm_run_arn
+
+[ "$OUTCOME" = "PASSED" ] && exit 0
+exit 1


### PR DESCRIPTION
Adds Device Farm browser testing step to Woodpecker CI pipeline. Tests run on push to main and on PRs. Requires secrets: device_farm_role_arn, device_farm_project_arn, device_farm_artifacts_bucket.