### PR TITLE
feat: pull Device Farm test credentials from SSM

### DIFF
--- a/.woodpecker/device-farm.yml
+++ b/.woodpecker/device-farm.yml
@@ -9,39 +9,41 @@ when:
 steps:
   - name: device-farm-test
     image: python:3.12-slim
-    secrets:
-      - device_farm_grid_url
-      - test_user_member_email
-      - test_user_member_password
-      - test_user_admin_email
-      - test_user_admin_password
-      - test_user_pending_email
-      - test_user_pending_password
-      - test_user_banned_email
-      - test_user_banned_password
     environment:
-      DEVICE_FARM_GRID_URL:
-        from_secret: device_farm_grid_url
-      TEST_USER_MEMBER_EMAIL:
-        from_secret: test_user_member_email
-      TEST_USER_MEMBER_PASSWORD:
-        from_secret: test_user_member_password
-      TEST_USER_ADMIN_EMAIL:
-        from_secret: test_user_admin_email
-      TEST_USER_ADMIN_PASSWORD:
-        from_secret: test_user_admin_password
-      TEST_USER_PENDING_EMAIL:
-        from_secret: test_user_pending_email
-      TEST_USER_PENDING_PASSWORD:
-        from_secret: test_user_pending_password
-      TEST_USER_BANNED_EMAIL:
-        from_secret: test_user_banned_email
-      TEST_USER_BANNED_PASSWORD:
-        from_secret: test_user_banned_password
+      AWS_REGION: us-west-2
       TEST_URL: https://awsug.clouddelnorte.org
       TEST_AUTH_URL: https://auth.clouddelnorte.org
       TEST_API_URL: https://rwmypxz9z6.execute-api.us-west-2.amazonaws.com
+    secrets:
+      - device_farm_grid_url
     commands:
+      - pip install awscli -q
       - pip install -r tests/device-farm/requirements.txt
+
+      # Assume OIDC role
+      - |
+        CREDS=$(aws sts assume-role-with-web-identity \
+          --role-arn "$CI_OIDC_ROLE_ARN" \
+          --role-session-name "device-farm-ci" \
+          --web-identity-token "$CI_OIDC_TOKEN" \
+          --query 'Credentials' --output json)
+        export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | python -c "import sys,json;print(json.load(sys.stdin)['AccessKeyId'])")
+        export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | python -c "import sys,json;print(json.load(sys.stdin)['SecretAccessKey'])")
+        export AWS_SESSION_TOKEN=$(echo "$CREDS" | python -c "import sys,json;print(json.load(sys.stdin)['SessionToken'])")
+
+      # Fetch test credentials from SSM Parameter Store
+      - |
+        export DEVICE_FARM_GRID_URL=$(aws ssm get-parameter --name '/device-farm/test-users/grid-url' --region us-west-2 --query 'Parameter.Value' --output text 2>/dev/null || echo "$DEVICE_FARM_GRID_URL")
+        export TEST_USER_MEMBER_EMAIL=$(aws ssm get-parameter --name '/device-farm/test-users/member-email' --region us-west-2 --query 'Parameter.Value' --output text)
+        export TEST_USER_MEMBER_PASSWORD=$(aws ssm get-parameter --name '/device-farm/test-users/member-password' --region us-west-2 --with-decryption --query 'Parameter.Value' --output text)
+        export TEST_USER_ADMIN_EMAIL=$(aws ssm get-parameter --name '/device-farm/test-users/admin-email' --region us-west-2 --query 'Parameter.Value' --output text)
+        export TEST_USER_ADMIN_PASSWORD=$(aws ssm get-parameter --name '/device-farm/test-users/admin-password' --region us-west-2 --with-decryption --query 'Parameter.Value' --output text)
+        export TEST_USER_PENDING_EMAIL=$(aws ssm get-parameter --name '/device-farm/test-users/pending-email' --region us-west-2 --query 'Parameter.Value' --output text)
+        export TEST_USER_PENDING_PASSWORD=$(aws ssm get-parameter --name '/device-farm/test-users/pending-password' --region us-west-2 --with-decryption --query 'Parameter.Value' --output text)
+        export TEST_USER_BANNED_EMAIL=$(aws ssm get-parameter --name '/device-farm/test-users/banned-email' --region us-west-2 --query 'Parameter.Value' --output text)
+        export TEST_USER_BANNED_PASSWORD=$(aws ssm get-parameter --name '/device-farm/test-users/banned-password' --region us-west-2 --with-decryption --query 'Parameter.Value' --output text)
+        export COGNITO_USER_POOL_ID=$(aws ssm get-parameter --name '/device-farm/test-users/cognito-user-pool-id' --region us-west-2 --query 'Parameter.Value' --output text)
+        export COGNITO_CLIENT_ID=$(aws ssm get-parameter --name '/device-farm/test-users/cognito-client-id' --region us-west-2 --query 'Parameter.Value' --output text)
+
       - pytest tests/device-farm/ --junitxml=results.xml -v
       - echo "Results saved to results.xml"

--- a/tests/device-farm/README.md
+++ b/tests/device-farm/README.md
@@ -2,6 +2,27 @@
 
 Comprehensive browser tests covering all user roles, broken links, console errors, auth flows, and API access control.
 
+## Credentials — SSM Parameter Store
+
+Test credentials are stored in AWS SSM Parameter Store and fetched at runtime by the CI pipeline after assuming the OIDC role. No secrets are stored in Woodpecker.
+
+**SSM path prefix:** `/device-farm/test-users/`
+
+| SSM Parameter | Type | Env Var |
+|---|---|---|
+| `/device-farm/test-users/member-email` | String | `TEST_USER_MEMBER_EMAIL` |
+| `/device-farm/test-users/member-password` | SecureString | `TEST_USER_MEMBER_PASSWORD` |
+| `/device-farm/test-users/admin-email` | String | `TEST_USER_ADMIN_EMAIL` |
+| `/device-farm/test-users/admin-password` | SecureString | `TEST_USER_ADMIN_PASSWORD` |
+| `/device-farm/test-users/pending-email` | String | `TEST_USER_PENDING_EMAIL` |
+| `/device-farm/test-users/pending-password` | SecureString | `TEST_USER_PENDING_PASSWORD` |
+| `/device-farm/test-users/banned-email` | String | `TEST_USER_BANNED_EMAIL` |
+| `/device-farm/test-users/banned-password` | SecureString | `TEST_USER_BANNED_PASSWORD` |
+| `/device-farm/test-users/cognito-user-pool-id` | String | `COGNITO_USER_POOL_ID` |
+| `/device-farm/test-users/cognito-client-id` | String | `COGNITO_CLIENT_ID` |
+
+The CI role (`device-farm-ci`) has `ssm:GetParameter`, `ssm:GetParameters`, and `ssm:GetParametersByPath` on `arn:aws:ssm:us-west-2:*:parameter/device-farm/test-users/*`.
+
 ## Environment Variables
 
 | Variable | Description |
@@ -10,6 +31,8 @@ Comprehensive browser tests covering all user roles, broken links, console error
 | `TEST_URL` | App base URL (default: `https://awsug.clouddelnorte.org`) |
 | `TEST_AUTH_URL` | Auth subdomain URL (default: `https://auth.clouddelnorte.org`) |
 | `TEST_API_URL` | API Gateway URL (default: `https://rwmypxz9z6.execute-api.us-west-2.amazonaws.com`) |
+| `COGNITO_USER_POOL_ID` | Cognito User Pool ID (fetched from SSM in CI) |
+| `COGNITO_CLIENT_ID` | Cognito App Client ID (fetched from SSM in CI) |
 | `TEST_USER_MEMBER_EMAIL` | Member test user email |
 | `TEST_USER_MEMBER_PASSWORD` | Member test user password |
 | `TEST_USER_ADMIN_EMAIL` | Admin test user email |
@@ -18,7 +41,6 @@ Comprehensive browser tests covering all user roles, broken links, console error
 | `TEST_USER_PENDING_PASSWORD` | Pending test user password |
 | `TEST_USER_BANNED_EMAIL` | Banned test user email |
 | `TEST_USER_BANNED_PASSWORD` | Banned test user password |
-| `AWS_REGION` | AWS region for Cognito (default: `us-west-2`) |
 
 ## Run Locally
 
@@ -29,15 +51,14 @@ docker run -d -p 4444:4444 selenium/standalone-chrome:latest
 # Install deps
 pip install -r tests/device-farm/requirements.txt
 
-# Export credentials
+# Export credentials (or fetch from SSM if you have AWS access)
+aws ssm get-parameters-by-path --path /device-farm/test-users/ --region us-west-2 --with-decryption
+
+# Or set manually:
 export TEST_USER_MEMBER_EMAIL="member@example.com"
 export TEST_USER_MEMBER_PASSWORD="..."
-export TEST_USER_ADMIN_EMAIL="admin@example.com"
-export TEST_USER_ADMIN_PASSWORD="..."
-export TEST_USER_PENDING_EMAIL="pending@example.com"
-export TEST_USER_PENDING_PASSWORD="..."
-export TEST_USER_BANNED_EMAIL="banned@example.com"
-export TEST_USER_BANNED_PASSWORD="..."
+export COGNITO_USER_POOL_ID="us-west-2_XXXXX"
+export COGNITO_CLIENT_ID="..."
 
 # Run
 pytest tests/device-farm/ -v --junitxml=results.xml
@@ -45,7 +66,7 @@ pytest tests/device-farm/ -v --junitxml=results.xml
 
 ## How Device Farm Runs It
 
-The Woodpecker CI pipeline (`.woodpecker/device-farm.yml`) installs Python deps, sets env vars from secrets, and runs pytest against the Device Farm Selenium Grid.
+The Woodpecker CI pipeline (`.woodpecker/device-farm.yml`) assumes the OIDC role, fetches all test credentials from SSM Parameter Store, then runs pytest against the Device Farm Selenium Grid.
 
 ## Adding Test Users to Cognito
 

--- a/tests/device-farm/conftest.py
+++ b/tests/device-farm/conftest.py
@@ -8,7 +8,8 @@ import pytest
 from selenium import webdriver
 from selenium.webdriver.remote.webdriver import WebDriver
 
-COGNITO_CLIENT_ID = "57eikmt418ea6vti2f6h0pl74r"
+COGNITO_CLIENT_ID = os.environ.get("COGNITO_CLIENT_ID", "57eikmt418ea6vti2f6h0pl74r")
+COGNITO_USER_POOL_ID = os.environ.get("COGNITO_USER_POOL_ID", "us-west-2_XXXXX")
 COGNITO_ENDPOINT = "https://cognito-idp.us-west-2.amazonaws.com/"
 AUTH_URL = "https://auth.clouddelnorte.org"
 APP_URL = "https://awsug.clouddelnorte.org"


### PR DESCRIPTION
## Summary

Replaces Woodpecker secrets with AWS SSM Parameter Store for Device Farm test credentials.

### Changes
- `.woodpecker/device-farm.yml`: Assumes OIDC role then fetches all test user credentials and Cognito config from SSM at runtime
- `tests/device-farm/conftest.py`: Reads `COGNITO_CLIENT_ID` and `COGNITO_USER_POOL_ID` from env vars (with fallback defaults)
- `tests/device-farm/README.md`: Documents SSM parameter paths and runtime credential fetching

### Dependencies
- IAM policy update in aws-device-farm-infra (SSMTestCredentials statement)
- SSM parameters must be stored (pending AWS SSO login)