### PR TITLE
style(cards): wave 23.5 polish — fix desktop whitespace + strengthen lighting/gradients/shadows

### DIFF
--- a/public/data/feeds.json
+++ b/public/data/feeds.json
@@ -33,24 +33,6 @@
   ],
   "awsml": [
     {
-      "title": "Integrate Atlassian Confluence Cloud with Amazon Quick",
-      "link": "https://aws.amazon.com/blogs/machine-learning/integrate-atlassian-confluence-cloud-with-amazon-quick/",
-      "pubDate": "2026-05-18",
-      "excerpt": "In this post, you will learn how to set up the Confluence Cloud integration with Quick. This includes creating a knowledge base for semantic search, setting up Actions to query and manage Confluence p"
-    },
-    {
-      "title": "Build custom code-based evaluators in Amazon Bedrock AgentCore",
-      "link": "https://aws.amazon.com/blogs/machine-learning/build-custom-code-based-evaluators-in-amazon-bedrock-agentcore/",
-      "pubDate": "2026-05-18",
-      "excerpt": "In this post, you will implement four Lambda-based custom code evaluators for a financial market-intelligence agent, register each with AgentCore, and run them in on-demand and online modes. You will "
-    },
-    {
-      "title": "Restrict access to sensitive documents in your Amazon Quick knowledge bases for Amazon S3",
-      "link": "https://aws.amazon.com/blogs/machine-learning/restrict-access-to-sensitive-documents-in-your-amazon-quick-knowledge-bases-for-amazon-s3/",
-      "pubDate": "2026-05-15",
-      "excerpt": "In this post, we walk through how to configure document-level ACLs for your S3 knowledge base in Amazon Quick. You will learn how to set up and verify an ACL configuration that enforces document-level"
-    },
-    {
       "title": "Improve bot accuracy with Amazon Lex Assisted NLU",
       "link": "https://aws.amazon.com/blogs/machine-learning/improve-bot-accuracy-with-amazon-lex-assisted-nlu/",
       "pubDate": "2026-05-14",
@@ -61,6 +43,24 @@
       "link": "https://aws.amazon.com/blogs/machine-learning/real-time-voice-agents-with-stream-vision-agents-and-amazon-nova-2-sonic/",
       "pubDate": "2026-05-14",
       "excerpt": "In this post, you learn how to combine Stream's Vision Agents open-source framework with Amazon Bedrock and Amazon Nova 2 Sonic to build real-time voice agents that can be production-ready in minutes."
+    },
+    {
+      "title": "From siloed data to unified insights: Cross-account Athena Access for Amazon Quick",
+      "link": "https://aws.amazon.com/blogs/machine-learning/from-siloed-data-to-unified-insights-cross-account-athena-access-for-amazon-quick/",
+      "pubDate": "2026-05-14",
+      "excerpt": "Today, we're announcing cross-account Athena access for Amazon Quick. With this feature, customers can query Athena data in other AWS accounts using AWS Identity and Access Management (IAM) role chain"
+    },
+    {
+      "title": "Control where your AI agents can browse with Chrome enterprise policies on Amazon Bedrock AgentCore",
+      "link": "https://aws.amazon.com/blogs/machine-learning/control-where-your-ai-agents-can-browse-with-chrome-enterprise-policies-on-amazon-bedrock-agentcore/",
+      "pubDate": "2026-05-14",
+      "excerpt": "In this post, you will configure Chrome enterprise policies to restrict a browser agent to a specific website, observe the policy enforcement through session recording, and demonstrate custom root CA "
+    },
+    {
+      "title": "Build financial document processing with Pulse AI and Amazon Bedrock",
+      "link": "https://aws.amazon.com/blogs/machine-learning/build-financial-document-processing-with-pulse-ai-and-amazon-bedrock/",
+      "pubDate": "2026-05-13",
+      "excerpt": "This post demonstrates how to build a documentation extraction and model fine-tuning pipeline that addresses challenges when processing the complex financial documents. By combining Pulse AI's advance"
     }
   ]
 }

--- a/public/data/feeds.json
+++ b/public/data/feeds.json
@@ -33,6 +33,24 @@
   ],
   "awsml": [
     {
+      "title": "Integrate Atlassian Confluence Cloud with Amazon Quick",
+      "link": "https://aws.amazon.com/blogs/machine-learning/integrate-atlassian-confluence-cloud-with-amazon-quick/",
+      "pubDate": "2026-05-18",
+      "excerpt": "In this post, you will learn how to set up the Confluence Cloud integration with Quick. This includes creating a knowledge base for semantic search, setting up Actions to query and manage Confluence p"
+    },
+    {
+      "title": "Build custom code-based evaluators in Amazon Bedrock AgentCore",
+      "link": "https://aws.amazon.com/blogs/machine-learning/build-custom-code-based-evaluators-in-amazon-bedrock-agentcore/",
+      "pubDate": "2026-05-18",
+      "excerpt": "In this post, you will implement four Lambda-based custom code evaluators for a financial market-intelligence agent, register each with AgentCore, and run them in on-demand and online modes. You will "
+    },
+    {
+      "title": "Restrict access to sensitive documents in your Amazon Quick knowledge bases for Amazon S3",
+      "link": "https://aws.amazon.com/blogs/machine-learning/restrict-access-to-sensitive-documents-in-your-amazon-quick-knowledge-bases-for-amazon-s3/",
+      "pubDate": "2026-05-15",
+      "excerpt": "In this post, we walk through how to configure document-level ACLs for your S3 knowledge base in Amazon Quick. You will learn how to set up and verify an ACL configuration that enforces document-level"
+    },
+    {
       "title": "Improve bot accuracy with Amazon Lex Assisted NLU",
       "link": "https://aws.amazon.com/blogs/machine-learning/improve-bot-accuracy-with-amazon-lex-assisted-nlu/",
       "pubDate": "2026-05-14",
@@ -43,24 +61,6 @@
       "link": "https://aws.amazon.com/blogs/machine-learning/real-time-voice-agents-with-stream-vision-agents-and-amazon-nova-2-sonic/",
       "pubDate": "2026-05-14",
       "excerpt": "In this post, you learn how to combine Stream's Vision Agents open-source framework with Amazon Bedrock and Amazon Nova 2 Sonic to build real-time voice agents that can be production-ready in minutes."
-    },
-    {
-      "title": "From siloed data to unified insights: Cross-account Athena Access for Amazon Quick",
-      "link": "https://aws.amazon.com/blogs/machine-learning/from-siloed-data-to-unified-insights-cross-account-athena-access-for-amazon-quick/",
-      "pubDate": "2026-05-14",
-      "excerpt": "Today, we're announcing cross-account Athena access for Amazon Quick. With this feature, customers can query Athena data in other AWS accounts using AWS Identity and Access Management (IAM) role chain"
-    },
-    {
-      "title": "Control where your AI agents can browse with Chrome enterprise policies on Amazon Bedrock AgentCore",
-      "link": "https://aws.amazon.com/blogs/machine-learning/control-where-your-ai-agents-can-browse-with-chrome-enterprise-policies-on-amazon-bedrock-agentcore/",
-      "pubDate": "2026-05-14",
-      "excerpt": "In this post, you will configure Chrome enterprise policies to restrict a browser agent to a specific website, observe the policy enforcement through session recording, and demonstrate custom root CA "
-    },
-    {
-      "title": "Build financial document processing with Pulse AI and Amazon Bedrock",
-      "link": "https://aws.amazon.com/blogs/machine-learning/build-financial-document-processing-with-pulse-ai-and-amazon-bedrock/",
-      "pubDate": "2026-05-13",
-      "excerpt": "This post demonstrates how to build a documentation extraction and model fine-tuning pipeline that addresses challenges when processing the complex financial documents. By combining Pulse AI's advance"
     }
   ]
 }

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -387,6 +387,23 @@
 	-webkit-backdrop-filter: blur(10px) saturate(1.15);
 }
 
+/* wave 23.5 — fill container: Cloudscape Container root + content must stretch
+   to fill the cdn-card flex parent so no dead whitespace remains on desktop. */
+.feed-grid__cell.cdn-card {
+	display: flex;
+	flex-direction: column;
+}
+
+.feed-grid__cell.cdn-card > [class*="awsui_root"] {
+	flex: 1 1 auto;
+	display: flex;
+	flex-direction: column;
+}
+
+.feed-grid__cell.cdn-card > [class*="awsui_root"] > [class*="awsui_content_"] {
+	flex: 1 1 auto;
+}
+
 /* glassmorphism — suppress Container chrome so the cdn-card glass surface shows.
    descendant (not direct-child) combinator handles any React wrapper divs between
    cdn-card and the Cloudscape root element. */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -136,11 +136,12 @@
 	--cdn-shadow-container-light:
 		0 1px 4px rgba(139, 90, 43, 0.1), 0 4px 12px rgba(139, 90, 43, 0.06);
 	--cdn-shadow-card-light:
-		0 2px 8px rgba(139, 90, 43, 0.12), 0 1px 3px rgba(0, 0, 0, 0.06),
-		0 0 1px rgba(139, 90, 43, 0.08);
+		0 1px 3px rgba(139, 90, 43, 0.1), 0 4px 10px -2px rgba(139, 90, 43, 0.12),
+		0 8px 20px -4px rgba(139, 90, 43, 0.08);
 	--cdn-shadow-card-hover-light:
-		0 8px 24px rgba(139, 90, 43, 0.18), 0 4px 10px rgba(0, 0, 0, 0.08),
-		0 0 2px rgba(139, 90, 43, 0.12);
+		0 4px 8px rgba(139, 90, 43, 0.14), 0 12px 28px -4px rgba(139, 90, 43, 0.18),
+		0 20px 40px -8px rgba(139, 90, 43, 0.1),
+		0 0 0 1px rgba(139, 90, 43, 0.06);
 	--cdn-shadow-input-light: inset 0 1px 3px rgba(139, 90, 43, 0.08);
 	--cdn-shadow-nav-light: 2px 0 8px rgba(139, 90, 43, 0.08);
 
@@ -282,8 +283,10 @@ html:not(.awsui-dark-mode) body {
 		0 8px 24px -6px rgba(0, 0, 0, 0.35), 0 4px 12px -3px rgba(0, 0, 0, 0.25),
 		inset 0 1px 0 rgba(255, 255, 255, 0.04);
 	--cdn-shadow-glow:
+		0 4px 8px rgba(0, 0, 0, 0.35),
 		0 16px 32px -8px rgba(0, 0, 0, 0.4),
-		0 0 30px -8px rgba(144, 96, 240, calc(0.2 + var(--cdn-mid) * 0.15));
+		0 0 20px -4px rgba(144, 96, 240, calc(0.22 + var(--cdn-mid) * 0.15)),
+		0 0 40px -8px rgba(144, 96, 240, calc(0.12 + var(--cdn-mid) * 0.1));
 
 	/* Table header — elevated surface in dark mode to distinguish from data rows */
 	--color-background-table-header-hdjxos: #0a0a1f;
@@ -363,10 +366,11 @@ html:not(.awsui-dark-mode) body {
 		rgba(30, 26, 48, 0.88) 30%,
 		rgba(17, 24, 39, 0.97) 100%
 	);
-	border-color: rgba(144, 96, 240, 0.15);
+	border-color: rgba(144, 96, 240, 0.18);
 	box-shadow:
-		0 8px 24px -6px rgba(0, 0, 0, 0.3),
-		0 0 20px -8px rgba(144, 96, 240, 0.1);
+		0 2px 4px rgba(0, 0, 0, 0.3),
+		0 8px 24px -6px rgba(0, 0, 0, 0.35),
+		0 0 24px -8px rgba(144, 96, 240, 0.15);
 }
 
 /* ==========================================================================
@@ -639,38 +643,55 @@ html:not(.awsui-dark-mode) body {
    thread + preserves clamp/excerpt geometry from the v0.0.0114 sprint.
    ========================================================================== */
 
-/* shared gradient + shadow tokens — single source of truth, both modes */
+/* shared gradient + shadow tokens — single source of truth, both modes
+   wave 23.5: strengthened gradients + layered shadow stack inspired by
+   fiona end-credits popout (multi-layer glow + radial accent bloom) */
 :root {
-	/* light mode: warm cream → amber-tinted cream → warm cream
-	   subtle 4-6% alpha shift, reads as cream-with-light not as gradient */
-	--cdn-card-gradient-light: linear-gradient(
-		135deg,
-		rgba(255, 250, 235, 0.55) 0%,
-		rgba(232, 215, 180, 0.18) 45%,
-		rgba(250, 244, 230, 0.5) 100%
-	);
-	/* warm amber rim glow + soft drop — sits above the existing cloudscape shadow */
+	/* light mode: warm cream → amber radial accent → cream edge
+	   stronger than prior 4-6% alpha — reads as warm directional light */
+	--cdn-card-gradient-light:
+		radial-gradient(
+			ellipse at 30% 0%,
+			rgba(201, 162, 63, 0.1) 0%,
+			transparent 60%
+		),
+		linear-gradient(
+			135deg,
+			rgba(255, 250, 235, 0.7) 0%,
+			rgba(232, 215, 180, 0.28) 45%,
+			rgba(250, 244, 230, 0.6) 100%
+		);
+	/* layered shadow: close contact + medium spread + ambient depth (fiona-credits inspired) */
 	--cdn-card-rim-light:
-		inset 0 1px 0 rgba(255, 250, 235, 0.7),
-		inset 0 -1px 0 rgba(139, 90, 43, 0.06),
-		0 1px 3px rgba(139, 90, 43, 0.08),
-		0 6px 16px -4px rgba(139, 90, 43, 0.12);
+		inset 0 1px 0 rgba(255, 250, 235, 0.85),
+		inset 0 -1px 0 rgba(139, 90, 43, 0.08),
+		0 1px 2px rgba(139, 90, 43, 0.12),
+		0 4px 8px -2px rgba(139, 90, 43, 0.1),
+		0 8px 20px -4px rgba(139, 90, 43, 0.14);
 }
 
 .awsui-dark-mode {
-	/* dark mode: violet bloom from top-left fading to deeper navy bottom-right
-	   reads as ambient violet rim light, not as a gradient */
-	--cdn-card-gradient-light: linear-gradient(
-		135deg,
-		rgba(144, 96, 240, 0.08) 0%,
-		rgba(48, 0, 106, 0.04) 45%,
-		rgba(10, 10, 46, 0.18) 100%
-	);
+	/* dark mode: violet radial bloom from top-left + linear depth gradient
+	   reads as ambient violet rim light with directional accent */
+	--cdn-card-gradient-light:
+		radial-gradient(
+			ellipse at 25% 0%,
+			rgba(144, 96, 240, 0.14) 0%,
+			transparent 55%
+		),
+		linear-gradient(
+			135deg,
+			rgba(144, 96, 240, 0.1) 0%,
+			rgba(48, 0, 106, 0.06) 45%,
+			rgba(10, 10, 46, 0.22) 100%
+		);
+	/* layered: inner highlight + close shadow + violet ambient glow + deep drop */
 	--cdn-card-rim-light:
-		inset 0 1px 0 rgba(199, 184, 232, 0.08),
-		inset 0 -1px 0 rgba(0, 0, 0, 0.25),
-		0 2px 6px rgba(0, 0, 0, 0.32),
-		0 8px 22px -6px rgba(144, 96, 240, 0.18);
+		inset 0 1px 0 rgba(199, 184, 232, 0.12),
+		inset 0 -1px 0 rgba(0, 0, 0, 0.3),
+		0 2px 4px rgba(0, 0, 0, 0.35),
+		0 6px 16px -4px rgba(144, 96, 240, 0.22),
+		0 12px 28px -8px rgba(0, 0, 0, 0.3);
 }
 
 /* Cloudscape Container body — variant-default + variant-stacked.


### PR DESCRIPTION
## what changes

- Fill-container fix: `feed-grid__cell.cdn-card` now flex-stretches the Cloudscape Container root so cards don't show dead whitespace below short content on desktop.
- Strengthened light-mode `--cdn-shadow-card-light` and hover variant — multi-layer shadow stack (1px close + 4-10px mid + 8-20px far + hover 0,1px ring at 6% alpha) for more pronounced depth.
- Strengthened dark-mode `--cdn-shadow-glow` — added close-shadow + dual-radius violet bloom layers.
- Strengthened glass card gradients per fiona end-credits popout reference (multi-layer glow + radial accent bloom).

## gates

- biome ci: 0 errors / 447 warnings (2 added by new CSS, baseline acceptable)
- npm run build: PASS
- vitest: 541 / 541 PASS

## scope

CSS only — `tokens.css` and `feed/styles.css`. No component changes, no JSON locale changes.