### PR TITLE
feat(player): wave 24b — connecting/retrying loading state with spinner inside aria-live region

### DIFF
--- a/src/components/persistent-player/__tests__/connecting-state.test.tsx
+++ b/src/components/persistent-player/__tests__/connecting-state.test.tsx
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { describe, expect, it } from "vitest";
+import en from "../../../locales/en-US.json";
+
+describe("connecting state copy and aria contract (wave 24b)", () => {
+	it("en-US persistentPlayer.connecting key exists and reads 'connecting'", () => {
+		expect(en.persistentPlayer?.connecting).toBe("connecting");
+	});
+
+	it("en-US persistentPlayer.retrying key exists and reads 'retrying'", () => {
+		expect(en.persistentPlayer?.retrying).toBe("retrying");
+	});
+
+	it("en-US persistentPlayer.connectingAria key exists for screen readers", () => {
+		expect(en.persistentPlayer?.connectingAria).toBe("connecting to stream");
+	});
+});

--- a/src/components/persistent-player/index.tsx
+++ b/src/components/persistent-player/index.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
+import Spinner from "@cloudscape-design/components/spinner";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "../../hooks/useTranslation";
@@ -62,6 +63,7 @@ function PersistentPlayerBar({
 	const audioRef = useRef<HTMLAudioElement>(null);
 	const [blocked, setBlocked] = useState(false);
 	const [playing, setPlaying] = useState(false);
+	const [connecting, setConnecting] = useState(false);
 	const [nowPlaying, setNowPlaying] = useState<string | null>(null);
 	const [rssAudioUrl, setRssAudioUrl] = useState<string | null>(null);
 	const [streamHealth, setStreamHealth] = useState<StreamHealth>("ok");
@@ -179,6 +181,7 @@ function PersistentPlayerBar({
 	useEffect(() => {
 		setNowPlaying(null);
 		setStreamHealth("ok");
+		setConnecting(false);
 		retryCountRef.current = 0;
 		hasConnectedRef.current = false;
 		if (errorTimerRef.current !== null) {
@@ -254,6 +257,7 @@ function PersistentPlayerBar({
 			}
 			// don't clear retryTimerRef — let the in-flight retry complete
 			setStreamHealth("ok");
+			setConnecting(false);
 		};
 
 		audio.addEventListener("error", tripError);
@@ -284,6 +288,7 @@ function PersistentPlayerBar({
 			document.body.classList.add("cdn-stream-playing");
 			if (isPodcast) document.body.classList.add("cdn-podcast-playing");
 			setPlaying(true);
+			setConnecting(false);
 			onPlayStateChangeRef.current?.(true);
 		};
 		const onStopEvt = () => {
@@ -422,7 +427,11 @@ function PersistentPlayerBar({
 	const play = useCallback(() => {
 		const audio = audioRef.current;
 		if (!audio) return;
-		audio.play().catch(() => setBlocked(true));
+		setConnecting(true);
+		audio.play().catch(() => {
+			setConnecting(false);
+			setBlocked(true);
+		});
 	}, []);
 
 	const pause = useCallback(() => {
@@ -645,11 +654,22 @@ function PersistentPlayerBar({
 					</span>
 				) : showRetryingUI ? (
 					<span className="cdn-pp__sub" role="status" aria-live="polite">
+						<Spinner size="normal" />
 						<span
 							className="cdn-pp__eyebrow cdn-pp__eyebrow--warn"
 							aria-hidden="true"
 						>
-							{t("persistentPlayer.streamErrorRetrying")}
+							{t("persistentPlayer.retrying")}
+						</span>
+					</span>
+				) : connecting ? (
+					<span className="cdn-pp__sub" role="status" aria-live="polite">
+						<Spinner size="normal" />
+						<span
+							className="cdn-pp__eyebrow cdn-pp__eyebrow--warn"
+							aria-hidden="true"
+						>
+							{t("persistentPlayer.connecting")}
 						</span>
 					</span>
 				) : (
@@ -785,6 +805,7 @@ function PersistentPlayerBar({
 					className="cdn-pp__btn cdn-pp__btn--play"
 					onClick={play}
 					aria-label="play"
+					aria-disabled={connecting ? "true" : undefined}
 				>
 					{isPodcast ? <PodcastPlayIcon /> : <>&#9654;</>}
 				</button>

--- a/src/components/persistent-player/styles.css
+++ b/src/components/persistent-player/styles.css
@@ -953,3 +953,16 @@ body.cdn-stream-playing .cdn-pp__sigil {
 		height: 16px;
 	}
 }
+
+/* Wave 24b — connecting spinner inside cdn-pp__sub */
+.cdn-pp__sub [class*="awsui_spinner"] {
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.cdn-pp__sub [class*="awsui_spinner"] {
+		display: none;
+	}
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -965,7 +965,10 @@
 		"streamErrorRetrying": "stream hiccup — retrying",
 		"streamErrorPersistent": "this station's stream is having a moment — try again or skip to another station",
 		"streamErrorRetryButton": "try again",
-		"streamErrorAdvancing": "station unavailable, advancing..."
+		"streamErrorAdvancing": "station unavailable, advancing...",
+		"connecting": "connecting",
+		"retrying": "retrying",
+		"connectingAria": "connecting to stream"
 	},
 	"rsvp": {
 		"breadcrumb": "RSVP",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -965,7 +965,10 @@
 		"streamErrorRetrying": "se trabó tantito — reintentando",
 		"streamErrorPersistent": "esta estación anda fallando — dale otra vez o pícale a otra estación",
 		"streamErrorRetryButton": "dale otra vez",
-		"streamErrorAdvancing": "estación no disponible, avanzando..."
+		"streamErrorAdvancing": "estación no disponible, avanzando...",
+		"connecting": "conectando",
+		"retrying": "reintentando",
+		"connectingAria": "conectando al stream"
 	},
 	"rsvp": {
 		"breadcrumb": "RSVP",


### PR DESCRIPTION
Second parallel-fleet ship.

## what lands

- New `connecting` boolean state in PersistentPlayerBar.
- Cloudscape `<Spinner>` renders INSIDE the existing `cdn-pp__sub` span (which already carries `role="status" aria-live="polite"`) — per stratia signoff, no sibling live region added.
- Render priority: failed > retrying > connecting > normal.
- Play button: `aria-disabled="true"` during connecting (NOT the disabled attribute — keeps it focusable for screen readers).
- `prefers-reduced-motion`: spinner hidden (visible label still announces state).
- New i18n keys in en-US + es-MX with norteño voice: `persistentPlayer.{connecting, retrying, connectingAria}`.
- 3 new vitest cases on the i18n contract (key existence + literal value).

## edge case handling
`setConnecting(false)` cleared in: `clearError` (recovery path), station-change reset effect, and `onPlay` body-class listener — belt-and-suspenders for the `key={isPodcast ? 'podcast' : 'radio'}` re-mount that flashes the audio element on station-type swap.

## gates
- biome ci: 0 errors (auto-organized imports applied)
- npm run build: PASS for main, auth, awsug
- vitest: 565 / 565 PASS (562 prior + 3 new)

## design doc + signoff
- `docs/wave-24-design.md` section 1
- `docs/wave-24-stratia-signoff.md` (APPROVED WITH CHANGES — concerns resolved: spinner inside existing live region; mapped to existing booleans, no parallel state machine)

## fleet trace
- planned by poltergeist-liora-moodle-ux
- executed by ghost-harald-task-runner in /home/bryanchasko/code/websites/cdn-wave24b worktree
- ran in parallel with wave-24a on disjoint files