### PR TITLE
feat(feed): wave 26a — SVG bulb overlay on dark-mode AWS gatherings card with flicker + hover/click

### DIFF
--- a/src/pages/feed/components/__tests__/event-bulbs-overlay.test.tsx
+++ b/src/pages/feed/components/__tests__/event-bulbs-overlay.test.tsx
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import EventBulbsOverlay from "../event-bulbs-overlay";
+
+describe("EventBulbsOverlay", () => {
+	it("renders an SVG with role=presentation and aria-hidden=true", () => {
+		const { container } = render(<EventBulbsOverlay />);
+		const svg = container.querySelector("svg");
+		expect(svg).not.toBeNull();
+		expect(svg).toHaveAttribute("role", "presentation");
+		expect(svg).toHaveAttribute("aria-hidden", "true");
+	});
+
+	it("renders at least 10 <circle> elements (bulbs)", () => {
+		const { container } = render(<EventBulbsOverlay />);
+		const circles = container.querySelectorAll("circle");
+		expect(circles.length).toBeGreaterThanOrEqual(10);
+	});
+
+	it("toggles .cdn-bulb--twinkling on a <circle> when clicked", () => {
+		const { container } = render(<EventBulbsOverlay />);
+		const circles = container.querySelectorAll("circle");
+		const target = circles[0];
+		expect(target.getAttribute("class") ?? "").not.toContain(
+			"cdn-bulb--twinkling",
+		);
+		fireEvent.click(target);
+		const twinkling = container.querySelector(".cdn-bulb--twinkling");
+		expect(twinkling).not.toBeNull();
+		expect(twinkling).toBe(target);
+	});
+
+	it("each bulb circle has the warm-glow fill", () => {
+		const { container } = render(<EventBulbsOverlay />);
+		const circles = container.querySelectorAll("circle");
+		for (const c of circles) {
+			expect(c.getAttribute("fill")).toBe("#fde68a");
+		}
+	});
+});

--- a/src/pages/feed/components/event-bulbs-overlay.css
+++ b/src/pages/feed/components/event-bulbs-overlay.css
@@ -1,0 +1,108 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+/* SPDX-License-Identifier: MIT-0 */
+
+/* ---------- Bulb overlay (dark-mode AWS Global Community Gatherings card) ---------- */
+/* The overlay <svg> is absolutely positioned over the dark-mode banner image.
+   Each <circle> flickers independently (different delays + durations) so the
+   string reads as live string-lights, not synchronized blinkers. Hover scales
+   + brightens an individual bulb; click triggers a one-shot twinkle burst. */
+
+.cdn-bulbs-overlay {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	pointer-events: none; /* let clicks pass through dead space; circles re-enable below */
+	overflow: visible;
+}
+
+.cdn-bulb {
+	pointer-events: auto;
+	cursor: pointer;
+	transform-origin: center;
+	transform-box: fill-box;
+	opacity: 0.92;
+	filter: drop-shadow(0 0 4px rgba(253, 230, 138, 0.85))
+		drop-shadow(0 0 10px rgba(253, 230, 138, 0.55));
+	animation-name: cdn-bulb-flicker;
+	animation-iteration-count: infinite;
+	animation-timing-function: ease-in-out;
+	animation-direction: alternate;
+	transition:
+		transform 180ms ease-out,
+		filter 180ms ease-out;
+}
+
+@keyframes cdn-bulb-flicker {
+	0% {
+		opacity: 0.85;
+		filter: drop-shadow(0 0 3px rgba(253, 230, 138, 0.7))
+			drop-shadow(0 0 8px rgba(253, 230, 138, 0.4));
+	}
+	50% {
+		opacity: 0.95;
+		filter: drop-shadow(0 0 5px rgba(253, 230, 138, 0.9))
+			drop-shadow(0 0 12px rgba(253, 230, 138, 0.6));
+	}
+	100% {
+		opacity: 1;
+		filter: drop-shadow(0 0 6px rgba(253, 230, 138, 1))
+			drop-shadow(0 0 14px rgba(253, 230, 138, 0.7));
+	}
+}
+
+/* Hover: scale up + brighten + briefly pause flicker so the user knows
+   their hover registered before the bulb returns to its idle cycle. */
+.cdn-bulb:hover {
+	transform: scale(1.15);
+	filter: drop-shadow(0 0 8px rgba(255, 247, 200, 1))
+		drop-shadow(0 0 18px rgba(253, 230, 138, 0.85));
+	animation-play-state: paused;
+}
+
+/* Click twinkle-burst — one-shot, replaces the looping flicker for ~600ms. */
+.cdn-bulb--twinkling {
+	animation-name: cdn-bulb-twinkle-burst;
+	animation-duration: 600ms !important;
+	animation-iteration-count: 1;
+	animation-timing-function: ease-out;
+	animation-direction: normal;
+}
+
+@keyframes cdn-bulb-twinkle-burst {
+	0% {
+		opacity: 1;
+		filter: drop-shadow(0 0 6px rgba(255, 247, 200, 1))
+			drop-shadow(0 0 14px rgba(253, 230, 138, 0.8));
+		transform: scale(1);
+	}
+	35% {
+		opacity: 1;
+		filter: drop-shadow(0 0 14px rgba(255, 255, 240, 1))
+			drop-shadow(0 0 28px rgba(253, 230, 138, 1))
+			drop-shadow(0 0 44px rgba(253, 230, 138, 0.6));
+		transform: scale(1.4);
+	}
+	100% {
+		opacity: 0.92;
+		filter: drop-shadow(0 0 4px rgba(253, 230, 138, 0.85))
+			drop-shadow(0 0 10px rgba(253, 230, 138, 0.55));
+		transform: scale(1);
+	}
+}
+
+/* prefers-reduced-motion: bulbs are static, no flicker, no twinkle, no scale.
+   Still visible (full opacity) so the artwork reads correctly. */
+@media (prefers-reduced-motion: reduce) {
+	.cdn-bulb {
+		animation: none;
+		opacity: 1;
+		transition: none;
+	}
+	.cdn-bulb:hover {
+		transform: none;
+	}
+	.cdn-bulb--twinkling {
+		animation: none;
+	}
+}

--- a/src/pages/feed/components/event-bulbs-overlay.tsx
+++ b/src/pages/feed/components/event-bulbs-overlay.tsx
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { useCallback, useState } from "react";
+import "./event-bulbs-overlay.css";
+
+/**
+ * Bulb position data — coordinates are in the 1200×630 viewBox space of the
+ * AWS Global Community Gatherings banner. The string of bulbs runs along the
+ * upper edge in a gentle curve, with a few accent bulbs around the corners
+ * and AWS Community badge area. Exact positions don't matter — flicker hides
+ * imprecision. `delay` and `duration` stagger animations so bulbs don't sync.
+ * A handful get faster cycles for liveness.
+ */
+type BulbPosition = {
+	cx: number;
+	cy: number;
+	r: number;
+	/** Animation delay in seconds (negative pushes start phase backward). */
+	delay: number;
+	/** Flicker cycle duration in seconds (3–7s, with 2-3 livelier ones). */
+	duration: number;
+};
+
+const BULB_POSITIONS: BulbPosition[] = [
+	// Top-edge curved string, left → right
+	{ cx: 90, cy: 70, r: 8, delay: -0.4, duration: 5.2 },
+	{ cx: 195, cy: 52, r: 7, delay: -1.7, duration: 6.1 },
+	{ cx: 305, cy: 42, r: 9, delay: -2.9, duration: 4.4 },
+	{ cx: 420, cy: 38, r: 7, delay: -0.9, duration: 5.8 },
+	{ cx: 540, cy: 40, r: 8, delay: -3.6, duration: 3.2 }, // livelier
+	{ cx: 660, cy: 44, r: 7, delay: -1.2, duration: 6.7 },
+	{ cx: 780, cy: 50, r: 9, delay: -2.4, duration: 4.0 },
+	{ cx: 900, cy: 58, r: 7, delay: -0.6, duration: 5.5 },
+	{ cx: 1010, cy: 70, r: 8, delay: -2.1, duration: 6.3 },
+	{ cx: 1110, cy: 88, r: 7, delay: -0.3, duration: 3.5 }, // livelier
+	// Side / corner accents
+	{ cx: 60, cy: 180, r: 6, delay: -1.5, duration: 6.9 },
+	{ cx: 1140, cy: 200, r: 6, delay: -2.7, duration: 5.0 },
+	{ cx: 80, cy: 320, r: 7, delay: -0.8, duration: 4.6 },
+	{ cx: 1130, cy: 340, r: 7, delay: -3.1, duration: 3.8 }, // livelier
+];
+
+export default function EventBulbsOverlay() {
+	const [twinklingId, setTwinklingId] = useState<number | null>(null);
+
+	const handleClick = useCallback((id: number) => {
+		setTwinklingId(id);
+		// Match the .cdn-bulb--twinkling animation duration in the CSS (~600ms).
+		window.setTimeout(() => {
+			setTwinklingId((current) => (current === id ? null : current));
+		}, 650);
+	}, []);
+
+	return (
+		<svg
+			className="cdn-bulbs-overlay"
+			viewBox="0 0 1200 630"
+			preserveAspectRatio="xMidYMid meet"
+			aria-hidden="true"
+			role="presentation"
+			focusable="false"
+		>
+			<title>Decorative flickering bulbs</title>
+			<defs>
+				<filter
+					id="cdn-bulb-halo"
+					x="-100%"
+					y="-100%"
+					width="300%"
+					height="300%"
+				>
+					<feGaussianBlur stdDeviation="3" />
+				</filter>
+			</defs>
+			{BULB_POSITIONS.map((bulb, idx) => {
+				const isTwinkling = twinklingId === idx;
+				const className = `cdn-bulb${isTwinkling ? " cdn-bulb--twinkling" : ""}`;
+				return (
+					// biome-ignore lint/a11y/noStaticElementInteractions: decorative SVG inside aria-hidden parent — click is pure visual delight, no functional action
+					<circle
+						// biome-ignore lint/suspicious/noArrayIndexKey: bulb positions are static and stable
+						key={idx}
+						className={className}
+						cx={bulb.cx}
+						cy={bulb.cy}
+						r={bulb.r}
+						fill="#fde68a"
+						style={{
+							animationDelay: `${bulb.delay}s`,
+							animationDuration: `${bulb.duration}s`,
+						}}
+						onMouseEnter={() => {
+							/* hover state is also CSS-driven via :hover; this stub keeps a JS hook available for future per-bulb hover behaviors */
+						}}
+						onClick={() => handleClick(idx)}
+					/>
+				);
+			})}
+		</svg>
+	);
+}

--- a/src/pages/feed/components/upcoming-virtual-event.tsx
+++ b/src/pages/feed/components/upcoming-virtual-event.tsx
@@ -8,6 +8,7 @@ import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import MeetupRsvpButton from "../../../components/brand-button/meetup-rsvp";
 import { useTranslation } from "../../../hooks/useTranslation";
+import EventBulbsOverlay from "./event-bulbs-overlay";
 
 const RSVP_URL =
 	"https://www.meetup.com/awsglobalcommunitygatherings/events/314332142/";
@@ -55,14 +56,17 @@ export default function UpcomingVirtualEvent() {
 						height={630}
 						loading="lazy"
 					/>
-					<img
-						src={EVENT_IMAGE_DARK}
-						alt={t("feedPage.upcomingVirtualEventImageAlt")}
-						className="feed-upcoming-virtual-event__image feed-upcoming-virtual-event__image--dark"
-						width={1200}
-						height={630}
-						loading="lazy"
-					/>
+					<div className="feed-upcoming-virtual-event__bulbs-wrapper">
+						<img
+							src={EVENT_IMAGE_DARK}
+							alt={t("feedPage.upcomingVirtualEventImageAlt")}
+							className="feed-upcoming-virtual-event__image feed-upcoming-virtual-event__image--dark"
+							width={1200}
+							height={630}
+							loading="lazy"
+						/>
+						<EventBulbsOverlay />
+					</div>
 					<Box fontWeight="bold" fontSize="heading-m">
 						<Link href={RSVP_URL} external>
 							{t("feedPage.upcomingVirtualEventTitle")}

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -1377,6 +1377,34 @@
 	display: block;
 }
 
+/* ---------- Bulbs overlay wrapper (dark-mode only) ---------- */
+/* Wraps the dark <img> + decorative <EventBulbsOverlay/> SVG so the SVG can be
+   absolutely positioned over the image only — never over the title link, RSVP
+   button, or other interactive UI below. The wrapper inherits the same width
+   constraints as the image so the SVG's viewBox aligns with the artwork. */
+.feed-upcoming-virtual-event__bulbs-wrapper {
+	position: relative;
+	display: block;
+	width: 100%;
+	max-width: 600px;
+	margin: 12px 0;
+}
+
+/* The wrapped image keeps its own margin/aspect rules — but inside the
+   wrapper, drop the wrapper's outer margin from the image so spacing isn't
+   doubled. */
+.feed-upcoming-virtual-event__bulbs-wrapper
+.feed-upcoming-virtual-event__image--dark {
+	margin: 0;
+}
+
+/* Light mode: hide the entire wrapper (the dark image inside is already
+   hidden by the existing image-swap rule, but hiding the wrapper also
+   removes the SVG overlay so it never paints over the light image). */
+:not(.awsui-dark-mode) .feed-upcoming-virtual-event__bulbs-wrapper {
+	display: none;
+}
+
 /* ---------- Next meetup card — stable height across loading/fallback/loaded ---------- */
 /* Reserve enough height for the loaded state (title + date + location + description)
    so the transition from loading does not shift the page layout. */


### PR DESCRIPTION
Adds a strand of warm patio string-lights as an SVG overlay on the dark-mode AWS Global Community Gatherings banner. 14 bulbs total (10 along upper curve + 4 corner accents) with per-bulb animation phase-shift (3.2–6.9s ease-in-out cycles, 3 faster sub-4s 'lively' bulbs), hover scale 1.15× + brighter shadow, click 600ms twinkle-burst (peak scale 1.4 + 44px halo).

## scope discipline
- Dark mode only (light variant has stars in the artwork, NOT bulbs — overlay must NOT bleed onto light)
- Decorative: aria-hidden + role=presentation, no tabindex
- prefers-reduced-motion: all animation disabled, bulbs static at full opacity
- Existing image-swap test continues to pass; new vitest covers SVG a11y, bulb count ≥10, click→.cdn-bulb--twinkling toggle, warm-fill invariant

## gates
- biome ci: 0 errors
- npm run build: PASS for main, auth, awsug
- vitest: 597 / 597 PASS