### PR TITLE
fix(kiro): populate project-context with Device Farm + stack docs

### DIFF
--- a/.kiro/steering/project-context.md
+++ b/.kiro/steering/project-context.md
@@ -1,30 +1,37 @@
-<!--
-  project-context.md template — rendered by bin/kiro-bootstrap into
-  <repo>/.kiro/steering/project-context.md
-  authored once at bootstrap, hand-edited as the project evolves
--->
-
 # project context — cloud-del-norte-website
 
 ## what this repo is
 
-cloud-del-norte-website is a `react-vite` repo in the heraldstack. specific purpose, audience, and runtime surface live in the project-specific facts section below — bootstrap fills in the type-derived defaults; the human author owns everything below the divider
+cloud-del-norte-website is a React + Vite SPA for the Cloud Del Norte community college CS program website. Deployed to AWS (S3 + CloudFront). Authenticated via Cognito on a dedicated auth subdomain.
 
 ## stack
 
-# TODO: list stack components (e.g. hugo, papermod-derived theme, woodpecker)
+- React 18 + Vite
+- AWS Cloudscape Design System (UI components)
+- Amazon Cognito (auth — hosted UI on auth subdomain, token flow via redirect)
+- Vitest (unit/integration tests)
+- Woodpecker CI (build, deploy, device-farm testing)
+- S3 + CloudFront (hosting)
 
 ## deploy targets
 
-# TODO: fill in deploy targets (e.g. s3://awsaerospace.org via woodpecker)
+- Production: S3 bucket via Woodpecker pipeline on main merge
+- Preview: per-branch deploys on PR (CloudFront invalidation)
 
----
+## testing infrastructure
+
+- **Device Farm integration**: `.woodpecker/device-farm.yml` — runs cross-browser/device tests on AWS Device Farm
+- **Test suite**: `tests/device-farm/` — pytest-based tests (auth flows, broken links, console errors, API access)
+- **Credentials**: SSM Parameter Store at `/device-farm/test-users/*`
+- **Infra repo**: `chasko-labs/aws-device-farm-infra` (Terraform for Device Farm project + device pools)
 
 ## notable architectural facts
 
-# TODO: document architectural facts (account-routing, deploy-exclusions, cross-repo runtime contracts)
-
-(this section is human-authored. fill in: account-routing rules, cross-account artifact splits, runtime quirks, deploy-exclusion rules, repo-internal subscope conventions, anything an agent needs to know to operate correctly here that is NOT in the repo-type doc)
+- Auth subdomain pattern: Cognito hosted UI on `auth.{domain}`, token exchange via redirect back to app
+- Token flow: authorization code grant → token endpoint → access/id/refresh tokens stored in session
+- Vitest runs in CI on every PR; Device Farm runs on main merge
+- Cloudscape components are the only permitted UI library — no MUI, no Tailwind
+- Static assets in `public/` are deployed as-is to S3 root
 
 ## the rule in one sentence
 

--- a/.kiro/steering/project-scope.md
+++ b/.kiro/steering/project-scope.md
@@ -1,34 +1,38 @@
-<!--
-  project-scope.md template — rendered by bin/kiro-bootstrap into
-  <repo>/.kiro/steering/project-scope.md
-  scope governs what agents in this repo may touch
--->
-
 # project scope — cloud-del-norte-website
 
 ## what this file does
 
-scope governs what agents operating in `cloud-del-norte-website` may touch. this is a constraint document, not an aspirational one — work outside the in-scope table escalates upstream rather than landing here. scope drift in a session is a routing failure, not a coding decision
+scope governs what agents operating in `cloud-del-norte-website` may touch. work outside the in-scope table escalates upstream rather than landing here.
 
 ## in-scope work
 
 | work type | owner agent |
 | --------- | ----------- |
-| TODO      | TODO        |
+| React components + pages (Cloudscape) | poltergeist-harald-cdn-product-owner |
+| Vite config + build pipeline | poltergeist-harald-cdn-product-owner |
+| Vitest unit/integration tests | poltergeist-harald-cdn-product-owner |
+| Device Farm test suite (tests/device-farm/) | ghost-orin-ci-cd |
+| Woodpecker CI pipelines (.woodpecker/) | ghost-orin-ci-cd |
+| CSS/styling fixes | ghost-liora-css-repair |
+| Documentation + content | poltergeist-voss-chasko-author |
 
 ## out-of-scope work
 
 | work type | escalates to |
 | --------- | ------------ |
-| TODO      | TODO         |
+| Cognito/IAM infrastructure changes | chasko-labs/aws-device-farm-infra or haunting-kiro-cli (stratia-aws-infra) |
+| Haunting agent definitions | haunting-kiro-cli repo |
+| Chrome extension work | chrome-extension-moodle-uploader repo |
+| Device Farm infra (Terraform) | chasko-labs/aws-device-farm-infra |
 
 ## escalation patterns
 
 | trigger | route |
 | ------- | ----- |
-| TODO    | TODO  |
-
-(when an agent observes a scope violation: name the violation, identify the receiving repo or collective, dispatch the appropriate cross-repo agent — never inline-fix work that belongs elsewhere)
+| Auth flow broken (Cognito config) | dispatch poltergeist-stratia-aws-infra |
+| Device Farm infra change needed | dispatch to aws-device-farm-infra repo |
+| CI pipeline structural change | ghost-orin-ci-cd |
+| Scope violation detected | name violation, identify receiving repo, dispatch — never inline-fix |
 
 ## the rule in one sentence
 


### PR DESCRIPTION
## Summary

Fills in the TODO-stub .kiro/steering files with real project context so haunting sessions have architectural awareness.

## Changes

- **project-context.md**: Documents stack (React/Vite/Cloudscape/Cognito), deploy targets, Device Farm integration, test suite location, SSM credential paths, infra repo reference.
- **project-scope.md**: Defines in-scope/out-of-scope work and escalation patterns.

## Why

Sessions were launching with empty project context, causing agents to be unaware of existing infrastructure (e.g., claiming Device Farm doesn't exist).