### PR TITLE
i18n(es-MX): norteño sweep on RSVP + featured event strings

### DIFF
--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -142,9 +142,9 @@
 		"upcomingVirtualEventFeaturedTalkSpeaker": "El organizador de AWSUG Cloud Del Norte, Bryan Chasko",
 		"upcomingVirtualEventFeaturedTalkTitle": "Una historia de migración: después de 240 meses consecutivos, evité un cargo de Microsoft",
 		"upcomingVirtualEventUgMarkLabel": "Marca AWS User Group",
-		"featuredEventInPersonLabel": "Junio de 2026 en persona: centro de El Paso, Texas",
-		"featuredEventSpotsRemaining": "{count} de {capacity} cupos disponibles",
-		"featuredEventRsvpPrimary": "RSVP y regístrate para el acceso speakeasy de CloudDelNorte.org",
+		"featuredEventInPersonLabel": "Junio 2026 presencial: centro de El Paso, Texas",
+		"featuredEventSpotsRemaining": "Quedan {count} de {capacity} cupos",
+		"featuredEventRsvpPrimary": "RSVP y regístrate al speakeasy de CloudDelNorte.org",
 		"featuredEventRsvpMeetup": "RSVP en Meetup"
 	},
 	"dashboardPage": {
@@ -269,7 +269,7 @@
 			"cancel": "Cancelar"
 		},
 		"myTicketsHeader": "Tus boletos",
-		"myTicketsEmpty": "Aún no has confirmado asistencia a eventos presenciales de Cloud Del Norte.",
+		"myTicketsEmpty": "Todavía no has hecho RSVP a ningún evento presencial de Cloud Del Norte.",
 		"myTicketsShowAtDoor": "Muestra este código en la puerta"
 	},
 	"createMeeting": {
@@ -971,14 +971,14 @@
 		"breadcrumb": "RSVP",
 		"pageTitle": "RSVP — Cloud Del Norte",
 		"header": "RSVP para evento presencial",
-		"subheader": "Limitado a las primeras 50 personas. Guarda tu código QR — muéstralo en la puerta para entrar.",
+		"subheader": "Solo las primeras 50 personas. Guarda tu código QR — muéstralo en la puerta.",
 		"checkingAuth": "Verificando tu sesión...",
-		"eventNotFound": "Evento no encontrado",
-		"eventNotFoundDesc": "Esta página de RSVP ya no está activa. Consulta los próximos eventos en la página de reuniones.",
+		"eventNotFound": "No encontramos el evento",
+		"eventNotFoundDesc": "Esta página de RSVP ya no está activa. Checa los próximos eventos en la página de reuniones.",
 		"soldOutHeader": "Este evento está lleno",
-		"soldOutBody": "Los 50 cupos presenciales están tomados. Revisa el feed para el próximo evento presencial, o únete a la reunión global virtual enlazada abajo.",
+		"soldOutBody": "Ya se llenaron los 50 cupos presenciales. Checa el feed para el próximo evento presencial, o únete a la reunión global virtual de abajo.",
 		"ticketHeader": "Estás en la lista",
-		"ticketSubheader": "Muestra este código QR en la puerta para entrar. Puedes volver a verlo en cualquier momento desde la página de reuniones.",
+		"ticketSubheader": "Muestra este código QR en la puerta. Puedes volverlo a ver cuando quieras desde la página de reuniones.",
 		"ticketEvent": "Evento",
 		"ticketDate": "Fecha",
 		"ticketLocation": "Ubicación",
@@ -987,6 +987,6 @@
 		"viewMyTickets": "Ver mis boletos",
 		"rsvpButton": "Confirmar mi RSVP",
 		"rsvpingNow": "Reservando tu lugar...",
-		"fallbackMeetupCta": "Mejor RSVP en Meetup"
+		"fallbackMeetupCta": "Mejor házlo por Meetup"
 	}
 }


### PR DESCRIPTION
Calibrates 10 recently-added es-MX strings against the established Chihuahua/Juárez voice already present in the file (informal `tú`, `checa`, `presencial`, `builders` loanword, direct cadence). Per LOCALIZATION.md guidance — community voice over corporate Spanish.

## changed strings

| key | before | after | rationale |
|---|---|---|---|
| feedPage.featuredEventInPersonLabel | Junio de 2026 en persona: centro de El Paso, Texas | Junio 2026 presencial: centro de El Paso, Texas | drop `en persona` calque, drop redundant `de` for clipped norteño cadence |
| feedPage.featuredEventSpotsRemaining | {count} de {capacity} cupos disponibles | Quedan {count} de {capacity} cupos | more natural Spanish framing for 'remaining' |
| feedPage.featuredEventRsvpPrimary | RSVP y regístrate para el acceso speakeasy de CloudDelNorte.org | RSVP y regístrate al speakeasy de CloudDelNorte.org | drops stiff `para el acceso` |
| rsvp.subheader | Limitado a las primeras 50 personas. Guarda tu código QR — muéstralo en la puerta para entrar. | Solo las primeras 50 personas. Guarda tu código QR — muéstralo en la puerta. | `solo` over `limitado a` (formal register), drops redundant `para entrar` |
| rsvp.eventNotFound | Evento no encontrado | No encontramos el evento | conversational over UI-system-message tone |
| rsvp.eventNotFoundDesc | ...Consulta los próximos eventos... | ...Checa los próximos eventos... | matches established `checa` usage in file |
| rsvp.soldOutBody | Los 50 cupos presenciales están tomados. Revisa el feed... | Ya se llenaron los 50 cupos presenciales. Checa el feed... | `ya se llenaron` natural spoken norteño, `checa` consistency |
| rsvp.ticketSubheader | ...Puedes volver a verlo en cualquier momento... | ...Puedes volverlo a ver cuando quieras... | norteño word order + casual register |
| rsvp.fallbackMeetupCta | Mejor RSVP en Meetup | Mejor házlo por Meetup | more idiomatic CTA construction |
| meetings.myTicketsEmpty | Aún no has confirmado asistencia a eventos presenciales de Cloud Del Norte. | Todavía no has hecho RSVP a ningún evento presencial de Cloud Del Norte. | parallels en voice ("haven't RSVPed"), more natural Spanish |

## scope

es-MX only. en-US untouched (transactional UI text already reads clearly).

## not changed (deliberately)

- `Reservando tu lugar...` — `apartando` is more local but `reservando` is clearer for state messaging. Functional UI, not voice-bearing.
- `Titular` for ticket holder — `asistente` would be alternative but `titular` is correct and unambiguous for a ticket field.
- `Ubicación` — `lugar` more colloquial but `ubicación` matches Cloudscape patterns elsewhere.
- Field labels `Evento`, `Fecha`, `Código del boleto` — short labels stay neutral.
- Did not introduce `fierro`, `morro`, `que rollo` slang since the established file voice does not use them in similar contexts.

## gates

- biome ci: 0 errors / 447 warnings (baseline)
- npm run build: PASS
- vitest: 562 / 562 PASS
- translation-coverage suite: 7/7 PASS (parity preserved)