### PR TITLE
feat(rsvp): in-person RSVP flow phase 1 — dual-CTA, /rsvp page, QR tickets

### DIFF
--- a/src/lib/__tests__/rsvp.test.ts
+++ b/src/lib/__tests__/rsvp.test.ts
@@ -1,0 +1,121 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	addRsvp,
+	buildTicketPayload,
+	CDN_EVENTS,
+	getEvent,
+	getRsvp,
+	listUserRsvps,
+	type RsvpRecord,
+	spotsRemaining,
+} from "../rsvp";
+
+const EVENT_ID = "happy-hour-2026-06-03";
+
+beforeEach(() => {
+	localStorage.clear();
+});
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+describe("rsvp lib", () => {
+	it("CDN_EVENTS contains the happy-hour event with expected capacity", () => {
+		const event = getEvent(EVENT_ID);
+		expect(event).toBeDefined();
+		expect(event?.capacity).toBe(50);
+		expect(event?.rsvpedBaseline).toBe(2);
+		expect(event?.location).toBe("Downtown El Paso, Texas");
+	});
+
+	it("spotsRemaining starts at capacity minus baseline", () => {
+		expect(spotsRemaining(EVENT_ID)).toBe(48);
+	});
+
+	it("spotsRemaining decrements by 1 for each in-app RSVP", () => {
+		addRsvp({ eventId: EVENT_ID, userSub: "u1", name: "Alice", email: null });
+		expect(spotsRemaining(EVENT_ID)).toBe(47);
+		addRsvp({ eventId: EVENT_ID, userSub: "u2", name: "Bob", email: null });
+		expect(spotsRemaining(EVENT_ID)).toBe(46);
+	});
+
+	it("addRsvp is idempotent for the same user+event", () => {
+		const first = addRsvp({
+			eventId: EVENT_ID,
+			userSub: "u1",
+			name: "Alice",
+			email: null,
+		});
+		const second = addRsvp({
+			eventId: EVENT_ID,
+			userSub: "u1",
+			name: "Alice (different)",
+			email: null,
+		});
+		expect(first).toEqual(second);
+		expect(spotsRemaining(EVENT_ID)).toBe(47);
+	});
+
+	it("getRsvp returns the record for matching user+event", () => {
+		addRsvp({
+			eventId: EVENT_ID,
+			userSub: "u1",
+			name: "Alice",
+			email: "a@example.com",
+		});
+		const found = getRsvp(EVENT_ID, "u1");
+		expect(found?.name).toBe("Alice");
+		expect(found?.email).toBe("a@example.com");
+	});
+
+	it("getRsvp returns undefined for missing user+event", () => {
+		expect(getRsvp(EVENT_ID, "missing")).toBeUndefined();
+	});
+
+	it("listUserRsvps returns only the calling user's records", () => {
+		addRsvp({ eventId: EVENT_ID, userSub: "u1", name: "A", email: null });
+		addRsvp({ eventId: EVENT_ID, userSub: "u2", name: "B", email: null });
+		const u1 = listUserRsvps("u1");
+		expect(u1).toHaveLength(1);
+		expect(u1[0].userSub).toBe("u1");
+	});
+
+	it("buildTicketPayload produces a stable cdn-ticket:v1 prefixed string", () => {
+		const record: RsvpRecord = {
+			eventId: EVENT_ID,
+			userSub: "u1",
+			name: null,
+			email: null,
+			createdAt: "2026-05-18T22:00:00.000Z",
+		};
+		expect(buildTicketPayload(record)).toBe(`cdn-ticket:v1:${EVENT_ID}:u1`);
+	});
+
+	it("spotsRemaining never goes negative when capacity is exhausted", () => {
+		const event = getEvent(EVENT_ID);
+		if (!event) throw new Error("event missing");
+		// Fill all remaining spots with synthetic RSVPs
+		for (let i = 0; i < event.capacity - event.rsvpedBaseline + 5; i++) {
+			addRsvp({
+				eventId: EVENT_ID,
+				userSub: `u${i}`,
+				name: null,
+				email: null,
+			});
+		}
+		expect(spotsRemaining(EVENT_ID)).toBe(0);
+	});
+
+	it("CDN_EVENTS list is non-empty", () => {
+		expect(CDN_EVENTS.length).toBeGreaterThan(0);
+	});
+
+	it("returns empty list for unknown event id", () => {
+		expect(getEvent("does-not-exist")).toBeUndefined();
+		expect(spotsRemaining("does-not-exist")).toBe(0);
+	});
+});

--- a/src/lib/rsvp.ts
+++ b/src/lib/rsvp.ts
@@ -1,0 +1,146 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/**
+ * RSVP client-side storage layer.
+ *
+ * Phase 1: localStorage-only. Each RSVP record is keyed by the user's Cognito
+ * `sub` and the event id. The QR ticket payload is derived deterministically
+ * from {sub, eventId, name, email} so the same authenticated user always
+ * regenerates the same ticket from the same browser.
+ *
+ * Phase 2 (deferred to a separate dispatch): replace the localStorage layer
+ * with an API Gateway HTTP V2 + Lambda + DynamoDB backend so capacity is
+ * enforced server-side and tickets survive across browsers/devices.
+ */
+
+const STORAGE_KEY = "cdn.rsvps.v1";
+
+export interface CdnEvent {
+	id: string;
+	title: string;
+	scheduledDate: string; // ISO date string YYYY-MM-DD
+	location: string;
+	capacity: number;
+	rsvpedBaseline: number; // spots already taken outside the in-app flow
+	meetupRsvpUrl: string;
+}
+
+export interface RsvpRecord {
+	eventId: string;
+	userSub: string;
+	name: string | null;
+	email: string | null;
+	createdAt: string; // ISO timestamp
+}
+
+/** Canonical event registry. Add upcoming in-person events here. */
+export const CDN_EVENTS: CdnEvent[] = [
+	{
+		id: "happy-hour-2026-06-03",
+		title: "Cloud Del Norte UG — Community Happy Hour & Networking Night",
+		scheduledDate: "2026-06-03",
+		location: "Downtown El Paso, Texas",
+		capacity: 50,
+		rsvpedBaseline: 2,
+		meetupRsvpUrl:
+			"https://www.meetup.com/awsugclouddelnorte/events/314839263/rsvp/",
+	},
+];
+
+export function getEvent(id: string): CdnEvent | undefined {
+	return CDN_EVENTS.find((e) => e.id === id);
+}
+
+function isBrowser(): boolean {
+	return typeof window !== "undefined" && typeof localStorage !== "undefined";
+}
+
+function readAll(): RsvpRecord[] {
+	if (!isBrowser()) return [];
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return [];
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return [];
+		return parsed as RsvpRecord[];
+	} catch {
+		return [];
+	}
+}
+
+function writeAll(records: RsvpRecord[]): void {
+	if (!isBrowser()) return;
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(records));
+	} catch {
+		// localStorage may be disabled (private mode, quota exceeded). The user
+		// will see the ticket on the confirmation page but it won't persist;
+		// next dispatch's backend will solve the durability problem.
+	}
+}
+
+/**
+ * Lookup a single user's RSVP for a given event.
+ * Returns undefined if no RSVP exists.
+ */
+export function getRsvp(
+	eventId: string,
+	userSub: string,
+): RsvpRecord | undefined {
+	return readAll().find((r) => r.eventId === eventId && r.userSub === userSub);
+}
+
+/**
+ * Add (or refresh) an RSVP record for the given user + event.
+ * Idempotent — a second call with the same {eventId,userSub} returns the
+ * existing record without duplicating it.
+ */
+export function addRsvp(input: {
+	eventId: string;
+	userSub: string;
+	name: string | null;
+	email: string | null;
+}): RsvpRecord {
+	const existing = getRsvp(input.eventId, input.userSub);
+	if (existing) return existing;
+	const record: RsvpRecord = {
+		eventId: input.eventId,
+		userSub: input.userSub,
+		name: input.name,
+		email: input.email,
+		createdAt: new Date().toISOString(),
+	};
+	const records = readAll();
+	records.push(record);
+	writeAll(records);
+	return record;
+}
+
+/** Return all RSVPs belonging to a single authenticated user. */
+export function listUserRsvps(userSub: string): RsvpRecord[] {
+	return readAll().filter((r) => r.userSub === userSub);
+}
+
+/**
+ * Spots remaining for an event. Counts the baseline (off-platform RSVPs) plus
+ * the local count of in-app RSVPs. Phase 2 will swap this for a server query.
+ */
+export function spotsRemaining(eventId: string): number {
+	const event = getEvent(eventId);
+	if (!event) return 0;
+	const localCount = readAll().filter((r) => r.eventId === eventId).length;
+	const taken = event.rsvpedBaseline + localCount;
+	return Math.max(0, event.capacity - taken);
+}
+
+/**
+ * Build the deterministic ticket payload string used as the QR code value.
+ * Format: `cdn-ticket:v1:{eventId}:{userSub}` — short, scannable, no PII.
+ * The check-in flow at the door scans this string and looks up the record
+ * server-side (when the backend lands in Phase 2). For now it serves as a
+ * stable identifier the user can show.
+ */
+export function buildTicketPayload(record: RsvpRecord): string {
+	return `cdn-ticket:v1:${record.eventId}:${record.userSub}`;
+}

--- a/src/locales/__tests__/translation-coverage.test.ts
+++ b/src/locales/__tests__/translation-coverage.test.ts
@@ -118,6 +118,8 @@ describe("translation coverage", () => {
 			"feedPage.builderCenterHeader", // "AWS Builder Center" - AWS program proper noun
 			"helpPanel.arrowheadPark", // "Arrowhead Research Park" - proper noun
 			"helpPanel.communityFoundedSuffix", // ", NMSU." - punctuation + acronym
+			"rsvp.breadcrumb", // "RSVP" - universal abbreviation
+			"rsvp.pageTitle", // "RSVP — Cloud Del Norte" - proper noun + universal abbreviation
 			"feedPage.pastMeetupSpeaker1Name", // proper name
 			"feedPage.pastMeetupSpeaker2Name", // proper name
 			"feedPage.pastMeetupSpeaker3Name", // proper name

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -141,7 +141,11 @@
 		"upcomingVirtualEventFeaturedTalkBadge": "FEATURED TALK",
 		"upcomingVirtualEventFeaturedTalkSpeaker": "AWSUG Cloud Del Norte organizer Bryan Chasko",
 		"upcomingVirtualEventFeaturedTalkTitle": "A Migration Story: After 240 Consecutive Months, I Avoided a Charge From Microsoft",
-		"upcomingVirtualEventUgMarkLabel": "AWS User Group mark"
+		"upcomingVirtualEventUgMarkLabel": "AWS User Group mark",
+		"featuredEventInPersonLabel": "June 2026 in person: Downtown El Paso, Texas",
+		"featuredEventSpotsRemaining": "{count} of {capacity} spots remaining",
+		"featuredEventRsvpPrimary": "RSVP & sign up for CloudDelNorte.org speakeasy access",
+		"featuredEventRsvpMeetup": "RSVP on Meetup"
 	},
 	"dashboardPage": {
 		"productionOverview": {
@@ -263,7 +267,10 @@
 			"meetupRsvpUrl": "Meetup RSVP URL",
 			"save": "Save",
 			"cancel": "Cancel"
-		}
+		},
+		"myTicketsHeader": "Your tickets",
+		"myTicketsEmpty": "You haven't RSVPed to any in-person Cloud Del Norte events yet.",
+		"myTicketsShowAtDoor": "Show this code at the door"
 	},
 	"createMeeting": {
 		"breadcrumb": "Create meeting",
@@ -959,5 +966,27 @@
 		"streamErrorPersistent": "this station's stream is having a moment — try again or skip to another station",
 		"streamErrorRetryButton": "try again",
 		"streamErrorAdvancing": "station unavailable, advancing..."
+	},
+	"rsvp": {
+		"breadcrumb": "RSVP",
+		"pageTitle": "RSVP — Cloud Del Norte",
+		"header": "RSVP for in-person event",
+		"subheader": "Limited to the first 50 people. Save your QR ticket — show it at the door for entry.",
+		"checkingAuth": "Checking your sign-in...",
+		"eventNotFound": "Event not found",
+		"eventNotFoundDesc": "This RSVP page is no longer active. See upcoming events on the meetings page.",
+		"soldOutHeader": "This event is full",
+		"soldOutBody": "All 50 in-person spots are taken. Watch the feed for the next in-person event, or join the global virtual gathering linked below.",
+		"ticketHeader": "You're on the list",
+		"ticketSubheader": "Show this QR code at the door for entry. You can pull it back up any time from the meetings page.",
+		"ticketEvent": "Event",
+		"ticketDate": "Date",
+		"ticketLocation": "Location",
+		"ticketHolder": "Ticket holder",
+		"ticketCode": "Ticket code",
+		"viewMyTickets": "View my tickets",
+		"rsvpButton": "Confirm my RSVP",
+		"rsvpingNow": "Reserving your seat...",
+		"fallbackMeetupCta": "RSVP on Meetup instead"
 	}
 }

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -141,7 +141,11 @@
 		"upcomingVirtualEventFeaturedTalkBadge": "PRESENTACIÓN DESTACADA",
 		"upcomingVirtualEventFeaturedTalkSpeaker": "El organizador de AWSUG Cloud Del Norte, Bryan Chasko",
 		"upcomingVirtualEventFeaturedTalkTitle": "Una historia de migración: después de 240 meses consecutivos, evité un cargo de Microsoft",
-		"upcomingVirtualEventUgMarkLabel": "Marca AWS User Group"
+		"upcomingVirtualEventUgMarkLabel": "Marca AWS User Group",
+		"featuredEventInPersonLabel": "Junio de 2026 en persona: centro de El Paso, Texas",
+		"featuredEventSpotsRemaining": "{count} de {capacity} cupos disponibles",
+		"featuredEventRsvpPrimary": "RSVP y regístrate para el acceso speakeasy de CloudDelNorte.org",
+		"featuredEventRsvpMeetup": "RSVP en Meetup"
 	},
 	"dashboardPage": {
 		"productionOverview": {
@@ -263,7 +267,10 @@
 			"meetupRsvpUrl": "URL de RSVP en Meetup",
 			"save": "Guardar",
 			"cancel": "Cancelar"
-		}
+		},
+		"myTicketsHeader": "Tus boletos",
+		"myTicketsEmpty": "Aún no has confirmado asistencia a eventos presenciales de Cloud Del Norte.",
+		"myTicketsShowAtDoor": "Muestra este código en la puerta"
 	},
 	"createMeeting": {
 		"breadcrumb": "Crear junta",
@@ -959,5 +966,27 @@
 		"streamErrorPersistent": "esta estación anda fallando — dale otra vez o pícale a otra estación",
 		"streamErrorRetryButton": "dale otra vez",
 		"streamErrorAdvancing": "estación no disponible, avanzando..."
+	},
+	"rsvp": {
+		"breadcrumb": "RSVP",
+		"pageTitle": "RSVP — Cloud Del Norte",
+		"header": "RSVP para evento presencial",
+		"subheader": "Limitado a las primeras 50 personas. Guarda tu código QR — muéstralo en la puerta para entrar.",
+		"checkingAuth": "Verificando tu sesión...",
+		"eventNotFound": "Evento no encontrado",
+		"eventNotFoundDesc": "Esta página de RSVP ya no está activa. Consulta los próximos eventos en la página de reuniones.",
+		"soldOutHeader": "Este evento está lleno",
+		"soldOutBody": "Los 50 cupos presenciales están tomados. Revisa el feed para el próximo evento presencial, o únete a la reunión global virtual enlazada abajo.",
+		"ticketHeader": "Estás en la lista",
+		"ticketSubheader": "Muestra este código QR en la puerta para entrar. Puedes volver a verlo en cualquier momento desde la página de reuniones.",
+		"ticketEvent": "Evento",
+		"ticketDate": "Fecha",
+		"ticketLocation": "Ubicación",
+		"ticketHolder": "Titular",
+		"ticketCode": "Código del boleto",
+		"viewMyTickets": "Ver mis boletos",
+		"rsvpButton": "Confirmar mi RSVP",
+		"rsvpingNow": "Reservando tu lugar...",
+		"fallbackMeetupCta": "Mejor RSVP en Meetup"
 	}
 }

--- a/src/pages/feed/components/__tests__/featured-event.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-event.test.tsx
@@ -20,14 +20,14 @@ describe("FeaturedEvent", () => {
 		expect(screen.getByText("FEATURED")).toBeInTheDocument();
 	});
 
-	it("renders the event title with link to RSVP URL", () => {
+	it("renders the event title with link to internal RSVP page", () => {
 		renderWithLocale("us");
 		const link = screen.getByText(
 			"AWS Cloud del Norte UG — Community Happy Hour & Networking Night",
 		);
 		expect(link.closest("a")).toHaveAttribute(
 			"href",
-			"https://www.meetup.com/awsugclouddelnorte/events/314839263/rsvp/",
+			"/rsvp/index.html?event=happy-hour-2026-06-03",
 		);
 	});
 
@@ -38,7 +38,7 @@ describe("FeaturedEvent", () => {
 
 	it("renders the date in es-MX format", () => {
 		renderWithLocale("mx");
-		expect(screen.getByText(/junio/i)).toBeInTheDocument();
+		expect(screen.getAllByText(/junio/i).length).toBeGreaterThan(0);
 	});
 
 	it("renders the RSVP button with target=_blank", () => {
@@ -54,5 +54,29 @@ describe("FeaturedEvent", () => {
 		);
 		expect(img).toHaveAttribute("loading", "lazy");
 		expect(img).toHaveAttribute("src", "/events/featured-2026-06-03.webp");
+	});
+
+	it("renders the in-person location label", () => {
+		renderWithLocale("us");
+		expect(
+			screen.getByText(/in person: Downtown El Paso, Texas/i),
+		).toBeInTheDocument();
+	});
+
+	it("renders the primary speakeasy RSVP button linking to /rsvp", () => {
+		renderWithLocale("us");
+		const primary = screen.getByRole("link", {
+			name: /RSVP & sign up for CloudDelNorte\.org speakeasy access/i,
+		});
+		expect(primary).toHaveAttribute(
+			"href",
+			"/rsvp/index.html?event=happy-hour-2026-06-03",
+		);
+	});
+
+	it("renders the spots remaining counter (48 of 50 default baseline)", () => {
+		localStorage.clear();
+		renderWithLocale("us");
+		expect(screen.getByText(/48 of 50 spots remaining/i)).toBeInTheDocument();
 	});
 });

--- a/src/pages/feed/components/featured-event.tsx
+++ b/src/pages/feed/components/featured-event.tsx
@@ -7,27 +7,49 @@ import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useEffect, useState } from "react";
 import { useTranslation } from "../../../hooks/useTranslation";
+import { getEvent, spotsRemaining } from "../../../lib/rsvp";
 
-const RSVP_URL =
-	"https://www.meetup.com/awsugclouddelnorte/events/314839263/rsvp/";
+const EVENT_ID = "happy-hour-2026-06-03";
 const EVENT_IMAGE = "/events/featured-2026-06-03.webp";
-const EVENT_DATE = "2026-06-03T18:00:00-06:00";
+const RSVP_PAGE_URL = `/rsvp/index.html?event=${EVENT_ID}`;
 
 export default function FeaturedEvent() {
 	const { t, locale } = useTranslation();
+	const event = getEvent(EVENT_ID);
+	const [remaining, setRemaining] = useState<number | null>(null);
+
+	useEffect(() => {
+		// localStorage is browser-only; compute on mount to avoid hydration drift.
+		setRemaining(spotsRemaining(EVENT_ID));
+	}, []);
 
 	const langTag = locale === "mx" ? "es-MX" : "en-US";
-	const formattedDate = new Intl.DateTimeFormat(langTag, {
-		weekday: "long",
-		year: "numeric",
-		month: "long",
-		day: "numeric",
-		hour: "numeric",
-		minute: "2-digit",
-		timeZoneName: "short",
-		timeZone: "America/Denver",
-	}).format(new Date(EVENT_DATE));
+	const eventDate = event ? `${event.scheduledDate}T18:00:00-06:00` : null;
+	const formattedDate = eventDate
+		? new Intl.DateTimeFormat(langTag, {
+				weekday: "long",
+				year: "numeric",
+				month: "long",
+				day: "numeric",
+				hour: "numeric",
+				minute: "2-digit",
+				timeZoneName: "short",
+				timeZone: "America/Denver",
+			}).format(new Date(eventDate))
+		: "";
+
+	const meetupUrl =
+		event?.meetupRsvpUrl ??
+		"https://www.meetup.com/awsugclouddelnorte/events/314839263/rsvp/";
+
+	const spotsCopy =
+		event && remaining !== null
+			? t("feedPage.featuredEventSpotsRemaining")
+					.replace("{count}", String(remaining))
+					.replace("{capacity}", String(event.capacity))
+			: "";
 
 	return (
 		<div className="feed-featured-event">
@@ -53,12 +75,17 @@ export default function FeaturedEvent() {
 						loading="lazy"
 					/>
 					<Box fontWeight="bold" fontSize="heading-m">
-						<Link href={RSVP_URL} external>
-							{t("feedPage.featuredEventTitle")}
-						</Link>
+						<Link href={RSVP_PAGE_URL}>{t("feedPage.featuredEventTitle")}</Link>
 					</Box>
 					<Box color="text-body-secondary" fontSize="body-s">
 						{formattedDate}
+					</Box>
+					<Box
+						color="text-body-secondary"
+						fontSize="body-s"
+						className="feed-featured-event__location"
+					>
+						{t("feedPage.featuredEventInPersonLabel")}
 					</Box>
 					<Box color="text-body-secondary" fontSize="body-s">
 						{t("feedPage.featuredEventLocation")}
@@ -66,15 +93,29 @@ export default function FeaturedEvent() {
 					<Box color="text-body-secondary" fontSize="body-s">
 						{t("feedPage.featuredEventDescription")}
 					</Box>
-					<Button
-						variant="primary"
-						href={RSVP_URL}
-						target="_blank"
-						iconAlign="right"
-						iconName="external"
-					>
-						{t("feedPage.featuredEventRsvp")}
-					</Button>
+					{spotsCopy && (
+						<Box
+							fontWeight="bold"
+							fontSize="body-s"
+							className="feed-featured-event__spots"
+						>
+							{spotsCopy}
+						</Box>
+					)}
+					<SpaceBetween size="xs" direction="vertical">
+						<Button variant="primary" href={RSVP_PAGE_URL}>
+							{t("feedPage.featuredEventRsvpPrimary")}
+						</Button>
+						<Button
+							variant="normal"
+							href={meetupUrl}
+							target="_blank"
+							iconAlign="right"
+							iconName="external"
+						>
+							{t("feedPage.featuredEventRsvpMeetup")}
+						</Button>
+					</SpaceBetween>
 				</SpaceBetween>
 			</Container>
 		</div>

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -1213,3 +1213,31 @@
 .awsui-dark-mode .feed-upcoming-virtual-event__featured-talk-title {
 	color: var(--cdn-lavender, #d7c7ee);
 }
+
+/* Featured event — location pill + seat counter (RSVP flow phase 1) */
+.feed-featured-event__location {
+	display: inline-block;
+	padding: 2px 10px;
+	border-radius: 999px;
+	background-color: rgba(139, 90, 43, 0.12);
+	border: 1px solid rgba(139, 90, 43, 0.32);
+	color: var(--cdn-amber, #8b5a2b);
+	font-size: var(--cdn-text-xs, 0.6875rem);
+	font-weight: 700;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+}
+
+.awsui-dark-mode .feed-featured-event__location {
+	background-color: rgba(255, 153, 0, 0.14);
+	border-color: rgba(255, 153, 0, 0.4);
+	color: var(--cdn-aws-orange, #ff9900);
+}
+
+.feed-featured-event__spots {
+	color: var(--cdn-purple, #5a1f8a);
+}
+
+.awsui-dark-mode .feed-featured-event__spots {
+	color: var(--cdn-lavender, #d7c7ee);
+}

--- a/src/pages/meetings/app.tsx
+++ b/src/pages/meetings/app.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 import Box from "@cloudscape-design/components/box";
+import SpaceBetween from "@cloudscape-design/components/space-between";
 import Tabs from "@cloudscape-design/components/tabs";
 import { useState } from "react";
 import Breadcrumbs from "../../components/breadcrumbs";
@@ -22,7 +23,9 @@ import {
 } from "../../utils/theme";
 import { HelpPanelHome } from "../create-meeting/components/help-panel-home";
 import VariationsTable from "./components/meetings-table";
+import MyTickets from "./components/my-tickets";
 import { variationsData } from "./data";
+import "../rsvp/styles.css";
 
 function BreadcrumbsContent() {
 	const { t } = useTranslation();
@@ -104,7 +107,10 @@ export default function App() {
 		>
 			{/* Guests can browse meetings; the join action inside VariationsTable
 			    gates on auth — guests see the list, must sign in to RSVP. */}
-			<MeetingsTabs />
+			<SpaceBetween size="l">
+				<MyTickets />
+				<MeetingsTabs />
+			</SpaceBetween>
 		</ShellLayout>
 	);
 }

--- a/src/pages/meetings/components/my-tickets.tsx
+++ b/src/pages/meetings/components/my-tickets.tsx
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import Box from "@cloudscape-design/components/box";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { QRCodeSVG } from "qrcode.react";
+import { useEffect, useState } from "react";
+import { useAuth } from "../../../hooks/useAuth";
+import { useTranslation } from "../../../hooks/useTranslation";
+import {
+	buildTicketPayload,
+	getEvent,
+	listUserRsvps,
+	type RsvpRecord,
+} from "../../../lib/rsvp";
+
+export default function MyTickets() {
+	const { t } = useTranslation();
+	const auth = useAuth();
+	const [tickets, setTickets] = useState<RsvpRecord[]>([]);
+
+	useEffect(() => {
+		if (!auth.isAuthenticated || !auth.sub) return;
+		setTickets(listUserRsvps(auth.sub));
+	}, [auth.isAuthenticated, auth.sub]);
+
+	if (!auth.isAuthenticated) return null;
+
+	return (
+		<Container
+			header={<Header variant="h2">{t("meetings.myTicketsHeader")}</Header>}
+		>
+			{tickets.length === 0 ? (
+				<Box color="text-status-inactive">{t("meetings.myTicketsEmpty")}</Box>
+			) : (
+				<SpaceBetween size="m">
+					{tickets.map((ticket) => {
+						const event = getEvent(ticket.eventId);
+						if (!event) return null;
+						const payload = buildTicketPayload(ticket);
+						return (
+							<div
+								key={ticket.eventId}
+								className="cdn-ticket cdn-ticket--compact"
+							>
+								<div className="cdn-ticket__qr">
+									<QRCodeSVG
+										value={payload}
+										size={160}
+										level="M"
+										marginSize={2}
+										fgColor="#5a1f8a"
+										bgColor="#ffffff"
+										title={`${event.title} ticket QR`}
+									/>
+								</div>
+								<dl className="cdn-ticket__meta">
+									<dt>{t("rsvp.ticketEvent")}</dt>
+									<dd>{event.title}</dd>
+									<dt>{t("rsvp.ticketDate")}</dt>
+									<dd>{event.scheduledDate}</dd>
+									<dt>{t("rsvp.ticketLocation")}</dt>
+									<dd>{event.location}</dd>
+									<dt>{t("rsvp.ticketHolder")}</dt>
+									<dd>{ticket.name ?? ticket.email ?? ticket.userSub}</dd>
+									<dt>{t("rsvp.ticketCode")}</dt>
+									<dd>
+										<code>{payload}</code>
+									</dd>
+								</dl>
+							</div>
+						);
+					})}
+					<Box color="text-status-inactive" fontSize="body-s">
+						<Link href="/rsvp/index.html">
+							{t("meetings.myTicketsShowAtDoor")}
+						</Link>
+					</Box>
+				</SpaceBetween>
+			)}
+		</Container>
+	);
+}

--- a/src/pages/meetings/data.ts
+++ b/src/pages/meetings/data.ts
@@ -484,4 +484,15 @@ export const variationsData: meeting[] = [
 		scheduledDate: "2026-06-03",
 		scheduledTime: "08:30",
 	},
+	{
+		name: "🍻 Cloud Del Norte UG — Community Happy Hour & Networking Night",
+		presenters: "Bryan Chasko",
+		happened: "false",
+		ondemand: "no",
+		eventlink: "https://www.meetup.com/awsugclouddelnorte/events/314839263/",
+		meetupRsvpUrl:
+			"https://www.meetup.com/awsugclouddelnorte/events/314839263/rsvp/",
+		scheduledDate: "2026-06-03",
+		scheduledTime: "18:00",
+	},
 ];

--- a/src/pages/rsvp/app.tsx
+++ b/src/pages/rsvp/app.tsx
@@ -1,0 +1,238 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Spinner from "@cloudscape-design/components/spinner";
+import { QRCodeSVG } from "qrcode.react";
+import { useEffect, useState } from "react";
+import Breadcrumbs from "../../components/breadcrumbs";
+import Navigation from "../../components/navigation";
+import { RequireAuth } from "../../components/require-auth";
+import { LocaleProvider } from "../../contexts/locale-context";
+import { useAuth } from "../../hooks/useAuth";
+import { useTranslation } from "../../hooks/useTranslation";
+import ShellLayout from "../../layouts/shell";
+import {
+	addRsvp,
+	buildTicketPayload,
+	getEvent,
+	getRsvp,
+	type RsvpRecord,
+	spotsRemaining,
+} from "../../lib/rsvp";
+import {
+	applyLocale,
+	initializeLocale,
+	type Locale,
+	setStoredLocale,
+} from "../../utils/locale";
+import {
+	applyTheme,
+	initializeTheme,
+	setStoredTheme,
+	type Theme,
+} from "../../utils/theme";
+
+function getEventIdFromQuery(): string {
+	const params = new URLSearchParams(window.location.search);
+	return params.get("event") ?? "happy-hour-2026-06-03";
+}
+
+function RsvpFlow() {
+	const { t, locale } = useTranslation();
+	const auth = useAuth();
+	const [eventId] = useState<string>(() => getEventIdFromQuery());
+	const event = getEvent(eventId);
+	const [ticket, setTicket] = useState<RsvpRecord | null>(null);
+	const [submitting, setSubmitting] = useState(false);
+	const [remaining, setRemaining] = useState<number>(() =>
+		event ? spotsRemaining(eventId) : 0,
+	);
+
+	// Auto-confirm RSVP on first authenticated visit (single-click flow once
+	// the user has signed in via the upstream beginSilentLogin redirect).
+	useEffect(() => {
+		if (!event || !auth.isAuthenticated || !auth.sub) return;
+		const existing = getRsvp(eventId, auth.sub);
+		if (existing) {
+			setTicket(existing);
+			setRemaining(spotsRemaining(eventId));
+			return;
+		}
+		if (remaining <= 0) return;
+		setSubmitting(true);
+		const record = addRsvp({
+			eventId,
+			userSub: auth.sub,
+			name: auth.name,
+			email: auth.email,
+		});
+		setTicket(record);
+		setRemaining(spotsRemaining(eventId));
+		setSubmitting(false);
+	}, [
+		event,
+		auth.isAuthenticated,
+		auth.sub,
+		auth.name,
+		auth.email,
+		eventId,
+		remaining,
+	]);
+
+	if (!event) {
+		return (
+			<Container
+				header={<Header variant="h2">{t("rsvp.eventNotFound")}</Header>}
+			>
+				<SpaceBetween size="m">
+					<Box>{t("rsvp.eventNotFoundDesc")}</Box>
+					<Button href="/meetings/index.html" variant="primary">
+						{t("rsvp.viewMyTickets")}
+					</Button>
+				</SpaceBetween>
+			</Container>
+		);
+	}
+
+	if (submitting) {
+		return (
+			<Container>
+				<Box padding="xxl" textAlign="center">
+					<SpaceBetween size="l" alignItems="center">
+						<Spinner size="large" />
+						<Box>{t("rsvp.rsvpingNow")}</Box>
+					</SpaceBetween>
+				</Box>
+			</Container>
+		);
+	}
+
+	if (!ticket && remaining <= 0) {
+		return (
+			<Container
+				header={<Header variant="h2">{t("rsvp.soldOutHeader")}</Header>}
+			>
+				<SpaceBetween size="m">
+					<Alert type="info">{t("rsvp.soldOutBody")}</Alert>
+					<Button
+						href={event.meetupRsvpUrl}
+						target="_blank"
+						iconAlign="right"
+						iconName="external"
+					>
+						{t("rsvp.fallbackMeetupCta")}
+					</Button>
+				</SpaceBetween>
+			</Container>
+		);
+	}
+
+	if (!ticket) {
+		// Edge: authenticated but addRsvp didn't run yet (StrictMode dev double-mount, etc.).
+		return (
+			<Container>
+				<Box padding="xxl" textAlign="center">
+					<Spinner size="large" />
+				</Box>
+			</Container>
+		);
+	}
+
+	const langTag = locale === "mx" ? "es-MX" : "en-US";
+	const formattedDate = new Intl.DateTimeFormat(langTag, {
+		weekday: "long",
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+		timeZoneName: "short",
+		timeZone: "America/Denver",
+	}).format(new Date(`${event.scheduledDate}T18:00:00-06:00`));
+	const ticketPayload = buildTicketPayload(ticket);
+
+	return (
+		<Container header={<Header variant="h2">{t("rsvp.ticketHeader")}</Header>}>
+			<SpaceBetween size="l">
+				<Alert type="success">{t("rsvp.ticketSubheader")}</Alert>
+				<div className="cdn-ticket">
+					<div className="cdn-ticket__qr">
+						<QRCodeSVG
+							value={ticketPayload}
+							size={232}
+							level="M"
+							marginSize={2}
+							fgColor="#5a1f8a"
+							bgColor="#ffffff"
+							title="Cloud Del Norte ticket QR code"
+						/>
+					</div>
+					<dl className="cdn-ticket__meta">
+						<dt>{t("rsvp.ticketEvent")}</dt>
+						<dd>{event.title}</dd>
+						<dt>{t("rsvp.ticketDate")}</dt>
+						<dd>{formattedDate}</dd>
+						<dt>{t("rsvp.ticketLocation")}</dt>
+						<dd>{event.location}</dd>
+						<dt>{t("rsvp.ticketHolder")}</dt>
+						<dd>{ticket.name ?? ticket.email ?? auth.sub}</dd>
+						<dt>{t("rsvp.ticketCode")}</dt>
+						<dd>
+							<code>{ticketPayload}</code>
+						</dd>
+					</dl>
+				</div>
+				<Box>
+					<Link href="/meetings/index.html">{t("rsvp.viewMyTickets")}</Link>
+				</Box>
+			</SpaceBetween>
+		</Container>
+	);
+}
+
+export default function App() {
+	const [theme, setTheme] = useState<Theme>(() => initializeTheme());
+	const [locale, setLocale] = useState<Locale>(() => initializeLocale());
+
+	const handleThemeChange = (newTheme: Theme) => {
+		setTheme(newTheme);
+		applyTheme(newTheme);
+		setStoredTheme(newTheme);
+	};
+	const handleLocaleChange = (newLocale: Locale) => {
+		setLocale(newLocale);
+		applyLocale(newLocale);
+		setStoredLocale(newLocale);
+	};
+
+	return (
+		<LocaleProvider locale={locale}>
+			<ShellLayout
+				theme={theme}
+				onThemeChange={handleThemeChange}
+				locale={locale}
+				onLocaleChange={handleLocaleChange}
+				breadcrumbs={
+					<Breadcrumbs active={{ text: "RSVP", href: "/rsvp/index.html" }} />
+				}
+				navigation={<Navigation />}
+			>
+				<RequireAuth>
+					<SpaceBetween size="l">
+						<Header variant="h1" description="">
+							Cloud Del Norte UG
+						</Header>
+						<RsvpFlow />
+					</SpaceBetween>
+				</RequireAuth>
+			</ShellLayout>
+		</LocaleProvider>
+	);
+}

--- a/src/pages/rsvp/index.html
+++ b/src/pages/rsvp/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon-star.svg" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>Cloud Del Norte - RSVP</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/rsvp/main.tsx"></script>
+  </body>
+</html>

--- a/src/pages/rsvp/main.tsx
+++ b/src/pages/rsvp/main.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "@cloudscape-design/global-styles/index.css";
+import "../../styles/tokens.css";
+import "./styles.css";
+import App from "./app";
+
+const root = ReactDOM.createRoot(
+	document.getElementById("root") as HTMLElement,
+);
+root.render(
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>,
+);

--- a/src/pages/rsvp/styles.css
+++ b/src/pages/rsvp/styles.css
@@ -1,0 +1,93 @@
+/* RSVP / ticket page — phase 1 (client-side, localStorage-backed) */
+
+.cdn-ticket {
+	display: grid;
+	grid-template-columns: minmax(232px, 280px) 1fr;
+	gap: 24px;
+	align-items: start;
+	padding: 20px;
+	border-radius: 12px;
+	background: linear-gradient(
+		135deg,
+		rgba(90, 31, 138, 0.08) 0%,
+		rgba(144, 96, 240, 0.06) 100%
+	);
+	border: 1px solid rgba(90, 31, 138, 0.22);
+}
+
+.awsui-dark-mode .cdn-ticket {
+	background: linear-gradient(
+		135deg,
+		rgba(144, 96, 240, 0.16) 0%,
+		rgba(215, 199, 238, 0.06) 100%
+	);
+	border-color: rgba(144, 96, 240, 0.42);
+}
+
+.cdn-ticket__qr {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 12px;
+	background: #ffffff;
+	border-radius: 12px;
+	box-shadow:
+		0 0 0 2px rgba(255, 153, 0, 0.55),
+		0 6px 20px rgba(90, 31, 138, 0.25);
+}
+
+.cdn-ticket__meta {
+	margin: 0;
+	display: grid;
+	grid-template-columns: max-content 1fr;
+	column-gap: 16px;
+	row-gap: 8px;
+	font-size: var(--cdn-text-sm, 0.875rem);
+}
+
+.cdn-ticket__meta dt {
+	color: var(--cdn-color-text-secondary);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	font-size: var(--cdn-text-xs, 0.6875rem);
+	align-self: center;
+}
+
+.awsui-dark-mode .cdn-ticket__meta dt {
+	color: var(--cdn-lavender, #d7c7ee);
+}
+
+.cdn-ticket__meta dd {
+	margin: 0;
+	color: var(--cdn-color-text);
+	overflow-wrap: anywhere;
+}
+
+.awsui-dark-mode .cdn-ticket__meta dd {
+	color: #faf7f0;
+}
+
+.cdn-ticket__meta code {
+	font-family:
+		ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+		"Courier New", monospace;
+	font-size: 0.85em;
+	background: rgba(0, 0, 0, 0.06);
+	padding: 1px 6px;
+	border-radius: 4px;
+}
+
+.awsui-dark-mode .cdn-ticket__meta code {
+	background: rgba(255, 255, 255, 0.08);
+}
+
+@media (max-width: 640px) {
+	.cdn-ticket {
+		grid-template-columns: 1fr;
+		justify-items: center;
+	}
+	.cdn-ticket__meta {
+		width: 100%;
+	}
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
 					__dirname,
 					"./src/pages/meeting-public/index.html",
 				),
+				rsvp: resolve(__dirname, "./src/pages/rsvp/index.html"),
 			},
 			output: {
 				// split BabylonJS + Cloudscape into long-lived named chunks so


### PR DESCRIPTION
## what ships

### featured event card (feed)
- Adds 'June 2026 in person: Downtown El Paso, Texas' location pill (amber on light, AWS-orange on dark)
- Shows '48 of 50 spots remaining' counter wired to `spotsRemaining()` (50 capacity, 2 baseline)
- Splits CTA into two buttons:
  - **Primary**: 'RSVP & sign up for CloudDelNorte.org speakeasy access' → `/rsvp/?event=happy-hour-2026-06-03`
  - **Secondary**: 'RSVP on Meetup' → external Meetup URL

### /rsvp MPA page (new)
- Vite entry registered, ShellLayout + Navigation wrapped, RequireAuth gate
- Single-click confirm flow: authenticated user lands → `addRsvp()` runs once (idempotent) → QR ticket renders
- Brand-styled QR (purple #5a1f8a on white, amber ring shadow)
- Ticket card shows event/date/location/holder/code
- Sold-out + event-not-found + submitting states handled

### /meetings page
- Happy Hour 2026-06-03 18:00 added to `variationsData[]` (alongside the existing 08:30 cowork on the same date)
- New 'Your Tickets' section above the Upcoming/History tabs renders QR for any RSVPs the signed-in user holds

### storage layer (Phase 1, client-side)
- `src/lib/rsvp.ts` — typed CdnEvent + RsvpRecord, localStorage backed, idempotent on (userSub, eventId)
- Ticket payload format: `cdn-ticket:v1:<eventId>:<userSub>` (short, scannable, no PII)
- 11 vitest tests covering get/add/list/spotsRemaining/payload/idempotency

## gates
- biome ci: 0 errors / 447 warnings (baseline)
- npm run build: PASS, /rsvp entry bundled
- vitest: 555 / 555 PASS (was 541 — added 11 rsvp lib + 3 featured-event)

## phase 2 (deferred to a separate dispatch)
- API Gateway HTTP V2 + Lambda + DynamoDB for true server-side capacity enforcement
- Cryptographic QR signing (today's QRs are deterministic but unsigned — fine for door check-in via the future Lambda lookup, not fine if the QR is a bearer token)
- Cross-device ticket retrieval (today: per-browser localStorage)
- Auto-cleanup of localStorage records after event completion

## known caveats to flag
- `48 of 50` is computed from `baseline (2) + local in-app RSVPs` — anyone clearing their localStorage resets their visible count. Server-side count is the Phase 2 job.
- The RSVP page assumes redirect from feed/meetings carries `?event=...`; default is the happy-hour event id.
- Featured event card's date display still says June 3 (matches all data); user's earlier copy mentioned 'May 2026 in person' which I'm rendering as 'June 2026 in person' to match — confirm wording before announcement.