### PR TITLE
feat(player): wave 26c — KEXP now-playing album art via api.kexp.org polling

### DIFF
--- a/src/components/persistent-player/__tests__/kexp-album-art.test.ts
+++ b/src/components/persistent-player/__tests__/kexp-album-art.test.ts
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/**
+ * Wave 26c — KEXP album-art guard.
+ *
+ * The persistent-player component renders the KEXP cover-art thumbnail only
+ * when (state.stationKey === "kexp" && kexpArt?.albumArtUrl). This test
+ * exercises the same predicate against representative inputs to lock in the
+ * KEXP-only contract:
+ *   - other stations never trigger the album-art branch
+ *   - kexp without album-art-url renders nothing
+ *   - kexp with album-art-url renders the thumbnail
+ *
+ * We test the predicate directly rather than rendering the full player
+ * (which requires audio + media-session mocking). This mirrors the
+ * auto-advance.test.ts pattern in this directory.
+ */
+
+import { describe, expect, it } from "vitest";
+import en from "../../../locales/en-US.json";
+import esMX from "../../../locales/es-MX.json";
+
+interface KexpArt {
+	song: string;
+	artist: string;
+	albumArtUrl: string | null;
+}
+
+function shouldRenderKexpArt(stationKey: string, art: KexpArt | null): boolean {
+	return stationKey === "kexp" && Boolean(art?.albumArtUrl);
+}
+
+describe("KEXP album-art KEXP-only render guard", () => {
+	const sampleArt: KexpArt = {
+		song: "I Can't Wait",
+		artist: "Nu Shooz",
+		albumArtUrl: "https://archive.example/cover.jpg",
+	};
+
+	it("renders when station=kexp and albumArtUrl is present", () => {
+		expect(shouldRenderKexpArt("kexp", sampleArt)).toBe(true);
+	});
+
+	it("does NOT render when station=kexp but art is null (API failure)", () => {
+		expect(shouldRenderKexpArt("kexp", null)).toBe(false);
+	});
+
+	it("does NOT render when station=kexp but albumArtUrl is null", () => {
+		expect(
+			shouldRenderKexpArt("kexp", { ...sampleArt, albumArtUrl: null }),
+		).toBe(false);
+	});
+
+	it("does NOT render when station=krux (different station)", () => {
+		expect(shouldRenderKexpArt("krux", sampleArt)).toBe(false);
+	});
+
+	it("does NOT render when station=el_sonido_kexp (different station)", () => {
+		// el_sonido_kexp is a separate stream entry — only the canonical
+		// `kexp` key surfaces the album-art block
+		expect(shouldRenderKexpArt("el_sonido_kexp", sampleArt)).toBe(false);
+	});
+
+	it("does NOT render when station is empty / podcast", () => {
+		expect(shouldRenderKexpArt("", sampleArt)).toBe(false);
+		expect(shouldRenderKexpArt("rust_in_production", sampleArt)).toBe(false);
+	});
+});
+
+describe("KEXP now-playing locale strings (Wave 26c)", () => {
+	it("en-US persistentPlayer.kexpNowPlayingFallback exists", () => {
+		expect(en.persistentPlayer?.kexpNowPlayingFallback).toBe(
+			"now playing on KEXP",
+		);
+	});
+
+	it("es-MX persistentPlayer.kexpNowPlayingFallback exists with parity", () => {
+		expect(esMX.persistentPlayer?.kexpNowPlayingFallback).toBe(
+			"sonando en KEXP",
+		);
+	});
+});

--- a/src/components/persistent-player/index.tsx
+++ b/src/components/persistent-player/index.tsx
@@ -5,6 +5,10 @@ import Spinner from "@cloudscape-design/components/spinner";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "../../hooks/useTranslation";
+import {
+	fetchKexpNowPlaying,
+	type KexpNowPlaying,
+} from "../../lib/kexp-now-playing";
 import { setMediaSession } from "../../lib/media-session";
 import {
 	clearPodcastPosition,
@@ -67,6 +71,18 @@ function PersistentPlayerBar({
 	const [nowPlaying, setNowPlaying] = useState<string | null>(null);
 	const [rssAudioUrl, setRssAudioUrl] = useState<string | null>(null);
 	const [streamHealth, setStreamHealth] = useState<StreamHealth>("ok");
+	// KEXP-only album art surface — populated by a parallel poll against
+	// api.kexp.org/v2/plays whenever the active station is `kexp` AND the
+	// audio is actually playing. Cleared on station-change / stop. The shared
+	// fetchMeta path already populates `nowPlaying` with "song — artist", so
+	// this state only holds the artwork URL + a refs-tracked "current track"
+	// signature used to skip stale-data re-renders.
+	const [kexpArt, setKexpArt] = useState<KexpNowPlaying | null>(null);
+	// stable signature of the last KEXP track we accepted — lets the polling
+	// effect short-circuit re-renders when KEXP returns the same row twice
+	// (DJ on a long airbreak after one song, slow rotations). Stored as ref so
+	// it survives across polls without joining the effect dep list.
+	const kexpTrackSigRef = useRef<string | null>(null);
 	// build-time podcast episode cache — populated once from /data/podcast-episodes.json.
 	// used as fallback when live RSS fetch is CORS-blocked in the browser.
 	const episodeCacheRef = useRef<Record<string, string | null> | null>(null);
@@ -419,6 +435,53 @@ function PersistentPlayerBar({
 		};
 	}, [fetchMeta, streamDef]);
 
+	// KEXP-only album art poll — runs in parallel with the shared metadata
+	// poller above (which populates `nowPlaying` from the same /v2/plays
+	// endpoint). We keep the two pollers separate because:
+	//   - the shared poller sits in streams.ts territory (parseMeta returns a
+	//     plain string, not artwork) and that file is owned by another wave
+	//   - this poller only runs while KEXP is the active station AND audio is
+	//     actually playing, so it disappears the moment the user stops or
+	//     skips to a different station
+	// Stale-data guard: if the API returns the same song/artist signature on
+	// the next poll, we skip the setState call so React does not re-render
+	// the <img> (which would otherwise re-trigger the lazy-load decode).
+	useEffect(() => {
+		if (state.stationKey !== "kexp" || !playing) {
+			// any non-KEXP station OR paused state immediately drops the album
+			// art surface — listener should never see a stale Nu Shooz cover
+			// while listening to KRUX
+			setKexpArt(null);
+			kexpTrackSigRef.current = null;
+			return;
+		}
+		let cancelled = false;
+		const poll = async () => {
+			const result = await fetchKexpNowPlaying();
+			if (cancelled) return;
+			if (!result) {
+				// API failure / airbreak — silently drop the album art block;
+				// the existing player UI continues to display the station label
+				// + (when present) the song-string from the shared poller
+				if (kexpTrackSigRef.current !== null) {
+					kexpTrackSigRef.current = null;
+					setKexpArt(null);
+				}
+				return;
+			}
+			const sig = `${result.song}::${result.artist}::${result.albumArtUrl ?? ""}`;
+			if (sig === kexpTrackSigRef.current) return; // unchanged — skip re-render
+			kexpTrackSigRef.current = sig;
+			setKexpArt(result);
+		};
+		poll();
+		const id = window.setInterval(poll, POLL_MS);
+		return () => {
+			cancelled = true;
+			window.clearInterval(id);
+		};
+	}, [state.stationKey, playing]);
+
 	const resume = useCallback(() => {
 		audioRef.current?.play().catch(() => {});
 		setBlocked(false);
@@ -623,6 +686,28 @@ function PersistentPlayerBar({
 					})()}
 				</span>
 			</div>
+			{/* KEXP-only album art — small thumbnail to the LEFT of the meta
+			    column. Renders only when station=kexp + we have an image URL.
+			    The aria-live wrapper announces track changes for screen
+			    readers; alt text on the inner <img> carries the
+			    "song — artist" line for sighted users. */}
+			{state.stationKey === "kexp" && kexpArt?.albumArtUrl ? (
+				<span className="cdn-pp__kexp-art-wrap" aria-live="polite">
+					<img
+						className="cdn-pp__kexp-art"
+						src={kexpArt.albumArtUrl}
+						alt={
+							kexpArt.song && kexpArt.artist
+								? `${kexpArt.song} by ${kexpArt.artist}`
+								: t("persistentPlayer.kexpNowPlayingFallback")
+						}
+						loading="lazy"
+						decoding="async"
+						width={40}
+						height={40}
+					/>
+				</span>
+			) : null}
 			<span className="cdn-pp__meta">
 				{streamDef?.donateUrl ? (
 					<a

--- a/src/components/persistent-player/styles.css
+++ b/src/components/persistent-player/styles.css
@@ -752,6 +752,66 @@ body.cdn-podcast-playing .cdn-pp__btn--resume {
 	opacity: 0.9;
 }
 
+/* KEXP now-playing album art (Wave 26c).
+   Renders ONLY when state.stationKey === "kexp" AND the API returned a
+   non-empty image_uri. The wrapper is the aria-live announcer; the inner
+   <img> is lazy-decoded so the cover-art-archive 500px PNG never blocks
+   first paint of the player itself.
+   Sits between the skip-wrap and the right-aligned meta column — visually
+   the cover-art is the "left anchor" of the now-playing pair. */
+.cdn-pp__kexp-art-wrap {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	width: 40px;
+	height: 40px;
+	border-radius: var(--cdn-radius-sm, 4px);
+	overflow: hidden;
+	/* faint station-tinted ring so the thumbnail reads as part of the player
+	   palette in both modes. KEXP buttercup in light, amber-darkened in
+	   dark — the ring uses --station-primary-mode which is already mode-
+	   aware via the .cdn-pp custom-property cascade above. */
+	box-shadow: 0 0 0 1px
+		color-mix(
+			in srgb,
+			var(--station-primary-mode, var(--cdn-violet, #9060f0)) 40%,
+			transparent
+		);
+}
+
+.cdn-pp__kexp-art {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+	border-radius: inherit;
+	/* slight desaturation in light mode so the thumbnail does not fight the
+	   cream parchment palette; full saturation in dark mode where the navy
+	   bg can carry vivid cover art */
+	filter: saturate(0.95);
+}
+
+.awsui-dark-mode .cdn-pp__kexp-art {
+	filter: saturate(1);
+}
+
+@media (max-width: 600px) {
+	/* shrink slightly on phones — meta column needs every pixel */
+	.cdn-pp__kexp-art-wrap {
+		width: 32px;
+		height: 32px;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.cdn-pp__kexp-art {
+		/* nothing animated here today, but lock the hook so any future
+		   transition added to this element honors the user setting */
+		transition: none;
+	}
+}
+
 @media (prefers-reduced-motion: reduce) {
 	.cdn-pp__btn--stop {
 		animation: none;

--- a/src/lib/__tests__/kexp-now-playing.test.ts
+++ b/src/lib/__tests__/kexp-now-playing.test.ts
@@ -1,0 +1,162 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchKexpNowPlaying } from "../kexp-now-playing";
+
+function fakeResponse(
+	status: number,
+	body?: unknown,
+	throwOnJson = false,
+): Response {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		json: async () => {
+			if (throwOnJson) throw new Error("bad json");
+			return body;
+		},
+	} as unknown as Response;
+}
+
+describe("fetchKexpNowPlaying", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("parses a trackplay row with song + artist + image_uri", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			fakeResponse(200, {
+				results: [
+					{
+						song: "I Can't Wait",
+						artist: "Nu Shooz",
+						play_type: "trackplay",
+						image_uri: "https://archive.example/cover-500.jpg",
+						thumbnail_uri: "https://archive.example/cover-250.jpg",
+					},
+				],
+			}),
+		);
+
+		const result = await fetchKexpNowPlaying(fetchMock);
+		expect(result).toEqual({
+			song: "I Can't Wait",
+			artist: "Nu Shooz",
+			albumArtUrl: "https://archive.example/cover-500.jpg",
+		});
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://api.kexp.org/v2/plays/?limit=1&format=json",
+		);
+	});
+
+	it("falls back to thumbnail_uri when image_uri is missing", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			fakeResponse(200, {
+				results: [
+					{
+						song: "Track",
+						artist: "Artist",
+						play_type: "trackplay",
+						thumbnail_uri: "https://archive.example/thumb.jpg",
+					},
+				],
+			}),
+		);
+
+		const result = await fetchKexpNowPlaying(fetchMock);
+		expect(result?.albumArtUrl).toBe("https://archive.example/thumb.jpg");
+	});
+
+	it("returns null albumArtUrl when image_uri is an empty string and no thumbnail", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			fakeResponse(200, {
+				results: [
+					{
+						song: "Untitled Demo",
+						artist: "Local Artist",
+						play_type: "trackplay",
+						image_uri: "",
+					},
+				],
+			}),
+		);
+
+		const result = await fetchKexpNowPlaying(fetchMock);
+		expect(result).toEqual({
+			song: "Untitled Demo",
+			artist: "Local Artist",
+			albumArtUrl: null,
+		});
+	});
+
+	it("treats missing play_type as a trackplay (back-compat)", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			fakeResponse(200, {
+				results: [
+					{
+						song: "S",
+						artist: "A",
+						image_uri: "https://example/i.jpg",
+					},
+				],
+			}),
+		);
+
+		const result = await fetchKexpNowPlaying(fetchMock);
+		expect(result).not.toBeNull();
+		expect(result?.song).toBe("S");
+	});
+
+	it("returns null on airbreak (non-trackplay) rows", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			fakeResponse(200, {
+				results: [
+					{
+						play_type: "airbreak",
+					},
+				],
+			}),
+		);
+
+		expect(await fetchKexpNowPlaying(fetchMock)).toBeNull();
+	});
+
+	it("returns null when results array is empty", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(fakeResponse(200, { results: [] }));
+		expect(await fetchKexpNowPlaying(fetchMock)).toBeNull();
+	});
+
+	it("returns null when both song and artist are missing", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			fakeResponse(200, {
+				results: [{ play_type: "trackplay" }],
+			}),
+		);
+		expect(await fetchKexpNowPlaying(fetchMock)).toBeNull();
+	});
+
+	it("returns null on non-2xx response", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(fakeResponse(503));
+		expect(await fetchKexpNowPlaying(fetchMock)).toBeNull();
+	});
+
+	it("returns null on network error", async () => {
+		const fetchMock = vi.fn().mockRejectedValue(new Error("offline"));
+		expect(await fetchKexpNowPlaying(fetchMock)).toBeNull();
+	});
+
+	it("returns null on malformed JSON", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(fakeResponse(200, undefined, true));
+		expect(await fetchKexpNowPlaying(fetchMock)).toBeNull();
+	});
+
+	it("returns null on null body", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(fakeResponse(200, null));
+		expect(await fetchKexpNowPlaying(fetchMock)).toBeNull();
+	});
+});

--- a/src/lib/kexp-now-playing.ts
+++ b/src/lib/kexp-now-playing.ts
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/**
+ * KEXP now-playing fetcher — surfaces the current song / artist / album-art
+ * URL from api.kexp.org/v2/plays so the persistent player can render a small
+ * cover-art thumbnail when the listener is tuned to the KEXP stream.
+ *
+ * Background:
+ *   - api.kexp.org is already in our CSP connect-src, so the fetch lands in
+ *     the browser without proxying.
+ *   - /v2/plays/?limit=1 returns an array of "play" rows. Each row has a
+ *     `play_type` enum — "trackplay" carries song metadata; "airbreak" /
+ *     "nontrackplay" rows are DJ talk segments and have no song / image.
+ *   - `image_uri` is a 500px cover-art-archive thumbnail when MusicBrainz has
+ *     a release match for the track. It can be an empty string when the
+ *     track is unmatched (DJs spinning unreleased / very obscure cuts) — we
+ *     normalize that to null so callers can short-circuit the <img> render.
+ *
+ * Contract:
+ *   - Returns { song, artist, albumArtUrl } on a fresh trackplay row
+ *   - Returns null on:
+ *       - network error
+ *       - non-2xx response
+ *       - malformed / empty JSON
+ *       - non-trackplay rows (airbreak, nontrackplay) — caller treats this
+ *         the same as "no current track" and drops the album art UI
+ *
+ *   albumArtUrl is null when image_uri is missing or empty so the UI can
+ *   distinguish "no image yet" from "no track playing".
+ *
+ * The fetch function is parameterized to keep tests deterministic — pass a
+ * mock through the optional second argument.
+ */
+
+const KEXP_PLAYS_ENDPOINT =
+	"https://api.kexp.org/v2/plays/?limit=1&format=json";
+
+export interface KexpNowPlaying {
+	readonly song: string;
+	readonly artist: string;
+	readonly albumArtUrl: string | null;
+}
+
+interface KexpPlayRow {
+	readonly artist?: string;
+	readonly song?: string;
+	readonly play_type?: string;
+	readonly image_uri?: string;
+	readonly thumbnail_uri?: string;
+}
+
+interface KexpPlaysResponse {
+	readonly results?: ReadonlyArray<KexpPlayRow>;
+}
+
+export async function fetchKexpNowPlaying(
+	fetchImpl: typeof fetch = fetch,
+): Promise<KexpNowPlaying | null> {
+	try {
+		const res = await fetchImpl(KEXP_PLAYS_ENDPOINT);
+		if (!res.ok) return null;
+		const data = (await res.json()) as KexpPlaysResponse | null;
+		const play = data?.results?.[0];
+		if (!play) return null;
+		// non-trackplay rows (airbreak, nontrackplay) have no song / image —
+		// caller drops the now-playing block entirely
+		if (play.play_type && play.play_type !== "trackplay") return null;
+		const song = typeof play.song === "string" ? play.song : "";
+		const artist = typeof play.artist === "string" ? play.artist : "";
+		if (!song && !artist) return null;
+		// image_uri is a non-empty string when MusicBrainz had a release match;
+		// fall back to thumbnail_uri (250px) for parity, then null when neither
+		// is populated so the UI can hide the <img> cleanly
+		const rawArt =
+			(typeof play.image_uri === "string" && play.image_uri.length > 0
+				? play.image_uri
+				: null) ??
+			(typeof play.thumbnail_uri === "string" && play.thumbnail_uri.length > 0
+				? play.thumbnail_uri
+				: null);
+		return {
+			song,
+			artist,
+			albumArtUrl: rawArt,
+		};
+	} catch {
+		// network error / malformed JSON — silent; caller drops the UI
+		return null;
+	}
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -968,7 +968,8 @@
 		"streamErrorAdvancing": "station unavailable, advancing...",
 		"connecting": "connecting",
 		"retrying": "retrying",
-		"connectingAria": "connecting to stream"
+		"connectingAria": "connecting to stream",
+		"kexpNowPlayingFallback": "now playing on KEXP"
 	},
 	"rsvp": {
 		"breadcrumb": "RSVP",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -968,7 +968,8 @@
 		"streamErrorAdvancing": "estación no disponible, avanzando...",
 		"connecting": "conectando",
 		"retrying": "reintentando",
-		"connectingAria": "conectando al stream"
+		"connectingAria": "conectando al stream",
+		"kexpNowPlayingFallback": "sonando en KEXP"
 	},
 	"rsvp": {
 		"breadcrumb": "RSVP",


### PR DESCRIPTION
Delivers on Bryan's standing request — KEXP album art finally lands.

## what ships
- New `src/lib/kexp-now-playing.ts` — fetches GET https://api.kexp.org/v2/plays/?limit=1&format=json, returns {song, artist, albumArtUrl} or null. Handles airbreak / empty / 503 / network error / malformed JSON / null body / thumbnail fallback.
- 30-second polling in PersistentPlayerBar, ONLY when stationKey === 'kexp' AND state is playing. Cleared on station change, pause, unmount.
- 40×40 album-art thumbnail rendered as a left anchor inside .cdn-pp section (32×32 on ≤600px). Light + dark parity. Faint station-tinted ring.
- Alt text `${song} by ${artist}`, lazy/async decode, aria-live='polite' on the wrapper.
- New i18n key persistentPlayer.kexpNowPlayingFallback (en: 'now playing on KEXP', es: 'sonando en KEXP').

## tests (19 new)
- 11 cases on kexp-now-playing.ts (all error paths)
- 8 cases on KEXP-only render predicate (krux/el_sonido_kexp/empty/podcast all correctly gated off)

## gates
- biome ci: 0 errors
- npm run build: PASS
- vitest: 612 / 612 PASS

api.kexp.org already in CSP connect-src, no infra touch needed.