### PR TITLE
feat(brand): branded RSVP buttons replace hideous Cloudscape blue (Meetup red + Speakeasy purple)

### DIFF
--- a/src/components/brand-button/__tests__/brand-button.test.tsx
+++ b/src/components/brand-button/__tests__/brand-button.test.tsx
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import MeetupRsvpButton from "../meetup-rsvp";
+import SpeakeasyRsvpButton from "../speakeasy-rsvp";
+
+describe("MeetupRsvpButton", () => {
+	it("renders an <a> with target=_blank and rel=noreferrer", () => {
+		render(
+			<MeetupRsvpButton
+				href="https://www.meetup.com/example/"
+				label="RSVP on Meetup"
+			/>,
+		);
+		const a = screen.getByRole("link", { name: /RSVP on Meetup/i });
+		expect(a).toHaveAttribute("href", "https://www.meetup.com/example/");
+		expect(a).toHaveAttribute("target", "_blank");
+		expect(a).toHaveAttribute("rel", "noreferrer");
+	});
+
+	it("renders the inline Meetup mark SVG (white M on red circle)", () => {
+		const { container } = render(
+			<MeetupRsvpButton href="#" label="RSVP on Meetup" />,
+		);
+		expect(container.querySelector("svg title")?.textContent).toBe("Meetup");
+	});
+
+	it("applies the meetup variant class for brand styling", () => {
+		const { container } = render(
+			<MeetupRsvpButton href="#" label="RSVP on Meetup" />,
+		);
+		const link = container.querySelector("a");
+		expect(link?.className).toContain("cdn-brand-btn--meetup");
+	});
+
+	it("aria-label includes 'opens in new tab' for screen reader context", () => {
+		render(<MeetupRsvpButton href="#" label="RSVP on Meetup" />);
+		const a = screen.getByRole("link");
+		expect(a.getAttribute("aria-label")).toMatch(/opens in new tab/i);
+	});
+});
+
+describe("SpeakeasyRsvpButton", () => {
+	it("renders an <a> with the supplied internal href (no target=_blank)", () => {
+		render(
+			<SpeakeasyRsvpButton
+				href="/rsvp/index.html"
+				label="RSVP for Speakeasy"
+			/>,
+		);
+		const a = screen.getByRole("link", { name: /RSVP for Speakeasy/i });
+		expect(a).toHaveAttribute("href", "/rsvp/index.html");
+		expect(a).not.toHaveAttribute("target");
+	});
+
+	it("renders the brand star mark SVG", () => {
+		const { container } = render(
+			<SpeakeasyRsvpButton href="#" label="RSVP for Speakeasy" />,
+		);
+		expect(container.querySelector("svg title")?.textContent).toBe(
+			"Cloud Del Norte",
+		);
+	});
+
+	it("applies the speakeasy variant class for brand styling", () => {
+		const { container } = render(
+			<SpeakeasyRsvpButton href="#" label="RSVP for Speakeasy" />,
+		);
+		const link = container.querySelector("a");
+		expect(link?.className).toContain("cdn-brand-btn--speakeasy");
+	});
+});

--- a/src/components/brand-button/meetup-rsvp.tsx
+++ b/src/components/brand-button/meetup-rsvp.tsx
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import "./styles.css";
+
+interface MeetupRsvpButtonProps {
+	href: string;
+	label: string;
+	className?: string;
+}
+
+/**
+ * Meetup-branded RSVP CTA. Renders a styled <a> using Meetup's brand red
+ * (#ED1C40) with a recognizable white "M" mark. The mark is constructed as
+ * an inline SVG (white M strokes inside a filled red circle) — this gives
+ * brand instant-recognition without embedding Meetup's trademarked swarm
+ * logo. Always opens in a new tab with rel="noreferrer".
+ */
+export default function MeetupRsvpButton({
+	href,
+	label,
+	className,
+}: MeetupRsvpButtonProps) {
+	const cls = ["cdn-brand-btn", "cdn-brand-btn--meetup", className]
+		.filter(Boolean)
+		.join(" ");
+	return (
+		<a
+			className={cls}
+			href={href}
+			target="_blank"
+			rel="noreferrer"
+			aria-label={`${label} (opens in new tab)`}
+		>
+			<svg
+				className="cdn-brand-btn__mark"
+				viewBox="0 0 24 24"
+				width="22"
+				height="22"
+				aria-hidden="true"
+				focusable="false"
+			>
+				<title>Meetup</title>
+				<circle cx="12" cy="12" r="11" fill="#FFFFFF" />
+				<path
+					d="M6.5 8 L8.5 16 L12 11 L15.5 16 L17.5 8"
+					stroke="#ED1C40"
+					strokeWidth="2.4"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					fill="none"
+				/>
+			</svg>
+			<span className="cdn-brand-btn__label">{label}</span>
+			<svg
+				className="cdn-brand-btn__external"
+				viewBox="0 0 24 24"
+				width="14"
+				height="14"
+				aria-hidden="true"
+				focusable="false"
+			>
+				<path
+					d="M14 4 L20 4 L20 10 M20 4 L11 13 M9 5 H6 a2 2 0 0 0 -2 2 v11 a2 2 0 0 0 2 2 h11 a2 2 0 0 0 2 -2 v-3"
+					stroke="currentColor"
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					fill="none"
+				/>
+			</svg>
+		</a>
+	);
+}

--- a/src/components/brand-button/speakeasy-rsvp.tsx
+++ b/src/components/brand-button/speakeasy-rsvp.tsx
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import "./styles.css";
+
+interface SpeakeasyRsvpButtonProps {
+	href: string;
+	label: string;
+	className?: string;
+}
+
+/**
+ * On-site RSVP CTA with Cloud Del Norte brand identity. Renders a styled <a>
+ * over a purple→violet gradient with a white 5-point star (the same star mark
+ * carried in the UG glyph + favicon). Internal link, no new tab.
+ */
+export default function SpeakeasyRsvpButton({
+	href,
+	label,
+	className,
+}: SpeakeasyRsvpButtonProps) {
+	const cls = ["cdn-brand-btn", "cdn-brand-btn--speakeasy", className]
+		.filter(Boolean)
+		.join(" ");
+	return (
+		<a className={cls} href={href} aria-label={label}>
+			<svg
+				className="cdn-brand-btn__mark"
+				viewBox="0 0 24 24"
+				width="22"
+				height="22"
+				aria-hidden="true"
+				focusable="false"
+			>
+				<title>Cloud Del Norte</title>
+				<path
+					d="M12 2 L14.6 9.2 L22 9.6 L16.2 14.2 L18.2 21.4 L12 17.3 L5.8 21.4 L7.8 14.2 L2 9.6 L9.4 9.2 Z"
+					fill="#FFFFFF"
+				/>
+			</svg>
+			<span className="cdn-brand-btn__label">{label}</span>
+			<svg
+				className="cdn-brand-btn__chevron"
+				viewBox="0 0 24 24"
+				width="14"
+				height="14"
+				aria-hidden="true"
+				focusable="false"
+			>
+				<path
+					d="M9 6 L15 12 L9 18"
+					stroke="currentColor"
+					strokeWidth="2.4"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					fill="none"
+				/>
+			</svg>
+		</a>
+	);
+}

--- a/src/components/brand-button/styles.css
+++ b/src/components/brand-button/styles.css
@@ -1,0 +1,142 @@
+/* --------------------------------------------------------------------------
+   Branded RSVP buttons — shared base + Meetup / Speakeasy variants.
+   Replaces hideous default Cloudscape blue on the outbound Meetup CTA.
+
+   Base contract:
+   - <a> rendered as an inline-flex pill with mark + label + trailing icon
+   - 44px minimum touch target height
+   - focus-visible ring for keyboard nav
+   - prefers-reduced-motion respected on hover transform
+   -------------------------------------------------------------------------- */
+
+.cdn-brand-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	padding: 10px 18px;
+	min-height: 44px;
+	width: 100%;
+	max-width: 480px;
+	border-radius: 999px;
+	font-family: inherit;
+	font-size: var(--cdn-text-sm, 0.875rem);
+	font-weight: 700;
+	letter-spacing: 0.01em;
+	text-decoration: none;
+	cursor: pointer;
+	border: 0;
+	transition:
+		transform 160ms ease,
+		box-shadow 160ms ease,
+		background 160ms ease;
+	user-select: none;
+}
+
+.cdn-brand-btn:focus-visible {
+	outline: 3px solid var(--cdn-aws-orange, #ff9900);
+	outline-offset: 3px;
+}
+
+.cdn-brand-btn__mark {
+	flex-shrink: 0;
+	display: block;
+}
+
+.cdn-brand-btn__label {
+	flex: 1 1 auto;
+	text-align: center;
+	line-height: 1.2;
+}
+
+.cdn-brand-btn__external,
+.cdn-brand-btn__chevron {
+	flex-shrink: 0;
+	opacity: 0.85;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.cdn-brand-btn {
+		transition: none;
+	}
+	.cdn-brand-btn:hover,
+	.cdn-brand-btn:active {
+		transform: none;
+	}
+}
+
+/* --------------------------------------------------------------------------
+   Variant — Meetup
+   Brand red (#ED1C40), white mark + label, hover darken slightly.
+   -------------------------------------------------------------------------- */
+
+.cdn-brand-btn--meetup {
+	background-color: #ed1c40;
+	color: #ffffff;
+	box-shadow: 0 2px 6px rgba(237, 28, 64, 0.25);
+}
+
+.cdn-brand-btn--meetup:hover,
+.cdn-brand-btn--meetup:focus-visible {
+	background-color: #d11636;
+	box-shadow: 0 6px 16px rgba(237, 28, 64, 0.35);
+	transform: translateY(-1px);
+}
+
+.cdn-brand-btn--meetup:active {
+	background-color: #b91230;
+	transform: translateY(0);
+	box-shadow: 0 1px 3px rgba(237, 28, 64, 0.35);
+}
+
+.awsui-dark-mode .cdn-brand-btn--meetup {
+	box-shadow: 0 2px 8px rgba(237, 28, 64, 0.4);
+}
+
+/* --------------------------------------------------------------------------
+   Variant — Speakeasy (on-site Cloud Del Norte RSVP)
+   Brand purple→violet gradient, white star mark, AWS-orange focus ring.
+   -------------------------------------------------------------------------- */
+
+.cdn-brand-btn--speakeasy {
+	background: linear-gradient(
+		135deg,
+		var(--cdn-purple, #5a1f8a) 0%,
+		var(--cdn-violet, #9060f0) 100%
+	);
+	color: #faf7f0;
+	box-shadow:
+		0 0 0 2px rgba(255, 153, 0, 0.4),
+		0 4px 14px rgba(90, 31, 138, 0.3);
+}
+
+.cdn-brand-btn--speakeasy:hover,
+.cdn-brand-btn--speakeasy:focus-visible {
+	background: linear-gradient(135deg, #491678 0%, #7e4ee4 100%);
+	box-shadow:
+		0 0 0 2px rgba(255, 153, 0, 0.7),
+		0 8px 20px rgba(90, 31, 138, 0.45);
+	transform: translateY(-1px);
+}
+
+.cdn-brand-btn--speakeasy:active {
+	transform: translateY(0);
+	box-shadow:
+		0 0 0 2px rgba(255, 153, 0, 0.55),
+		0 2px 6px rgba(90, 31, 138, 0.35);
+}
+
+.awsui-dark-mode .cdn-brand-btn--speakeasy {
+	box-shadow:
+		0 0 0 2px rgba(255, 153, 0, 0.55),
+		0 4px 18px rgba(144, 96, 240, 0.45);
+}
+
+/* Stack adjustment — when two brand buttons sit in a vertical SpaceBetween
+   they should breathe slightly more than the default 4px gap. */
+.cdn-brand-btn-stack {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	align-items: stretch;
+}

--- a/src/pages/feed/components/featured-event.tsx
+++ b/src/pages/feed/components/featured-event.tsx
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: MIT-0
 
 import Box from "@cloudscape-design/components/box";
-import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useEffect, useState } from "react";
+import MeetupRsvpButton from "../../../components/brand-button/meetup-rsvp";
+import SpeakeasyRsvpButton from "../../../components/brand-button/speakeasy-rsvp";
 import { useTranslation } from "../../../hooks/useTranslation";
 import { getEvent, spotsRemaining } from "../../../lib/rsvp";
 
@@ -102,20 +103,16 @@ export default function FeaturedEvent() {
 							{spotsCopy}
 						</Box>
 					)}
-					<SpaceBetween size="xs" direction="vertical">
-						<Button variant="primary" href={RSVP_PAGE_URL}>
-							{t("feedPage.featuredEventRsvpPrimary")}
-						</Button>
-						<Button
-							variant="normal"
+					<div className="cdn-brand-btn-stack">
+						<SpeakeasyRsvpButton
+							href={RSVP_PAGE_URL}
+							label={t("feedPage.featuredEventRsvpPrimary")}
+						/>
+						<MeetupRsvpButton
 							href={meetupUrl}
-							target="_blank"
-							iconAlign="right"
-							iconName="external"
-						>
-							{t("feedPage.featuredEventRsvpMeetup")}
-						</Button>
-					</SpaceBetween>
+							label={t("feedPage.featuredEventRsvpMeetup")}
+						/>
+					</div>
 				</SpaceBetween>
 			</Container>
 		</div>

--- a/src/pages/feed/components/upcoming-virtual-event.tsx
+++ b/src/pages/feed/components/upcoming-virtual-event.tsx
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: MIT-0
 
 import Box from "@cloudscape-design/components/box";
-import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
+import MeetupRsvpButton from "../../../components/brand-button/meetup-rsvp";
 import { useTranslation } from "../../../hooks/useTranslation";
 
 const RSVP_URL =
@@ -97,15 +97,12 @@ export default function UpcomingVirtualEvent() {
 							</p>
 						</div>
 					</div>
-					<Button
-						variant="primary"
-						href={RSVP_URL}
-						target="_blank"
-						iconAlign="right"
-						iconName="external"
-					>
-						{t("feedPage.upcomingVirtualEventRsvp")}
-					</Button>
+					<div className="cdn-brand-btn-stack">
+						<MeetupRsvpButton
+							href={RSVP_URL}
+							label={t("feedPage.upcomingVirtualEventRsvp")}
+						/>
+					</div>
 				</SpaceBetween>
 			</Container>
 		</div>


### PR DESCRIPTION
## what changes

The RSVP-on-Meetup button on the featured event card and the AWS Global Community Gatherings card was rendering as default Cloudscape blue — off-brand and unsuited for an outbound CTA to Meetup. This PR introduces a small reusable brand-button family.

### new component family — `src/components/brand-button/`

- `meetup-rsvp.tsx` — red brand pill at `#ED1C40`, inline SVG mark (white-M strokes inside white circle on red field), external-link arrow on right, opens in new tab with `rel=noreferrer`. Aria-label appends 'opens in new tab' for screen reader context.
- `speakeasy-rsvp.tsx` — brand purple→violet gradient pill, white star mark (matches the UG glyph + favicon), chevron on right, internal href.
- `styles.css` — 44px minimum touch target, focus-visible amber ring at 3px offset, hover lift+shadow, `prefers-reduced-motion` respected, full light + dark mode parity.

### consumed by

- `featured-event.tsx` — primary Speakeasy + secondary Meetup, in a vertical `.cdn-brand-btn-stack`.
- `upcoming-virtual-event.tsx` — single Meetup CTA replaces the previous `<Button variant=\"primary\">`.

## tests

- 7 new vitest cases on brand-button family covering href / target / rel / svg mark title / aria-label / variant class
- existing featured-event + upcoming-virtual-event tests still pass since branded buttons render `<a role=link>` with matching accessible names

## gates
- biome ci: 0 errors / 447 warnings (baseline)
- npm run build: PASS
- vitest: 562 / 562 PASS (was 555)