### PR TITLE
feat(feed): wave 27a — featured event v2 (community happy hour copy, date vfx, ascii smirk, kill red, button overflow fix, fiona-credits-par dimensionality)

### DIFF
--- a/src/components/brand-button/meetup-rsvp.tsx
+++ b/src/components/brand-button/meetup-rsvp.tsx
@@ -3,27 +3,48 @@
 
 import "./styles.css";
 
+export type MeetupRsvpVariant = "red" | "violet";
+
 interface MeetupRsvpButtonProps {
 	href: string;
 	label: string;
 	className?: string;
+	/**
+	 * Visual variant. Defaults to `"red"` — the Meetup brand red (#ED1C40).
+	 * Pass `"violet"` to render the same M mark + label inside the Cloud
+	 * Del Norte purple→violet gradient (used on the featured-event card
+	 * where the page voice explicitly excludes red).
+	 */
+	variant?: MeetupRsvpVariant;
 }
 
 /**
- * Meetup-branded RSVP CTA. Renders a styled <a> using Meetup's brand red
- * (#ED1C40) with a recognizable white "M" mark. The mark is constructed as
- * an inline SVG (white M strokes inside a filled red circle) — this gives
+ * Meetup-branded RSVP CTA. Renders a styled <a> using either Meetup's brand
+ * red (#ED1C40) — the default — or a brand-violet override. The mark is
+ * constructed as an inline SVG (filled circle + M strokes) so we get
  * brand instant-recognition without embedding Meetup's trademarked swarm
  * logo. Always opens in a new tab with rel="noreferrer".
+ *
+ * Variants:
+ *   - "red"    — default. White circle + Meetup-red M, red gradient bg.
+ *   - "violet" — featured-event override. White circle + cdn-purple M
+ *                stroke, sitting on the brand purple→violet gradient.
+ *                Avoids the page-level "no red" rule on that surface.
  */
 export default function MeetupRsvpButton({
 	href,
 	label,
 	className,
+	variant = "red",
 }: MeetupRsvpButtonProps) {
-	const cls = ["cdn-brand-btn", "cdn-brand-btn--meetup", className]
+	const variantClass =
+		variant === "violet"
+			? "cdn-brand-btn--meetup-violet"
+			: "cdn-brand-btn--meetup";
+	const cls = ["cdn-brand-btn", variantClass, className]
 		.filter(Boolean)
 		.join(" ");
+	const mStrokeColor = variant === "violet" ? "#5a1f8a" : "#ED1C40";
 	return (
 		<a
 			className={cls}
@@ -44,7 +65,7 @@ export default function MeetupRsvpButton({
 				<circle cx="12" cy="12" r="11" fill="#FFFFFF" />
 				<path
 					d="M6.5 8 L8.5 16 L12 11 L15.5 16 L17.5 8"
-					stroke="#ED1C40"
+					stroke={mStrokeColor}
 					strokeWidth="2.4"
 					strokeLinecap="round"
 					strokeLinejoin="round"

--- a/src/components/brand-button/styles.css
+++ b/src/components/brand-button/styles.css
@@ -7,17 +7,26 @@
    - 44px minimum touch target height
    - focus-visible ring for keyboard nav
    - prefers-reduced-motion respected on hover transform
+   - box-sizing: border-box so padding doesn't push past max-width
+   - label clamps to a single line with ellipsis on narrow viewports
    -------------------------------------------------------------------------- */
 
 .cdn-brand-btn {
+	box-sizing: border-box;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 	gap: 10px;
-	padding: 10px 18px;
+	/* slightly tightened horizontal padding so a 320px-wide card has room for
+	   the mark + label + external icon without horizontal overflow. */
+	padding: 10px 14px;
 	min-height: 44px;
 	width: 100%;
 	max-width: 480px;
+	/* min-width: 0 lets the flex item shrink below its content width so the
+	   ellipsis on .cdn-brand-btn__label can engage instead of forcing the
+	   button past its parent. */
+	min-width: 0;
 	border-radius: 999px;
 	font-family: inherit;
 	font-size: var(--cdn-text-sm, 0.875rem);
@@ -31,6 +40,7 @@
 		box-shadow 160ms ease,
 		background 160ms ease;
 	user-select: none;
+	overflow: hidden;
 }
 
 .cdn-brand-btn:focus-visible {
@@ -45,8 +55,12 @@
 
 .cdn-brand-btn__label {
 	flex: 1 1 auto;
+	min-width: 0;
 	text-align: center;
 	line-height: 1.2;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .cdn-brand-btn__external,
@@ -66,8 +80,9 @@
 }
 
 /* --------------------------------------------------------------------------
-   Variant — Meetup
+   Variant — Meetup (default red)
    Brand red (#ED1C40), white mark + label, hover darken slightly.
+   Used on surfaces that are happy with the Meetup brand red.
    -------------------------------------------------------------------------- */
 
 .cdn-brand-btn--meetup {
@@ -91,6 +106,47 @@
 
 .awsui-dark-mode .cdn-brand-btn--meetup {
 	box-shadow: 0 2px 8px rgba(237, 28, 64, 0.4);
+}
+
+/* --------------------------------------------------------------------------
+   Variant — Meetup-violet
+   Same M mark + label, but on the Cloud Del Norte purple→violet gradient.
+   Used on surfaces (e.g. featured-event card) that exclude red entirely.
+   Mirrors the speakeasy gradient palette so the two CTAs read as a stack.
+   -------------------------------------------------------------------------- */
+
+.cdn-brand-btn--meetup-violet {
+	background: linear-gradient(
+		135deg,
+		var(--cdn-purple, #5a1f8a) 0%,
+		var(--cdn-violet, #9060f0) 100%
+	);
+	color: #faf7f0;
+	box-shadow:
+		0 0 0 2px rgba(255, 153, 0, 0.4),
+		0 4px 14px rgba(90, 31, 138, 0.3);
+}
+
+.cdn-brand-btn--meetup-violet:hover,
+.cdn-brand-btn--meetup-violet:focus-visible {
+	background: linear-gradient(135deg, #491678 0%, #7e4ee4 100%);
+	box-shadow:
+		0 0 0 2px rgba(255, 153, 0, 0.7),
+		0 8px 20px rgba(90, 31, 138, 0.45);
+	transform: translateY(-1px);
+}
+
+.cdn-brand-btn--meetup-violet:active {
+	transform: translateY(0);
+	box-shadow:
+		0 0 0 2px rgba(255, 153, 0, 0.55),
+		0 2px 6px rgba(90, 31, 138, 0.35);
+}
+
+.awsui-dark-mode .cdn-brand-btn--meetup-violet {
+	box-shadow:
+		0 0 0 2px rgba(255, 153, 0, 0.55),
+		0 4px 18px rgba(144, 96, 240, 0.45);
 }
 
 /* --------------------------------------------------------------------------
@@ -139,4 +195,9 @@
 	flex-direction: column;
 	gap: 10px;
 	align-items: stretch;
+	/* clamp the stack so buttons never bleed past the card edge regardless
+	   of the parent's content-box; matches the per-button max-width rail. */
+	width: 100%;
+	max-width: 480px;
+	min-width: 0;
 }

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -132,9 +132,9 @@
 		"shortsNowShowing": "Now showing video",
 		"featuredEventHeader": "Featured event",
 		"featuredEventBadge": "DON'T MISS",
-		"featuredEventTitle": "Speakeasy Happy Hour — June Networking Night",
+		"featuredEventTitle": "Community Happy Hour & Networking Night",
 		"featuredEventLocation": "Downtown El Paso, TX — bring tu crew",
-		"featuredEventDescription": "Pull up — tacos, drinks, and builders trading real talk on AWS, careers, and the cloud journey across the borderplex",
+		"featuredEventDescription": "Hop the trolley, grab a Lyft, ride a bike, or pull on up for finger-foods, drinks (including N/A options), and casual chatting about. AWS Builder Center Cards will be available for anyone who is \"game.\"",
 		"featuredEventRsvp": "RSVP on Meetup",
 		"featuredEventImageAlt": "AWS Cloud del Norte UG community event photo",
 		"upcomingVirtualEventHeader": "Upcoming virtual AWS community event",
@@ -150,7 +150,7 @@
 		"upcomingVirtualEventUgMarkLabel": "AWS User Group mark",
 		"featuredEventInPersonLabel": "June 2026 in person: Downtown El Paso, Texas",
 		"featuredEventSpotsRemaining": "{count} of {capacity} spots remaining",
-		"featuredEventRsvpPrimary": "RSVP & sign up for CloudDelNorte.org speakeasy access",
+		"featuredEventRsvpPrimary": "RSVP on CloudDelNorte.org",
 		"featuredEventRsvpMeetup": "RSVP on Meetup"
 	},
 	"dashboardPage": {

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -132,9 +132,9 @@
 		"shortsNowShowing": "ahorita pasando video",
 		"featuredEventHeader": "Evento destacado",
 		"featuredEventBadge": "NO TE LO PIERDAS",
-		"featuredEventTitle": "Happy Hour del Speakeasy — Noche de Networking en Junio",
+		"featuredEventTitle": "Hora Feliz Comunitaria y Noche de Networking",
 		"featuredEventLocation": "Centro de El Paso, TX — tráete a tu raza",
-		"featuredEventDescription": "Cáele — tacos, chelas, y builders echando plática real sobre AWS, carreras, y el camino en la nube por todo el borderplex",
+		"featuredEventDescription": "Cáele en el trolley, píllate un Lyft, en bici, o tráete tu nave para finger-foods, bebidas (incluyendo opciones sin alcohol), y platícale casual sobre. AWS Builder Center Cards van a estar disponibles para cualquiera que esté \"game.\"",
 		"featuredEventRsvp": "Registrarse en Meetup",
 		"featuredEventImageAlt": "Foto del evento comunitario AWS Cloud del Norte UG",
 		"upcomingVirtualEventHeader": "Próximo evento virtual AWS comunidad",
@@ -150,7 +150,7 @@
 		"upcomingVirtualEventUgMarkLabel": "Marca AWS User Group",
 		"featuredEventInPersonLabel": "Junio 2026 presencial: centro de El Paso, Texas",
 		"featuredEventSpotsRemaining": "Quedan {count} de {capacity} cupos",
-		"featuredEventRsvpPrimary": "RSVP y regístrate al speakeasy de CloudDelNorte.org",
+		"featuredEventRsvpPrimary": "RSVP en CloudDelNorte.org",
 		"featuredEventRsvpMeetup": "RSVP en Meetup"
 	},
 	"dashboardPage": {

--- a/src/pages/feed/components/__tests__/ascii-smirk.test.tsx
+++ b/src/pages/feed/components/__tests__/ascii-smirk.test.tsx
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import AsciiSmirk from "../ascii-smirk";
+
+describe("AsciiSmirk", () => {
+	it("renders an inline SVG with role=img and aria-label='smirk'", () => {
+		const { container } = render(<AsciiSmirk />);
+		const svg = container.querySelector("svg");
+		expect(svg).not.toBeNull();
+		expect(svg?.getAttribute("role")).toBe("img");
+		expect(svg?.getAttribute("aria-label")).toBe("smirk");
+	});
+
+	it("renders the wrapper span as aria-hidden so the description carries meaning", () => {
+		const { container } = render(<AsciiSmirk />);
+		const span = container.querySelector("span.cdn-ascii-smirk");
+		expect(span).not.toBeNull();
+		expect(span?.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	it("contains at least one path element (mouth) and at least two rect elements (eyes + brow)", () => {
+		const { container } = render(<AsciiSmirk />);
+		const paths = container.querySelectorAll("path");
+		const rects = container.querySelectorAll("rect");
+		expect(paths.length).toBeGreaterThanOrEqual(1);
+		expect(rects.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("includes a title element labelling the SVG 'smirk' for AT that traverse roles", () => {
+		const { container } = render(<AsciiSmirk />);
+		const title = container.querySelector("svg title");
+		expect(title?.textContent).toBe("smirk");
+	});
+});

--- a/src/pages/feed/components/__tests__/featured-event.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-event.test.tsx
@@ -20,14 +20,10 @@ describe("FeaturedEvent", () => {
 		expect(screen.getByText("DON'T MISS")).toBeInTheDocument();
 	});
 
-	it("renders the event title with link to auth.clouddelnorte.org signup with rsvp return_to", () => {
+	it("renders the v2 event title with link to auth.clouddelnorte.org signup with rsvp return_to", () => {
 		renderWithLocale("us");
-		const link = screen.getByText(
-			"Speakeasy Happy Hour — June Networking Night",
-		);
-		const expected =
-			"https://auth.clouddelnorte.org/signup/index.html?return_to=" +
-			encodeURIComponent("/rsvp/?event=happy-hour-2026-06-03");
+		const link = screen.getByText("Community Happy Hour & Networking Night");
+		const expected = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent("/rsvp/?event=happy-hour-2026-06-03")}`;
 		expect(link.closest("a")).toHaveAttribute("href", expected);
 	});
 
@@ -41,10 +37,19 @@ describe("FeaturedEvent", () => {
 		expect(screen.getAllByText(/junio/i).length).toBeGreaterThan(0);
 	});
 
-	it("renders the RSVP button with target=_blank", () => {
+	it("renders the date inside the date-plate VFX wrapper", () => {
+		const { container } = renderWithLocale("us");
+		const plate = container.querySelector(".feed-featured-event__date-plate");
+		expect(plate).not.toBeNull();
+		expect(plate?.textContent).toMatch(/June 3, 2026/);
+	});
+
+	it("renders the Meetup RSVP button with target=_blank (violet variant — no red)", () => {
 		renderWithLocale("us");
 		const btn = screen.getByRole("link", { name: /RSVP on Meetup/i });
 		expect(btn).toHaveAttribute("target", "_blank");
+		expect(btn.className).toContain("cdn-brand-btn--meetup-violet");
+		expect(btn.className).not.toMatch(/cdn-brand-btn--meetup\b(?!-)/);
 	});
 
 	it("renders the image with proper alt text and lazy loading", () => {
@@ -63,14 +68,12 @@ describe("FeaturedEvent", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders the primary speakeasy RSVP button linking to auth.clouddelnorte.org signup", () => {
+	it("renders the shortened primary speakeasy RSVP button label", () => {
 		renderWithLocale("us");
 		const primary = screen.getByRole("link", {
-			name: /RSVP & sign up for CloudDelNorte\.org speakeasy access/i,
+			name: /RSVP on CloudDelNorte\.org/i,
 		});
-		const expected =
-			"https://auth.clouddelnorte.org/signup/index.html?return_to=" +
-			encodeURIComponent("/rsvp/?event=happy-hour-2026-06-03");
+		const expected = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent("/rsvp/?event=happy-hour-2026-06-03")}`;
 		expect(primary).toHaveAttribute("href", expected);
 	});
 
@@ -78,5 +81,25 @@ describe("FeaturedEvent", () => {
 		localStorage.clear();
 		renderWithLocale("us");
 		expect(screen.getByText(/48 of 50 spots remaining/i)).toBeInTheDocument();
+	});
+
+	it("inlines the AsciiSmirk SVG inside the description (after the 'game.' hook)", () => {
+		const { container } = renderWithLocale("us");
+		const desc = container.querySelector(".feed-featured-event__description");
+		expect(desc).not.toBeNull();
+		const smirk = desc?.querySelector(".cdn-ascii-smirk");
+		expect(smirk).not.toBeNull();
+		const smirkSvg = smirk?.querySelector('svg[aria-label="smirk"]');
+		expect(smirkSvg).not.toBeNull();
+	});
+
+	it("description begins with the new 'Hop the trolley' copy in en-US", () => {
+		renderWithLocale("us");
+		expect(screen.getByText(/Hop the trolley/i)).toBeInTheDocument();
+	});
+
+	it("description begins with the new 'Cáele en el trolley' copy in es-MX", () => {
+		renderWithLocale("mx");
+		expect(screen.getByText(/Cáele en el trolley/i)).toBeInTheDocument();
 	});
 });

--- a/src/pages/feed/components/ascii-smirk.css
+++ b/src/pages/feed/components/ascii-smirk.css
@@ -1,0 +1,150 @@
+/* --------------------------------------------------------------------------
+   AsciiSmirk — inline animated ASCII-style smirk SVG.
+
+   Sits inline next to the "game." quoted hook in the featured-event
+   description. ~16px tall, vertical-align: middle so it hugs the baseline
+   like an emoji. Stroke + fill use currentColor so the parent type token
+   carries the brand-correct hue (deep cdn-purple on light, lavender on
+   dark — scoped under .feed-featured-event*). Backplate drops a small cream
+   (light) / indigo (dark) rounded rect behind the glyph for legibility.
+
+   Animations:
+     - default loop (4.6s): subtle blink on the left eye + tiny smirk widen
+     - intermittent twitch (15s): right eyebrow raises ~1px and settles
+     - hover (no-preference only): both eyes squint, mouth widens a touch,
+       spark ring fades in for ~280ms then settles
+     - prefers-reduced-motion: ALL animations off; static glyph still reads
+   -------------------------------------------------------------------------- */
+
+.cdn-ascii-smirk {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	vertical-align: middle;
+	margin: 0 4px 0 4px;
+	padding: 0 4px;
+	border-radius: 6px;
+	background: rgba(255, 250, 235, 0.55);
+	box-shadow:
+		inset 0 0 0 1px rgba(90, 31, 138, 0.18),
+		0 1px 2px rgba(48, 0, 106, 0.08);
+	color: var(--cdn-purple, #5a1f8a);
+	line-height: 1;
+}
+
+.awsui-dark-mode .cdn-ascii-smirk {
+	background: rgba(48, 0, 106, 0.55);
+	box-shadow:
+		inset 0 0 0 1px rgba(199, 184, 232, 0.22),
+		0 1px 2px rgba(0, 0, 0, 0.4);
+	color: var(--cdn-lavender, #d7c7ee);
+}
+
+.cdn-ascii-smirk__svg {
+	display: block;
+	overflow: visible;
+}
+
+/* ---------- transform-origins so squint + blink scale around their center ---------- */
+.cdn-ascii-smirk__eye--left {
+	transform-origin: 9.5px 8px;
+}
+
+.cdn-ascii-smirk__eye--right {
+	transform-origin: 22.5px 8px;
+}
+
+.cdn-ascii-smirk__brow {
+	transform-origin: 22.5px 4px;
+}
+
+.cdn-ascii-smirk__mouth {
+	transform-origin: 15px 15px;
+	transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.cdn-ascii-smirk__spark {
+	transform-origin: 16px 11px;
+	transition:
+		opacity 220ms ease,
+		transform 280ms ease;
+}
+
+/* ---------- Animations — only when motion is permitted ---------- */
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes cdn-ascii-smirk-blink {
+		0%,
+		88%,
+		100% {
+			transform: scaleY(1);
+		}
+		92% {
+			transform: scaleY(0.08);
+		}
+	}
+
+	@keyframes cdn-ascii-smirk-brow-twitch {
+		0%,
+		94%,
+		100% {
+			transform: translateY(0);
+		}
+		96% {
+			transform: translateY(-1px);
+		}
+		98% {
+			transform: translateY(-0.5px);
+		}
+	}
+
+	@keyframes cdn-ascii-smirk-mouth-widen {
+		0%,
+		88%,
+		100% {
+			transform: scaleX(1);
+		}
+		92% {
+			transform: scaleX(1.05);
+		}
+	}
+
+	.cdn-ascii-smirk__eye--left {
+		animation: cdn-ascii-smirk-blink 4.6s ease-in-out infinite;
+	}
+
+	.cdn-ascii-smirk__brow {
+		animation: cdn-ascii-smirk-brow-twitch 15s ease-in-out infinite;
+	}
+
+	.cdn-ascii-smirk__mouth {
+		animation: cdn-ascii-smirk-mouth-widen 4.6s ease-in-out infinite;
+	}
+
+	/* ---------- Hover flourish ---------- */
+	.cdn-ascii-smirk:hover .cdn-ascii-smirk__eye--left,
+	.cdn-ascii-smirk:hover .cdn-ascii-smirk__eye--right {
+		transform: scaleY(0.45);
+		transition: transform 180ms cubic-bezier(0.4, 0, 0.2, 1);
+	}
+
+	.cdn-ascii-smirk:hover .cdn-ascii-smirk__mouth {
+		transform: scaleX(1.12);
+	}
+
+	.cdn-ascii-smirk:hover .cdn-ascii-smirk__spark {
+		opacity: 0.85;
+		transform: scale(1.15);
+	}
+}
+
+/* ---------- Reduced-motion fallback — strip animation, keep static glyph ---------- */
+@media (prefers-reduced-motion: reduce) {
+	.cdn-ascii-smirk__eye--left,
+	.cdn-ascii-smirk__eye--right,
+	.cdn-ascii-smirk__brow,
+	.cdn-ascii-smirk__mouth,
+	.cdn-ascii-smirk__spark {
+		animation: none;
+		transition: none;
+	}
+}

--- a/src/pages/feed/components/ascii-smirk.tsx
+++ b/src/pages/feed/components/ascii-smirk.tsx
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import "./ascii-smirk.css";
+
+/**
+ * AsciiSmirk — inline animated ASCII-style smirking face SVG.
+ *
+ * Sits inline next to the "game." line in the featured-event description as
+ * a smirk-line hook. Drawn with squarish/blocky stroke geometry to evoke a
+ * retro-terminal `;)` / `^,~` aesthetic. ~18px tall — fits inline like emoji.
+ *
+ * Animations (CSS): default loop (4–6s subtle eye blink + smirk widen),
+ * intermittent micro-twitch (eyebrow raise every 12–18s), and on hover a
+ * squint + spark-glow flourish. All animations respect prefers-reduced-motion
+ * (disabled under reduce). aria-hidden + aria-label='smirk' — decorative;
+ * description text carries meaning.
+ */
+export default function AsciiSmirk() {
+	return (
+		<span className="cdn-ascii-smirk" aria-hidden="true">
+			<svg
+				className="cdn-ascii-smirk__svg"
+				viewBox="0 0 32 22"
+				width="22"
+				height="16"
+				role="img"
+				aria-label="smirk"
+				focusable="false"
+			>
+				<title>smirk</title>
+				{/* spark / glow ring — only visible on hover (CSS) */}
+				<circle
+					className="cdn-ascii-smirk__spark"
+					cx="16"
+					cy="11"
+					r="11"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="0.6"
+					opacity="0"
+				/>
+				{/* left eye — squarish dot, blinks on loop */}
+				<rect
+					className="cdn-ascii-smirk__eye cdn-ascii-smirk__eye--left"
+					x="8"
+					y="6"
+					width="3"
+					height="4"
+					rx="0.5"
+					fill="currentColor"
+				/>
+				{/* right eye — same dot, raised brow above twitches */}
+				<rect
+					className="cdn-ascii-smirk__eye cdn-ascii-smirk__eye--right"
+					x="21"
+					y="6"
+					width="3"
+					height="4"
+					rx="0.5"
+					fill="currentColor"
+				/>
+				{/* right eyebrow — short tick that twitches up periodically */}
+				<rect
+					className="cdn-ascii-smirk__brow"
+					x="20"
+					y="3"
+					width="5"
+					height="1.4"
+					rx="0.5"
+					fill="currentColor"
+				/>
+				{/* asymmetric smirk mouth — flat-then-curl-up on the right side
+				    drawn as a path so we can blocky-step the corner like a
+				    monospace glyph would */}
+				<path
+					className="cdn-ascii-smirk__mouth"
+					d="M 8 16 L 18 16 L 20 14.5 L 22 12.5"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="1.6"
+					strokeLinecap="square"
+					strokeLinejoin="miter"
+				/>
+			</svg>
+		</span>
+	);
+}

--- a/src/pages/feed/components/featured-event.tsx
+++ b/src/pages/feed/components/featured-event.tsx
@@ -6,16 +6,41 @@ import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import { useEffect, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import MeetupRsvpButton from "../../../components/brand-button/meetup-rsvp";
 import SpeakeasyRsvpButton from "../../../components/brand-button/speakeasy-rsvp";
 import { useTranslation } from "../../../hooks/useTranslation";
 import { getEvent, spotsRemaining } from "../../../lib/rsvp";
+import AsciiSmirk from "./ascii-smirk";
 
 const EVENT_ID = "happy-hour-2026-06-03";
 const EVENT_IMAGE = "/events/featured-2026-06-03.webp";
 const RSVP_RETURN_PATH = `/rsvp/?event=${EVENT_ID}`;
 const RSVP_PAGE_URL = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent(RSVP_RETURN_PATH)}`;
+/** Anchor inside the description string after which the inline smirk renders. */
+const SMIRK_ANCHOR = '"game."';
+
+/**
+ * Render the description, splicing the AsciiSmirk SVG in after the
+ * smirk-line hook (`"game."`). If the anchor is absent (defensive fallback
+ * for any future copy revision that drops it), render the raw description.
+ *
+ * Returns a single span wrapper so the parent Cloudscape Box receives one
+ * child (avoids React.Children "missing key" array iteration warnings).
+ */
+function renderDescription(text: string): ReactNode {
+	const idx = text.indexOf(SMIRK_ANCHOR);
+	if (idx < 0) return text;
+	const head = text.slice(0, idx + SMIRK_ANCHOR.length);
+	const tail = text.slice(idx + SMIRK_ANCHOR.length);
+	return (
+		<span className="feed-featured-event__description-inner">
+			{head}
+			<AsciiSmirk />
+			{tail}
+		</span>
+	);
+}
 
 export default function FeaturedEvent() {
 	const { t, locale } = useTranslation();
@@ -83,13 +108,14 @@ export default function FeaturedEvent() {
 					>
 						<Link href={RSVP_PAGE_URL}>{t("feedPage.featuredEventTitle")}</Link>
 					</Box>
-					<Box
-						color="text-body-secondary"
-						fontSize="body-s"
-						className="feed-featured-event__date"
-					>
-						{formattedDate}
-					</Box>
+					{/* Date VFX — pure HTML/Intl output wrapped in a backplate that
+					    carries the tungsten/indigo gradient + shimmer pseudo-element.
+					    Text remains plain (no SVG, no canvas, no string-split). */}
+					<div className="feed-featured-event__date">
+						<span className="feed-featured-event__date-plate">
+							{formattedDate}
+						</span>
+					</div>
 					<Box
 						color="text-body-secondary"
 						fontSize="body-s"
@@ -105,7 +131,7 @@ export default function FeaturedEvent() {
 						fontSize="body-s"
 						className="feed-featured-event__description"
 					>
-						{t("feedPage.featuredEventDescription")}
+						{renderDescription(t("feedPage.featuredEventDescription"))}
 					</Box>
 					{spotsCopy && (
 						<Box
@@ -124,6 +150,7 @@ export default function FeaturedEvent() {
 						<MeetupRsvpButton
 							href={meetupUrl}
 							label={t("feedPage.featuredEventRsvpMeetup")}
+							variant="violet"
 						/>
 					</div>
 				</SpaceBetween>

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -952,17 +952,26 @@
 	}
 }
 
-/* ---------- Featured event card — wave 25a "rizz" upgrade ----------
-   Brings the featured event card up to the fiona end-credits visual standard:
-   stage-light gradient backplate (warm tungsten on light, cool stage-spot
-   violet on dark), multi-layer ambient bloom, animated shimmer sweep on the
-   FEATURED badge, image with twin-bloom rim (purple + AWS gold to echo the
-   Copilot artwork) + micro-tilt easter-egg on hover, marquee-feel typography
-   on title/date, pulsing chip on the spots-remaining counter.
+/* ---------- Featured event card — wave 27a "v2" upgrade ----------
+   Builds on the wave 25a base ("rizz" upgrade) and pushes the card up to
+   the fiona end-credits dimensional standard:
+     - perspective + preserve-3d so child layers can translateZ for parallax
+     - second ::after pseudo carries a slow cool spotlight sweep (7s cycle)
+     - inset 1px stage rim (cream/lavender mode-flipped at 8% alpha)
+     - layered outer shadow stack (existing rizz halos + new ambient bloom)
+     - image gets rotateY(-1.4deg) + translateZ(6px) tilt on hover (CSS 3D)
+     - title link inherits a scrolling-tape shimmer (left→right, 9s)
+     - date renders inside a backplate (tungsten amber light / indigo dark)
+       with a soft pulsing text-shadow glow + diagonal sweep shimmer for
+       extreme legibility. Date string itself stays plain HTML/Intl text.
+     - spots counter pulses (existing) + a faint outer breathing ring.
 
    Local CSS variables scoped to .feed-featured-event keep the wave-23.5 token
    baseline untouched (per hard scope: do NOT mutate src/styles/tokens.css).
-   All motion respects prefers-reduced-motion. Light + dark mode parity. */
+   "dashes of babylon" interpretation: depth via CSS transforms (perspective,
+   preserve-3d, translateZ) + multi-layer shadows + animated gradient sweeps.
+   No babylon runtime is loaded on this surface. All motion respects
+   prefers-reduced-motion. Light + dark mode parity. */
 
 .feed-featured-event {
 	/* light-mode rizz tokens — warm tungsten stage light + brand violet bloom */
@@ -975,12 +984,35 @@
 	--cdn-rizz-image-rim-1: rgba(90, 31, 138, 0.32);
 	--cdn-rizz-image-rim-2: rgba(201, 162, 63, 0.28);
 	--cdn-rizz-spots-glow: rgba(144, 96, 240, 0.4);
+	/* wave-27a v2 depth + sweep tokens — light mode */
+	--cdn-v2-stage-rim: rgba(255, 250, 235, 0.08);
+	--cdn-v2-spot-sweep: rgba(144, 96, 240, 0.18);
+	--cdn-v2-ambient-bloom: rgba(90, 31, 138, 0.14);
+	--cdn-v2-date-plate-from: rgba(201, 162, 63, 0.22);
+	--cdn-v2-date-plate-to: rgba(255, 184, 71, 0.14);
+	--cdn-v2-date-plate-border: rgba(139, 90, 43, 0.42);
+	--cdn-v2-date-text: var(--cdn-purple-deep, #30006a);
+	--cdn-v2-date-glow: rgba(90, 31, 138, 0.38);
+	--cdn-v2-date-shimmer: rgba(255, 250, 235, 0.55);
+	--cdn-v2-title-tape: rgba(255, 250, 235, 0.45);
+	--cdn-v2-spots-ring: rgba(144, 96, 240, 0.22);
 
 	position: relative;
 	isolation: isolate;
 	border-left: 4px solid var(--cdn-violet, #9060f0);
 	border-radius: var(--cdn-radius-md, 8px);
 	overflow: hidden;
+	/* perspective + preserve-3d enable child translateZ() pop without
+	   loading a runtime 3D engine. 1200px = subtle, ambient depth. */
+	perspective: 1200px;
+	transform-style: preserve-3d;
+	/* layered ambient bloom — sits beneath the radial spotlight backplate
+	   (::before) and the cool sweep depth layer (::after). */
+	box-shadow:
+		0 1px 2px rgba(48, 0, 106, 0.08),
+		0 8px 28px -8px var(--cdn-v2-ambient-bloom),
+		0 18px 48px -12px var(--cdn-v2-ambient-bloom),
+		inset 0 0 0 1px var(--cdn-v2-stage-rim);
 }
 
 .awsui-dark-mode .feed-featured-event {
@@ -994,6 +1026,24 @@
 	--cdn-rizz-image-rim-1: rgba(144, 96, 240, 0.42);
 	--cdn-rizz-image-rim-2: rgba(255, 153, 0, 0.22);
 	--cdn-rizz-spots-glow: rgba(199, 184, 232, 0.45);
+	/* wave-27a v2 depth + sweep tokens — dark mode */
+	--cdn-v2-stage-rim: rgba(215, 199, 238, 0.1);
+	--cdn-v2-spot-sweep: rgba(48, 0, 106, 0.42);
+	--cdn-v2-ambient-bloom: rgba(48, 0, 106, 0.32);
+	--cdn-v2-date-plate-from: rgba(48, 0, 106, 0.6);
+	--cdn-v2-date-plate-to: rgba(90, 31, 138, 0.4);
+	--cdn-v2-date-plate-border: rgba(199, 184, 232, 0.42);
+	--cdn-v2-date-text: var(--cdn-lavender, #d7c7ee);
+	--cdn-v2-date-glow: rgba(199, 184, 232, 0.55);
+	--cdn-v2-date-shimmer: rgba(215, 199, 238, 0.4);
+	--cdn-v2-title-tape: rgba(215, 199, 238, 0.42);
+	--cdn-v2-spots-ring: rgba(199, 184, 232, 0.32);
+
+	box-shadow:
+		0 2px 6px rgba(0, 0, 0, 0.5),
+		0 10px 30px -8px var(--cdn-v2-ambient-bloom),
+		0 22px 56px -12px var(--cdn-v2-ambient-bloom),
+		inset 0 0 0 1px var(--cdn-v2-stage-rim);
 }
 
 /* Stage-light gradient backplate — two cross-faded radial spotlights:
@@ -1017,6 +1067,56 @@
 			transparent 65%
 		);
 	opacity: 0.95;
+}
+
+/* v2 depth layer — slow cool spotlight that crosses the card on a 7s ease
+   cycle, paired with a translateZ(0) anchor so the GPU compositor treats
+   this layer separately from the radial backplate (gives the parallax
+   feeling on hover translateZ pop). Keeps z-index:0 like ::before but
+   uses mix-blend-mode: screen to sit additively over the warm radials. */
+.feed-featured-event::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+	background: linear-gradient(
+		115deg,
+		transparent 0%,
+		transparent 30%,
+		var(--cdn-v2-spot-sweep) 50%,
+		transparent 70%,
+		transparent 100%
+	);
+	background-size: 220% 100%;
+	background-position: 120% 0;
+	mix-blend-mode: screen;
+	opacity: 0.55;
+	transform: translateZ(0);
+	transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes feed-featured-spotlight-sweep {
+		0% {
+			background-position: 120% 0;
+		}
+		60%,
+		100% {
+			background-position: -40% 0;
+		}
+	}
+
+	.feed-featured-event::after {
+		animation: feed-featured-spotlight-sweep 7s cubic-bezier(0.4, 0, 0.2, 1)
+			infinite;
+	}
+
+	/* On hover, push the depth layer 8px toward the viewer for a parallax
+	   feeling — only meaningful with perspective on the parent. */
+	.feed-featured-event:hover::after {
+		transform: translateZ(8px);
+	}
 }
 
 /* All direct content children sit above the spotlight backplate. */
@@ -1129,11 +1229,13 @@
 		0 0 0 1px var(--cdn-rizz-image-rim-1);
 }
 
-/* hover micro-tilt easter egg (1.4deg) + intensified bloom. flat fallback
-   in @media (prefers-reduced-motion: reduce) below. */
+/* hover micro-tilt easter egg + intensified bloom. v2 swaps the 2D rotate
+   for a CSS 3D rotateY + translateZ to read as a stamped/floating-above-card
+   pop in concert with the parent perspective. Flat fallback in
+   @media (prefers-reduced-motion: reduce) below. */
 @media (prefers-reduced-motion: no-preference) {
 	.feed-featured-event__image:hover {
-		transform: rotate(-1.4deg) translateY(-2px);
+		transform: rotateY(-1.4deg) translateZ(6px) translateY(-2px);
 		filter: brightness(1.04) saturate(1.06);
 		box-shadow:
 			inset 0 0 0 1px rgba(255, 250, 235, 0.28),
@@ -1151,11 +1253,20 @@
 }
 
 .feed-featured-event__title a {
+	/* v2 — title gradient gets a 3rd cream stop so animating background-position
+	   sweeps the highlight from left → right every 9s, giving a subtle scrolling
+	   tape feel without redrawing the text. The clip-to-text mask keeps the
+	   shimmer constrained to the glyph silhouettes. */
 	background-image: linear-gradient(
 		90deg,
 		var(--cdn-purple, #5a1f8a) 0%,
-		var(--cdn-violet, #9060f0) 100%
+		var(--cdn-violet, #9060f0) 38%,
+		var(--cdn-v2-title-tape) 50%,
+		var(--cdn-violet, #9060f0) 62%,
+		var(--cdn-purple, #5a1f8a) 100%
 	);
+	background-size: 220% 100%;
+	background-position: 120% 0;
 	background-clip: text;
 	-webkit-background-clip: text;
 	color: transparent;
@@ -1168,8 +1279,29 @@
 	background-image: linear-gradient(
 		90deg,
 		var(--cdn-violet, #9060f0) 0%,
-		var(--cdn-lavender, #d7c7ee) 100%
+		var(--cdn-lavender, #d7c7ee) 38%,
+		var(--cdn-v2-title-tape) 50%,
+		var(--cdn-lavender, #d7c7ee) 62%,
+		var(--cdn-violet, #9060f0) 100%
 	);
+	background-size: 220% 100%;
+	background-position: 120% 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes feed-featured-title-tape {
+		0% {
+			background-position: 120% 0;
+		}
+		70%,
+		100% {
+			background-position: -40% 0;
+		}
+	}
+
+	.feed-featured-event__title a {
+		animation: feed-featured-title-tape 9s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+	}
 }
 
 .feed-featured-event__title a:hover,
@@ -1184,9 +1316,146 @@
 	border-radius: 2px;
 }
 
+/* ---------- Date VFX — extreme legibility backplate + glow + shimmer ----------
+   The date string itself is plain HTML output from Intl.DateTimeFormat (no
+   SVG, no canvas, no string splitting). The wrapper div carries the layout
+   margin. The inner span is the backplate: tungsten amber gradient on light,
+   indigo gradient on dark. Bold tabular figures, slightly tightened tracking
+   for a marquee feel. A soft pulsing text-shadow ring breathes the legibility
+   up without pulling motion focus, and a faint diagonal sweep shimmer rides
+   the backplate on a slow loop (paired with the global ::after spotlight,
+   timed differently so they don't collide). All animation gated behind
+   prefers-reduced-motion: no-preference. */
 .feed-featured-event__date {
-	letter-spacing: 0.04em;
+	display: block;
+	margin: 4px 0 2px;
 	font-variant-numeric: tabular-nums;
+}
+
+.feed-featured-event__date-plate {
+	position: relative;
+	display: inline-block;
+	padding: 6px 14px;
+	border-radius: 8px;
+	background: linear-gradient(
+		135deg,
+		var(--cdn-v2-date-plate-from) 0%,
+		var(--cdn-v2-date-plate-to) 100%
+	);
+	border: 1px solid var(--cdn-v2-date-plate-border);
+	color: var(--cdn-v2-date-text);
+	/* baseline body-s in feed is ~14px; bump to 1.5x ≈ 21px for legibility. */
+	font-size: 1.5rem;
+	font-weight: 800;
+	line-height: 1.15;
+	letter-spacing: 0.01em;
+	font-variant-numeric: tabular-nums;
+	overflow: hidden;
+	box-shadow:
+		inset 0 1px 0 rgba(255, 250, 235, 0.5),
+		0 2px 6px -1px rgba(139, 90, 43, 0.18),
+		0 6px 18px -6px var(--cdn-v2-date-glow);
+	/* small CSS 3D pop — sits 4px above the card surface so the perspective
+	   on the parent gives it a stamped-floating-above feel. */
+	transform: translateZ(4px);
+}
+
+.awsui-dark-mode .feed-featured-event__date-plate {
+	box-shadow:
+		inset 0 1px 0 rgba(215, 199, 238, 0.22),
+		0 2px 8px -2px rgba(0, 0, 0, 0.4),
+		0 6px 22px -6px var(--cdn-v2-date-glow);
+}
+
+/* Diagonal shimmer sweep across the date plate — slower than the badge
+   (badge: 4.6s, date: 6.5s) so the eye registers the glow individually. */
+.feed-featured-event__date-plate::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	background: linear-gradient(
+		115deg,
+		transparent 0%,
+		transparent 38%,
+		var(--cdn-v2-date-shimmer) 50%,
+		transparent 62%,
+		transparent 100%
+	);
+	background-size: 240% 100%;
+	background-position: 120% 0;
+	mix-blend-mode: screen;
+	border-radius: inherit;
+	opacity: 0.65;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes feed-featured-date-glow {
+		0%,
+		100% {
+			text-shadow:
+				0 0 0 transparent,
+				0 1px 0 rgba(255, 250, 235, 0.45);
+			box-shadow:
+				inset 0 1px 0 rgba(255, 250, 235, 0.5),
+				0 2px 6px -1px rgba(139, 90, 43, 0.18),
+				0 6px 18px -6px var(--cdn-v2-date-glow);
+		}
+		50% {
+			text-shadow:
+				0 0 6px var(--cdn-v2-date-glow),
+				0 1px 0 rgba(255, 250, 235, 0.45);
+			box-shadow:
+				inset 0 1px 0 rgba(255, 250, 235, 0.6),
+				0 2px 8px -1px rgba(139, 90, 43, 0.22),
+				0 8px 24px -6px var(--cdn-v2-date-glow);
+		}
+	}
+
+	@keyframes feed-featured-date-glow-dark {
+		0%,
+		100% {
+			text-shadow:
+				0 0 0 transparent,
+				0 1px 0 rgba(0, 0, 0, 0.35);
+			box-shadow:
+				inset 0 1px 0 rgba(215, 199, 238, 0.22),
+				0 2px 8px -2px rgba(0, 0, 0, 0.4),
+				0 6px 22px -6px var(--cdn-v2-date-glow);
+		}
+		50% {
+			text-shadow:
+				0 0 8px var(--cdn-v2-date-glow),
+				0 1px 0 rgba(0, 0, 0, 0.35);
+			box-shadow:
+				inset 0 1px 0 rgba(215, 199, 238, 0.3),
+				0 2px 10px -2px rgba(0, 0, 0, 0.45),
+				0 10px 28px -6px var(--cdn-v2-date-glow);
+		}
+	}
+
+	@keyframes feed-featured-date-shimmer {
+		0% {
+			background-position: 120% 0;
+		}
+		70%,
+		100% {
+			background-position: -40% 0;
+		}
+	}
+
+	.feed-featured-event__date-plate {
+		animation: feed-featured-date-glow 4s ease-in-out infinite;
+	}
+
+	.awsui-dark-mode .feed-featured-event__date-plate {
+		animation: feed-featured-date-glow-dark 4s ease-in-out infinite;
+	}
+
+	.feed-featured-event__date-plate::after {
+		animation: feed-featured-date-shimmer 6.5s cubic-bezier(0.4, 0, 0.2, 1)
+			infinite;
+	}
 }
 
 .feed-featured-event__description {
@@ -1228,8 +1497,12 @@
 		0 2px 8px -2px rgba(255, 153, 0, 0.32);
 }
 
-/* ---------- Spots-remaining — chip with stage-light pulse ---------- */
+/* ---------- Spots-remaining — chip with stage-light pulse + outer ring ----------
+   v2 adds a faint outer ring (via outline + box-shadow ring) that breathes
+   in concert with the existing inner pulse — same period (3.4s) so the
+   eye reads them as one harmonized "the seats are filling" beat. */
 .feed-featured-event__spots {
+	position: relative;
 	display: inline-block;
 	padding: 4px 12px;
 	border-radius: 999px;
@@ -1247,6 +1520,18 @@
 		inset 0 1px 0 rgba(255, 250, 235, 0.4),
 		0 0 0 0 var(--cdn-rizz-spots-glow),
 		0 2px 8px -2px rgba(90, 31, 138, 0.22);
+}
+
+/* outer breathing ring — sits 4px outside the chip via ::before, same beat
+   as the inner pulse so they read as a single emissive halo. */
+.feed-featured-event__spots::before {
+	content: "";
+	position: absolute;
+	inset: -3px;
+	border-radius: inherit;
+	border: 1px solid var(--cdn-v2-spots-ring);
+	opacity: 0.55;
+	pointer-events: none;
 }
 
 .awsui-dark-mode .feed-featured-event__spots {
@@ -1303,6 +1588,25 @@
 	.awsui-dark-mode .feed-featured-event__spots {
 		animation: feed-featured-spots-pulse-dark 3.4s ease-in-out infinite;
 	}
+
+	/* breathing outer ring — same 3.4s beat, opacity + scale offset 180° so
+	   the ring expands as the inner glow lifts. Reads as harmonized halo. */
+	@keyframes feed-featured-spots-ring-breathe {
+		0%,
+		100% {
+			opacity: 0.45;
+			transform: scale(1);
+		}
+		50% {
+			opacity: 0.85;
+			transform: scale(1.05);
+		}
+	}
+
+	.feed-featured-event__spots::before {
+		animation: feed-featured-spots-ring-breathe 3.4s ease-in-out infinite;
+		transform-origin: center;
+	}
 }
 
 /* ---------- Reduced-motion fallback — strip all animation, keep static
@@ -1314,6 +1618,34 @@
 		opacity: 0.5;
 	}
 
+	.feed-featured-event::after {
+		animation: none;
+		background-position: 50% 0;
+		opacity: 0.4;
+		transform: none;
+	}
+
+	.feed-featured-event:hover::after {
+		transform: none;
+	}
+
+	.feed-featured-event__title a,
+	.awsui-dark-mode .feed-featured-event__title a {
+		animation: none;
+		background-position: 0 0;
+	}
+
+	.feed-featured-event__date-plate,
+	.awsui-dark-mode .feed-featured-event__date-plate {
+		animation: none;
+	}
+
+	.feed-featured-event__date-plate::after {
+		animation: none;
+		background-position: 50% 0;
+		opacity: 0.4;
+	}
+
 	.feed-featured-event__image,
 	.feed-featured-event__image:hover {
 		transform: none;
@@ -1323,6 +1655,12 @@
 	.feed-featured-event__spots,
 	.awsui-dark-mode .feed-featured-event__spots {
 		animation: none;
+	}
+
+	.feed-featured-event__spots::before {
+		animation: none;
+		transform: none;
+		opacity: 0.55;
 	}
 }
 


### PR DESCRIPTION
Comprehensive v2 rework of the featured event card per Bryan's critique of v1.

## six concerns, one atomic commit

### 1. copy
- **title** (en): `Speakeasy Happy Hour — June Networking Night` → **`Community Happy Hour & Networking Night`**
- **title** (es): → **`Hora Feliz Comunitaria y Noche de Networking`**
- **description** (en): replaced with Bryan's verbatim copy: *'Hop the trolley, grab a Lyft, ride a bike, or pull on up for finger-foods, drinks (including N/A options), and casual chatting about. AWS Builder Center Cards will be available for anyone who is "game."'*
- **description** (es): norteño parity (cáele en el trolley, píllate un Lyft, en bici, o tráete tu nave…)
- **primary button label**: shortened to `RSVP on CloudDelNorte.org` / `RSVP en CloudDelNorte.org` to fit a single line on 320px viewports.

### 2. date VFX (extremely legible)
- 1.5x baseline body size, weight 800, tabular-nums
- Tungsten-amber backplate (light) / indigo backplate (dark) under the date string
- Pulsing text-shadow ring + diagonal sweep shimmer behind the plate
- Plate sits on translateZ(4px) for a stamped 'floating-above-card' feel
- Date string itself stays plain Intl.DateTimeFormat — pure CSS treatment around it

### 3. animated ASCII-style smirk SVG
- New `src/pages/feed/components/ascii-smirk.tsx` + css
- ~16px inline SVG: blocky retro-terminal strokes, eyes as rects, asymmetric smirk mouth
- Default loop: blink every 4.6s
- Intermittent micro-twitch brow every 15s
- Hover: eyes squint, smirk widens, emits a spark ring
- prefers-reduced-motion: all animations off, static smirk renders correctly
- Renders inline directly after "game." word in the description

### 4. red removed from the page
`grep -n 'ED1C40\|#d11636\|#b91230' src/pages/feed/styles.css src/pages/feed/components/featured-event.tsx` returns ZERO matches.

Solution: new `variant="violet"` prop on MeetupRsvpButton — same M mark, brand purple→violet gradient instead of #ED1C40 red. M stroke flipped to cdn-purple for contrast on the white circle. Existing red variant kept available for other surfaces.

### 5. button overflow fix
Three layered changes:
1. Shortened primary label (kills the long string overflow)
2. `.cdn-brand-btn` audited: `box-sizing: border-box`, `min-width: 0`, label `white-space: nowrap + text-overflow: ellipsis`, padding 18px→14px
3. `.cdn-brand-btn-stack` clamped to `max-width: 480px` so stack respects same rail

Verified buttons fit at both 320px and 600px viewport widths with focus rings + ARIA contracts preserved.

### 6. fiona-credits-par dimensionality
Pure CSS, no Babylon runtime. The 'dashes of Babylon' interpretation: depth via CSS transforms.
- Card root: `perspective(1200px)` + `transform-style: preserve-3d` so children layer in real depth
- Image hover: `rotateY(-1.4deg) translateZ(6px)` — subtle 3D pop
- Date plate: `translateZ(4px)` floats above card
- Second ::after spotlight sweep (7s cool gradient, mix-blend-mode: screen) over the existing warm/violet radial backplate
- Inset 1px stage rim at 8% alpha for stage-edge feel
- Title link gradient gained third cream stop + 9s scrolling-tape shimmer
- Spots-remaining outer breathing ring harmonised with existing pulse

## gates
- biome ci: 0 errors / 531 pre-existing warnings unchanged
- npm run build: PASS for main, auth, awsug
- vitest: 627 / 627 PASS (added 4 new ascii-smirk tests + updated 13 featured-event assertions)
- accessibility: prefers-reduced-motion respected on every new animation; 4.5:1 contrast verified