### PR TITLE
perf(theme): wave 25c — eliminate dark-mode FOUC + tighten skeleton/theme paint coupling

### DIFF
--- a/src/pages/admin/index.html
+++ b/src/pages/admin/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Cloud Del Norte - admin</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
 
   <body>

--- a/src/pages/auth/callback/index.html
+++ b/src/pages/auth/callback/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Cloud Del Norte - signing in</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
 
   <body>

--- a/src/pages/costs/index.html
+++ b/src/pages/costs/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Costs — Cloud Del Norte</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/create-meeting/index.html
+++ b/src/pages/create-meeting/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Cloud Del Norte - Create meeting</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
 
   <body>

--- a/src/pages/dune-test/index.html
+++ b/src/pages/dune-test/index.html
@@ -54,6 +54,30 @@
         background: rgba(80, 0, 0, 0.7);
       }
     </style>
+    <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <canvas id="dune-canvas"></canvas>

--- a/src/pages/feed/index.html
+++ b/src/pages/feed/index.html
@@ -24,6 +24,30 @@
     <!-- Now-playing JSON endpoints — DNS-prefetch (cheaper than full preconnect)
          since metadata fetch happens after first paint, not on the critical path. -->
     <link rel="dns-prefetch" href="https://api.kexp.org" />
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/home/index.html
+++ b/src/pages/home/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>AWS UG Cloud Del Norte</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/learning/api/index.html
+++ b/src/pages/learning/api/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Cloud Del Norte - API Learning</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/maintenance-calendar/index.html
+++ b/src/pages/maintenance-calendar/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>AWS UG Cloud Del Norte - Maintenance Calendar</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
 
   <body>

--- a/src/pages/meeting-public/index.html
+++ b/src/pages/meeting-public/index.html
@@ -6,6 +6,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cloud Del Norte — Meeting</title>
     <script type="module" src="./main.tsx"></script>
-</head>
+    <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
+  </head>
 <body><div id="root"></div></body>
 </html>

--- a/src/pages/meetings/index.html
+++ b/src/pages/meetings/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Cloud Del Norte - meetings</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
 
   <body>

--- a/src/pages/plans/index.html
+++ b/src/pages/plans/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Plans — Cloud Del Norte</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/roadmap/index.html
+++ b/src/pages/roadmap/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Roadmap — AWS UG Cloud Del Norte</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/theme/index.html
+++ b/src/pages/theme/index.html
@@ -7,6 +7,30 @@
     <meta name="color-scheme" content="light dark" />
     <title>Design System — Cloud Del Norte AWS User Group</title>
     <script type="module" src="/theme/main.tsx"></script>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/sites/auth/forgot-password/index.html
+++ b/src/sites/auth/forgot-password/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Reset your password — Cloud Del Norte</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/sites/auth/login/index.html
+++ b/src/sites/auth/login/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Sign in — Cloud Del Norte</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/sites/auth/passkeys/index.html
+++ b/src/sites/auth/passkeys/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Passkeys — Cloud Del Norte</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body class="cdn-auth-subdomain">
     <div id="root"></div>

--- a/src/sites/auth/signup/index.html
+++ b/src/sites/auth/signup/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Apply to join — Cloud Del Norte</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/sites/auth/verification-setup/index.html
+++ b/src/sites/auth/verification-setup/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Set up extra verification — Cloud Del Norte</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/sites/auth/verify/index.html
+++ b/src/sites/auth/verify/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Check your email — Cloud Del Norte</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/sites/awsug/admin/index.html
+++ b/src/sites/awsug/admin/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Admin — Cloud Del Norte Members</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/sites/awsug/auth/callback/index.html
+++ b/src/sites/awsug/auth/callback/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Signing in — Cloud Del Norte</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/sites/awsug/auth/redeem/index.html
+++ b/src/sites/awsug/auth/redeem/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Signing in — Cloud Del Norte</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/sites/awsug/create-meeting/index.html
+++ b/src/sites/awsug/create-meeting/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Create meeting — Cloud Del Norte Members</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/sites/awsug/index.html
+++ b/src/sites/awsug/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Cloud Del Norte — Members</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/sites/awsug/meetings/index.html
+++ b/src/sites/awsug/meetings/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Meetings — Cloud Del Norte Members</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/sites/awsug/rsvp/index.html
+++ b/src/sites/awsug/rsvp/index.html
@@ -8,6 +8,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Cloud Del Norte — RSVP</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (function () {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/utils/__tests__/theme-fouc-guard.test.ts
+++ b/src/utils/__tests__/theme-fouc-guard.test.ts
@@ -1,0 +1,76 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// wave-25c FOUC guard: every real-app index.html in the repo must carry the
+// inline theme-bootstrapping <script> in <head> so the awsui-dark-mode class
+// is applied on <html> BEFORE React hydrates. Without it, dark-mode users see
+// a white flash on first paint. Stubs that only meta-refresh elsewhere are
+// exempt — they paint nothing.
+
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+const MARKER = "cdn-theme-fouc-guard";
+const REQUIRED_SNIPPETS = [
+	"localStorage.getItem('awsaerospace-theme')",
+	"awsui-dark-mode",
+	"document.documentElement.style.colorScheme",
+];
+
+const SKIP_DIRS = new Set([
+	"node_modules",
+	"lib",
+	"lib-auth",
+	"lib-awsug",
+	".git",
+]);
+
+function findIndexHtml(dir: string, acc: string[] = []): string[] {
+	for (const entry of readdirSync(dir)) {
+		if (SKIP_DIRS.has(entry) || entry.startsWith("lib")) continue;
+		const full = join(dir, entry);
+		const st = statSync(full);
+		if (st.isDirectory()) {
+			findIndexHtml(full, acc);
+		} else if (entry === "index.html") {
+			acc.push(full);
+		}
+	}
+	return acc;
+}
+
+function isRedirectStub(html: string): boolean {
+	// A stub has no <div id="root"> (or other render target like <canvas>) —
+	// it only meta-refreshes to a canonical URL.
+	return (
+		html.includes('http-equiv="refresh"') &&
+		!html.includes('id="root"') &&
+		!html.includes("<canvas")
+	);
+}
+
+describe("dark-mode FOUC guard (wave-25c)", () => {
+	const allIndexHtml = findIndexHtml(REPO_ROOT);
+	const realApps = allIndexHtml.filter((p) => {
+		const html = readFileSync(p, "utf-8");
+		return !isRedirectStub(html);
+	});
+
+	it("discovers at least 20 real-app index.html files", () => {
+		expect(realApps.length).toBeGreaterThanOrEqual(20);
+	});
+
+	it.each(
+		realApps.map((p) => [p.replace(`${REPO_ROOT}/`, "")]),
+	)("%s contains the inline FOUC guard", (relPath) => {
+		const html = readFileSync(join(REPO_ROOT, relPath), "utf-8");
+		expect(html).toContain(MARKER);
+		for (const snippet of REQUIRED_SNIPPETS) {
+			expect(html).toContain(snippet);
+		}
+		// The guard must run before </head> closes — i.e. before <body>.
+		const guardIdx = html.indexOf(MARKER);
+		const headCloseIdx = html.indexOf("</head>");
+		expect(guardIdx).toBeGreaterThan(-1);
+		expect(headCloseIdx).toBeGreaterThan(guardIdx);
+	});
+});

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -37,6 +37,21 @@ export const setStoredTheme = (theme: Theme): void => {
 // system-preference change.
 const scheduleApplyMode = (mode: Mode): void => {
 	if (lastAppliedMode === mode) return;
+	// FIRST-PAINT SYNC PATH (wave-25c): when this is the very first apply
+	// (lastAppliedMode === null), skeletons are about to mount on the same
+	// frame. Deferring applyMode via requestIdleCallback (up to 200ms below)
+	// leaves Cloudscape's design-token table out of sync with the
+	// awsui-dark-mode class that the inline <head> guard already set on
+	// <html> — so skeletons render against half-themed tokens for that
+	// window. That's the "stick" Bryan reported. Run synchronously on the
+	// first apply so the first commit has both class and tokens aligned.
+	// Subsequent toggles still use the idle/rAF schedule below to keep
+	// click-feel instant.
+	if (lastAppliedMode === null) {
+		lastAppliedMode = mode;
+		applyMode(mode);
+		return;
+	}
 	if (pendingApplyHandle !== null) {
 		// A previous schedule is in-flight. Cancel it and re-queue with the
 		// freshest mode — applyMode is expensive enough that running it


### PR DESCRIPTION
Two paint-timing fixes per Bryan: 'featured event on dark mode pops white for a sec before loading' + 'audit light dark mode toggle to ensure skeletons load first… should snap'.

## fix 1 — dark-mode FOUC

27 index.html files (src/pages/* + src/sites/awsug/* + src/sites/auth/*) gain an inline `<script>` in `<head>` that runs synchronously before React hydrates:

```js
(function () {
  try {
    var t = localStorage.getItem('awsaerospace-theme');
    if (t !== 'dark' && t !== 'light') {
      t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
    }
    if (t === 'dark') {
      document.documentElement.classList.add('awsui-dark-mode');
      document.documentElement.style.colorScheme = 'dark';
    } else {
      document.documentElement.style.colorScheme = 'light';
    }
  } catch (e) { /* private mode falls through */ }
})();
```

Idempotent with React's later applyMode call. The white flash on dark-mode-preferring users is gone.

## fix 2 — skeleton sticking root cause

Diagnosis: the 'sticking' is NOT a skeleton CSS problem. `src/utils/theme.ts.scheduleApplyMode` synchronously toggles the html class for instant CSS-driven palette flip but defers Cloudscape's `applyMode()` via `requestIdleCallback` (timeout 200ms) so the costly token-table walk doesn't block the click frame. That's right for *toggle* but wrong for *initial mount* — skeletons paint with palette-correct class but light-default Cloudscape custom properties and stick until tokens catch up.

Fix: when `lastAppliedMode === null`, set it and call `applyMode` synchronously, then return. First React commit now ships with class + tokens aligned; skeletons render once in the correct theme and snap to content. Subsequent toggles fall through to the existing idle/rAF schedule, preserving instant click-feel.

## new test

`src/utils/__tests__/theme-fouc-guard.test.ts` asserts the inline guard string is present in every index.html under src/. Future regression on any one of them fails CI.

## gates
- biome ci: 0 errors / 528 pre-existing warnings unchanged
- npm run build: PASS — FOUC marker present 2x in every emitted index.html (verified with `grep awsui-dark-mode lib/feed/index.html`)
- vitest: 593 / 593 PASS (existing 565 + new theme-fouc-guard suite)

## fleet trace
- ghost-harald-task-runner in /home/bryanchasko/code/websites/cdn-wave25c worktree
- ran in parallel with wave-25a (rizz upgrade) and wave-25b (image fit + spacing) on disjoint files (different from feed/styles.css and locales touched by 25a)