### PR TITLE
docs: add backlinks to aws-device-farm-infra

### DIFF
--- a/.woodpecker/device-farm.yml
+++ b/.woodpecker/device-farm.yml
@@ -1,4 +1,5 @@
 # woodpecker ci — device farm browser testing
+# infra: https://github.com/chasko-labs/aws-device-farm-infra (private)
 # repo: chasko-labs/cloud-del-norte-website
 # runs after build on push to main and on pull requests
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ auth chain: workload x509 cert → IAM RolesAnywhere → `heraldstack-ci-deploy`
 
 pipeline steps: `install` → `build` → `deploy` (main) or `deploy-dev` (dev) → `screenshot-prod` / `screenshot-dev`
 
+Browser/device testing infrastructure: [aws-device-farm-infra](https://github.com/chasko-labs/aws-device-farm-infra) (private)
+
 post-deploy screenshot captures run automatically and are available at predictable URLs — see [docs/ops/ci-screenshots.md](docs/ops/ci-screenshots.md) for the URL pattern and capture matrix.
 
 ### Manual deploy

--- a/docs/testing-runbook.md
+++ b/docs/testing-runbook.md
@@ -1,5 +1,7 @@
 # cloud del norte testing runbook
 
+Browser/device testing infrastructure: [aws-device-farm-infra](https://github.com/chasko-labs/aws-device-farm-infra) (private)
+
 how to test this site end-to-end from rocm-aibox without claude-in-chrome.
 
 ## quick recipe — verify a CSS change visually


### PR DESCRIPTION
Adds cross-repo backlinks to chasko-labs/aws-device-farm-infra in README (CI/CD section), .woodpecker/device-farm.yml (header comment), and docs/testing-runbook.md.