### PR TITLE
style(feed): wave 25b — fit AWS gatherings image + add spacing between event cards

### DIFF
--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -455,6 +455,12 @@
 	min-height: 0;
 }
 
+/* wave 25b — extra breathing room between stacked event cards (featured,
+   next-meetup, upcoming-virtual). 14px additional vertical gap. */
+.feed-grid__cell--full + .feed-grid__cell--full {
+	margin-top: 14px;
+}
+
 /* ---------- Builder center deck — 4-card window with rotation
    v0.0.0105 — bryan: "stick to showing 4 at a time with ability to rotate
    through the article cards to see the rest". Window of exactly 4 cards;
@@ -999,9 +1005,15 @@
 	max-width: 600px;
 	height: auto;
 	aspect-ratio: 1200 / 630;
-	object-fit: cover;
+	object-fit: contain;
+	object-position: center;
+	background-color: rgba(0, 0, 0, 0.04);
 	border-radius: var(--cdn-radius-md, 8px);
 	margin: 12px 0;
+}
+
+.awsui-dark-mode .feed-upcoming-virtual-event__image {
+	background-color: rgba(255, 255, 255, 0.04);
 }
 
 /* Theme-driven image swap — show only the variant that matches the active


### PR DESCRIPTION
Two surgical CSS fixes per Bryan: 'aws community gatherings top/bottom of the image is cut off — fit the whole image in frame' + 'as of 0.0.143 need a smidge more spacing between the event cards'.

## fixes

1. `.feed-upcoming-virtual-event__image`: `object-fit: cover` → `contain` + neutral letterbox backplate (`rgba(0,0,0,0.04)` light / `rgba(255,255,255,0.04)` dark). Source image is 1200×630; aspect-ratio match means contain renders identically when math works, with graceful fallback when responsive width drift makes the math 0.5px off.
2. `.feed-grid__cell--full + .feed-grid__cell--full { margin-top: 14px; }` — adjacent sibling selector adds 14px vertical gap between consecutive full-width event cards. Pure CSS, no TSX touch.

## gates
- biome ci: 0 errors / 447 warnings
- npm run build: PASS
- vitest: 565 / 565 PASS

## fleet trace
- ghost-liora-css-repair authored CSS edits, dispatcher closed out gates + commit + push (css-repair ghost has no shell access)
- ran in parallel with wave-25a and wave-25c in /home/bryanchasko/code/websites/cdn-wave25b worktree