### PR TITLE
feat(feed): wave 28b — wire @fight4ourexistencepodcast shorts carousel + oldest/newest sort

### DIFF
--- a/scripts/fetch-youtube-shorts.mjs
+++ b/scripts/fetch-youtube-shorts.mjs
@@ -1,35 +1,32 @@
 #!/usr/bin/env node
 
 // scripts/fetch-youtube-shorts.mjs
-// Wave 24e — fetch YouTube Shorts from a Mescalero-related channel.
-// Writes public/data/youtube-shorts.json before the Vite build.
+// Wave 24e / 28b — fetch YouTube uploads from a confirmed Mescalero-related
+// channel and write public/data/youtube-shorts.json before the Vite build.
+//
+// Source channel (wave 28b, 2026-05-19):
+//   "The Fight For Our Existence Podcast" — @fight4ourexistencepodcast
+//   Topics: Oak Flat, Indigenous culture, MMIP movement.
+//   Canonical channel id: UCCzkF6zRCRfZ0oxxsiPzG6w
 //
 // Strategy:
-//   1. If WAVE_24E_YOUTUBE_CHANNEL_ID env var is set, fetch the channel's RSS
-//      upload feed (https://www.youtube.com/feeds/videos.xml?channel_id=...)
-//      — no API key required, returns ~15 most recent uploads.
-//   2. Filter / cap to the first N items (N = SHORTS_LIMIT).
-//   3. Without the YouTube Data API, we cannot reliably filter by duration
-//      (< 60s). The shape of the JSON is identical regardless — operator
-//      curates the source channel so all uploads are shorts, OR a future
-//      enhancement layers API-based duration filtering.
+//   1. Fetch the channel's RSS upload feed
+//      (https://www.youtube.com/feeds/videos.xml?channel_id=...)
+//      — no API key required, returns ~15 most recent uploads in
+//      newest-first order.
+//   2. Cap to the first SHORTS_LIMIT items.
+//   3. Without the YouTube Data API, duration filtering (< 60s for true
+//      Shorts) is not possible at build time. The carousel renders
+//      whatever the channel published most recently; if the channel is
+//      mostly long-form, those will appear too. Future enhancement may
+//      layer Data-API-based duration filtering.
 //
-// On any error, writes an empty array and console.warn — does not fail the
-// build (matches the contract of fetch-feeds.mjs).
+// On any error, writes an empty array and console.warn — does not fail
+// the build (matches the contract of fetch-feeds.mjs). The carousel
+// component shows a localized empty state when the array is empty.
 //
-// TODO(operator): set WAVE_24E_YOUTUBE_CHANNEL_ID to a verified Mescalero-
-// related channel. Candidates investigated 2026-05-18:
-//   - "Mescalero Apache Tribe" — no canonical YouTube channel located.
-//   - "Inn of the Mountain Gods" — no canonical YouTube channel located.
-//   - "Writing on the Wall" podcast (Blue Shendo / Cris Frizzell) — audio-only
-//     per Captivate.fm; no YouTube channel discovered.
-//   - "Peter Santenello" — has Mescalero Apache video (YOUTUBE_ID:
-//     watch?v=p3JmCEFW7vc per petersantenello.com), but channel is
-//     general-travel, not Mescalero-specific.
-// Until WAVE_24E_YOUTUBE_CHANNEL_ID is set, this script writes a small
-// placeholder list (see PLACEHOLDER_SHORTS) so the carousel renders with
-// representative content. The empty-state path is exercised when
-// PLACEHOLDER_SHORTS is `[]`.
+// The default channel id can be overridden by the WAVE_24E_YOUTUBE_CHANNEL_ID
+// environment variable for future channel changes without code edits.
 
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -42,22 +39,9 @@ const OUT_DIR = join(ROOT, "public/data");
 const OUT_PATH = join(OUT_DIR, "youtube-shorts.json");
 
 const SHORTS_LIMIT = 8;
-const CHANNEL_ID = process.env.WAVE_24E_YOUTUBE_CHANNEL_ID || "";
-
-// Placeholder shorts. Each entry: { videoId, title, thumbnailUrl, publishedAt }.
-// These are real, public, Mescalero-themed YouTube videos curated as a
-// stand-in until WAVE_24E_YOUTUBE_CHANNEL_ID is configured. They are NOT
-// actual YouTube Shorts (no <60s constraint enforced here) — when an
-// operator-confirmed channel is wired in, this list is replaced wholesale.
-// TODO(operator): swap or empty this list once the source channel is set.
-const PLACEHOLDER_SHORTS = [
-	{
-		videoId: "p3JmCEFW7vc",
-		title: "Mescalero Apache Tribe — Native Cowboys (Peter Santenello)",
-		thumbnailUrl: "https://i.ytimg.com/vi/p3JmCEFW7vc/hqdefault.jpg",
-		publishedAt: "2022-07-19",
-	},
-];
+const DEFAULT_CHANNEL_ID = "UCCzkF6zRCRfZ0oxxsiPzG6w";
+const CHANNEL_ID =
+	process.env.WAVE_24E_YOUTUBE_CHANNEL_ID || DEFAULT_CHANNEL_ID;
 
 const parser = new XMLParser({
 	ignoreAttributes: false,
@@ -116,23 +100,16 @@ async function fetchChannelShorts(channelId, limit) {
 mkdirSync(OUT_DIR, { recursive: true });
 
 let shorts = [];
-if (CHANNEL_ID) {
-	try {
-		shorts = await fetchChannelShorts(CHANNEL_ID, SHORTS_LIMIT);
-		console.log(
-			`[fetch-youtube-shorts] channel ${CHANNEL_ID}: ${shorts.length} shorts`,
-		);
-	} catch (err) {
-		console.warn(
-			`[fetch-youtube-shorts] warn: channel ${CHANNEL_ID} fetch failed — ${err.message}. Writing placeholder list.`,
-		);
-		shorts = PLACEHOLDER_SHORTS.slice(0, SHORTS_LIMIT);
-	}
-} else {
+try {
+	shorts = await fetchChannelShorts(CHANNEL_ID, SHORTS_LIMIT);
 	console.log(
-		"[fetch-youtube-shorts] WAVE_24E_YOUTUBE_CHANNEL_ID not set — using placeholder list. See TODO(operator) at top of script.",
+		`[fetch-youtube-shorts] channel ${CHANNEL_ID}: ${shorts.length} shorts`,
 	);
-	shorts = PLACEHOLDER_SHORTS.slice(0, SHORTS_LIMIT);
+} catch (err) {
+	console.warn(
+		`[fetch-youtube-shorts] warn: channel ${CHANNEL_ID} fetch failed — ${err.message}. Writing empty list.`,
+	);
+	shorts = [];
 }
 
 writeFileSync(OUT_PATH, JSON.stringify(shorts, null, 2));

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -130,6 +130,13 @@
 		"shortsModalTitle": "Mescalero short",
 		"shortsModalClose": "Close player",
 		"shortsNowShowing": "Now showing video",
+		"shortsSort": {
+			"legend": "Sort by",
+			"newest": "Newest first",
+			"oldest": "Oldest first",
+			"changedAriaNewest": "Sorted newest first",
+			"changedAriaOldest": "Sorted oldest first"
+		},
 		"featuredEventHeader": "Featured event",
 		"featuredEventBadge": "DON'T MISS",
 		"featuredEventTitle": "Community Happy Hour & Networking Night",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -130,6 +130,13 @@
 		"shortsModalTitle": "short mescalero",
 		"shortsModalClose": "cerrar reproductor",
 		"shortsNowShowing": "ahorita pasando video",
+		"shortsSort": {
+			"legend": "Ordenar por",
+			"newest": "Reciente primero",
+			"oldest": "Más viejo primero",
+			"changedAriaNewest": "Ordenado: reciente primero",
+			"changedAriaOldest": "Ordenado: más viejo primero"
+		},
 		"featuredEventHeader": "Evento destacado",
 		"featuredEventBadge": "NO TE LO PIERDAS",
 		"featuredEventTitle": "Hora Feliz Comunitaria y Noche de Networking",

--- a/src/pages/feed/components/__tests__/youtube-shorts-carousel.test.tsx
+++ b/src/pages/feed/components/__tests__/youtube-shorts-carousel.test.tsx
@@ -2,30 +2,38 @@
 // SPDX-License-Identifier: MIT-0
 
 // Wave 24e — YouTubeShortsCarousel tests.
-// Covers:
-//  - renders > 0 thumbnails when shorts data is present
-//  - renders empty-state when shorts data is empty
-//  - clicking a thumbnail invokes the open-modal path
+// Wave 28b — added sort-selector coverage:
+//  - newest-first is the default order
+//  - clicking "Oldest first" reverses the rendered order
+//  - sort selection round-trips through localStorage
 
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { LocaleProvider } from "../../../../contexts/locale-context";
 import YouTubeShortsCarousel, {
+	SHORTS_SORT_STORAGE_KEY,
 	type YouTubeShort,
 } from "../youtube-shorts-carousel";
 
+// Source order matches the YouTube RSS feed shape: newest first.
 const SAMPLE_SHORTS: YouTubeShort[] = [
 	{
-		videoId: "p3JmCEFW7vc",
-		title: "Mescalero Apache Tribe — Native Cowboys (Peter Santenello)",
-		thumbnailUrl: "https://i.ytimg.com/vi/p3JmCEFW7vc/hqdefault.jpg",
-		publishedAt: "2022-07-19",
+		videoId: "newest1",
+		title: "MMIP movement update",
+		thumbnailUrl: "https://i.ytimg.com/vi/newest1/hqdefault.jpg",
+		publishedAt: "2026-05-16",
 	},
 	{
-		videoId: "abc12345678",
-		title: "Mescalero rodeo highlight",
-		thumbnailUrl: "https://i.ytimg.com/vi/abc12345678/hqdefault.jpg",
-		publishedAt: "2024-09-01",
+		videoId: "middle1",
+		title: "Oak Flat — the fight continues",
+		thumbnailUrl: "https://i.ytimg.com/vi/middle1/hqdefault.jpg",
+		publishedAt: "2026-03-14",
+	},
+	{
+		videoId: "oldest1",
+		title: "This Land Is Our Mother — Lozen at Oak Flat",
+		thumbnailUrl: "https://i.ytimg.com/vi/oldest1/hqdefault.jpg",
+		publishedAt: "2025-09-06",
 	},
 ];
 
@@ -37,7 +45,30 @@ function renderWith(shorts: YouTubeShort[]) {
 	);
 }
 
+function thumbTitles(): string[] {
+	return screen.getAllByTestId("shorts-thumb").map((btn) => {
+		const titleSpan = btn.querySelector(".feed-shorts-carousel__title");
+		return titleSpan?.textContent?.trim() ?? "";
+	});
+}
+
 describe("YouTubeShortsCarousel", () => {
+	beforeEach(() => {
+		try {
+			window.localStorage.removeItem(SHORTS_SORT_STORAGE_KEY);
+		} catch {
+			// jsdom always provides localStorage; defensive only
+		}
+	});
+
+	afterEach(() => {
+		try {
+			window.localStorage.removeItem(SHORTS_SORT_STORAGE_KEY);
+		} catch {
+			// noop
+		}
+	});
+
 	it("renders one button per short when data is present", () => {
 		renderWith(SAMPLE_SHORTS);
 		const thumbs = screen.getAllByTestId("shorts-thumb");
@@ -63,6 +94,50 @@ describe("YouTubeShortsCarousel", () => {
 		expect(iframe).toHaveAttribute(
 			"src",
 			`https://www.youtube.com/embed/${SAMPLE_SHORTS[0].videoId}`,
+		);
+	});
+
+	// --- wave 28b sort selector --------------------------------------
+
+	it("defaults to newest-first order matching the source data", () => {
+		renderWith(SAMPLE_SHORTS);
+		const titles = thumbTitles();
+		expect(titles).toEqual(SAMPLE_SHORTS.map((s) => s.title));
+	});
+
+	it("reverses the rendered order when oldest-first is selected", () => {
+		renderWith(SAMPLE_SHORTS);
+		// Cloudscape SegmentedControl renders each option as a button labelled
+		// by its text. Click the "Oldest first" button.
+		const oldestButton = screen.getByRole("button", { name: /oldest first/i });
+		fireEvent.click(oldestButton);
+
+		const titles = thumbTitles();
+		expect(titles).toEqual(
+			SAMPLE_SHORTS.slice()
+				.reverse()
+				.map((s) => s.title),
+		);
+		// Live-region announcement reflects the change.
+		expect(screen.getByTestId("shorts-sort-live-region")).toHaveTextContent(
+			/sorted oldest first/i,
+		);
+	});
+
+	it("persists the selected sort order in localStorage and restores it on remount", () => {
+		const { unmount } = renderWith(SAMPLE_SHORTS);
+		fireEvent.click(screen.getByRole("button", { name: /oldest first/i }));
+		expect(window.localStorage.getItem(SHORTS_SORT_STORAGE_KEY)).toBe("oldest");
+
+		unmount();
+
+		// Remount fresh and expect oldest-first ordering without re-clicking.
+		renderWith(SAMPLE_SHORTS);
+		const titles = thumbTitles();
+		expect(titles).toEqual(
+			SAMPLE_SHORTS.slice()
+				.reverse()
+				.map((s) => s.title),
 		);
 	});
 });

--- a/src/pages/feed/components/youtube-shorts-carousel.css
+++ b/src/pages/feed/components/youtube-shorts-carousel.css
@@ -11,6 +11,28 @@
 	width: 100%;
 }
 
+/* ----- Sort selector -------------------------------------------------- */
+.feed-shorts-carousel__sort {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: var(--cdn-space-xs);
+	margin-bottom: var(--cdn-space-sm);
+}
+
+/* sr-only utility for the live-region announcement */
+.feed-shorts-carousel__sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
 .feed-shorts-carousel__track {
 	display: flex;
 	gap: var(--cdn-space-md);
@@ -157,4 +179,13 @@
 	height: 100%;
 	border: 0;
 	border-radius: var(--cdn-radius-md);
+}
+
+/* ----- Sort selector — light + dark parity ---------------------------- */
+:root:not(.awsui-dark-mode) .feed-shorts-carousel__sort {
+	color: var(--cdn-color-text);
+}
+
+.awsui-dark-mode .feed-shorts-carousel__sort {
+	color: rgba(255, 255, 255, 0.92);
 }

--- a/src/pages/feed/components/youtube-shorts-carousel.tsx
+++ b/src/pages/feed/components/youtube-shorts-carousel.tsx
@@ -2,6 +2,12 @@
 // SPDX-License-Identifier: MIT-0
 
 // Wave 24e — Mescalero YouTube Shorts carousel.
+// Wave 28b — wired to The Fight For Our Existence Podcast
+// (@fight4ourexistencepodcast, channel UCCzkF6zRCRfZ0oxxsiPzG6w) +
+// added a SegmentedControl to flip sort order between newest-first
+// (default) and oldest-first, with the user's choice persisted to
+// localStorage under "cdn-shorts-sort".
+//
 // Renders horizontal thumbnail strip; click opens Cloudscape Modal with
 // in-place YouTube embed. Build-time data source: public/data/youtube-shorts.json
 // (produced by scripts/fetch-youtube-shorts.mjs). When the JSON is empty,
@@ -12,7 +18,8 @@ import Box from "@cloudscape-design/components/box";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import Modal from "@cloudscape-design/components/modal";
-import { useCallback, useEffect, useRef, useState } from "react";
+import SegmentedControl from "@cloudscape-design/components/segmented-control";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "../../../hooks/useTranslation";
 import "./youtube-shorts-carousel.css";
 
@@ -31,6 +38,30 @@ export interface YouTubeShortsCarouselProps {
 }
 
 const DEFAULT_DATA_URL = "/data/youtube-shorts.json";
+
+/** localStorage key persisting the user's sort preference between visits. */
+export const SHORTS_SORT_STORAGE_KEY = "cdn-shorts-sort";
+
+type ShortsSortOrder = "newest" | "oldest";
+
+function readStoredSort(): ShortsSortOrder {
+	if (typeof window === "undefined") return "newest";
+	try {
+		const raw = window.localStorage.getItem(SHORTS_SORT_STORAGE_KEY);
+		return raw === "oldest" ? "oldest" : "newest";
+	} catch {
+		return "newest";
+	}
+}
+
+function writeStoredSort(value: ShortsSortOrder): void {
+	if (typeof window === "undefined") return;
+	try {
+		window.localStorage.setItem(SHORTS_SORT_STORAGE_KEY, value);
+	} catch {
+		// ignore storage failures (private mode, quota, etc.)
+	}
+}
 
 async function fetchShorts(url: string): Promise<YouTubeShort[]> {
 	try {
@@ -52,6 +83,10 @@ export default function YouTubeShortsCarousel({
 	const [ready, setReady] = useState<boolean>(shortsProp !== undefined);
 	const [activeIndex, setActiveIndex] = useState(0);
 	const [modalShortId, setModalShortId] = useState<string | null>(null);
+	const [sortOrder, setSortOrder] = useState<ShortsSortOrder>(() =>
+		readStoredSort(),
+	);
+	const [sortAnnouncement, setSortAnnouncement] = useState<string>("");
 	const buttonsRef = useRef<Array<HTMLButtonElement | null>>([]);
 
 	useEffect(() => {
@@ -67,6 +102,28 @@ export default function YouTubeShortsCarousel({
 		};
 	}, [shortsProp, dataUrl]);
 
+	// Source JSON arrives in newest-first order from the YouTube RSS feed.
+	// Reverse for oldest-first; do not mutate the source array.
+	const orderedShorts = useMemo<YouTubeShort[]>(
+		() => (sortOrder === "oldest" ? shorts.slice().reverse() : shorts),
+		[shorts, sortOrder],
+	);
+
+	const handleSortChange = useCallback(
+		(next: ShortsSortOrder) => {
+			if (next === sortOrder) return;
+			setSortOrder(next);
+			writeStoredSort(next);
+			setActiveIndex(0);
+			setSortAnnouncement(
+				next === "oldest"
+					? t("feedPage.shortsSort.changedAriaOldest")
+					: t("feedPage.shortsSort.changedAriaNewest"),
+			);
+		},
+		[sortOrder, t],
+	);
+
 	const focusThumb = useCallback((next: number) => {
 		setActiveIndex(next);
 		// defer focus until the next render's ref attaches
@@ -75,29 +132,30 @@ export default function YouTubeShortsCarousel({
 
 	const handleKeyDown = useCallback(
 		(e: React.KeyboardEvent<HTMLButtonElement>, i: number) => {
-			if (shorts.length === 0) return;
+			if (orderedShorts.length === 0) return;
 			if (e.key === "ArrowRight") {
 				e.preventDefault();
-				focusThumb((i + 1) % shorts.length);
+				focusThumb((i + 1) % orderedShorts.length);
 			} else if (e.key === "ArrowLeft") {
 				e.preventDefault();
-				focusThumb((i - 1 + shorts.length) % shorts.length);
+				focusThumb((i - 1 + orderedShorts.length) % orderedShorts.length);
 			} else if (e.key === "Home") {
 				e.preventDefault();
 				focusThumb(0);
 			} else if (e.key === "End") {
 				e.preventDefault();
-				focusThumb(shorts.length - 1);
+				focusThumb(orderedShorts.length - 1);
 			}
 		},
-		[shorts.length, focusThumb],
+		[orderedShorts.length, focusThumb],
 	);
 
-	const activeShort = shorts.find((s) => s.videoId === modalShortId) ?? null;
+	const activeShort =
+		orderedShorts.find((s) => s.videoId === modalShortId) ?? null;
 
 	const announce = ready
-		? shorts.length > 0
-			? `${t("feedPage.shortsNowShowing")} ${activeIndex + 1} ${t("feedPage.articleAriaConnector")} ${shorts.length}`
+		? orderedShorts.length > 0
+			? `${t("feedPage.shortsNowShowing")} ${activeIndex + 1} ${t("feedPage.articleAriaConnector")} ${orderedShorts.length}`
 			: t("feedPage.shortsEmpty")
 		: "";
 
@@ -105,7 +163,7 @@ export default function YouTubeShortsCarousel({
 		<Container
 			header={<Header variant="h2">{t("feedPage.shortsHeader")}</Header>}
 		>
-			{shorts.length === 0 ? (
+			{orderedShorts.length === 0 ? (
 				<Box
 					color="text-status-inactive"
 					fontSize="body-s"
@@ -115,6 +173,34 @@ export default function YouTubeShortsCarousel({
 				</Box>
 			) : (
 				<>
+					<div className="feed-shorts-carousel__sort" data-testid="shorts-sort">
+						<Box
+							fontSize="body-s"
+							color="text-status-inactive"
+							margin={{ right: "xs" }}
+						>
+							<span id="shorts-sort-legend">
+								{t("feedPage.shortsSort.legend")}
+							</span>
+						</Box>
+						<SegmentedControl
+							selectedId={sortOrder}
+							ariaLabelledby="shorts-sort-legend"
+							options={[
+								{
+									id: "newest",
+									text: t("feedPage.shortsSort.newest"),
+								},
+								{
+									id: "oldest",
+									text: t("feedPage.shortsSort.oldest"),
+								},
+							]}
+							onChange={({ detail }) =>
+								handleSortChange(detail.selectedId as ShortsSortOrder)
+							}
+						/>
+					</div>
 					<div
 						className="feed-shorts-carousel"
 						role="group"
@@ -124,7 +210,7 @@ export default function YouTubeShortsCarousel({
 							className="feed-shorts-carousel__track"
 							data-testid="shorts-track"
 						>
-							{shorts.map((short, i) => (
+							{orderedShorts.map((short, i) => (
 								<li key={short.videoId} className="feed-shorts-carousel__item">
 									<button
 										type="button"
@@ -171,6 +257,13 @@ export default function YouTubeShortsCarousel({
 					>
 						<span aria-live="polite" data-testid="shorts-live-region">
 							{announce}
+						</span>
+						<span
+							aria-live="polite"
+							className="feed-shorts-carousel__sr-only"
+							data-testid="shorts-sort-live-region"
+						>
+							{sortAnnouncement}
 						</span>
 					</Box>
 				</>


### PR DESCRIPTION
Channel ID confirmed: UCCzkF6zRCRfZ0oxxsiPzG6w (The Fight For Our Existence Podcast). Removed placeholder + TODO. Cloudscape SegmentedControl for sort (Newest first / Oldest first), localStorage persistence under 'cdn-shorts-sort', aria-live announces sort changes. 5 new i18n keys (en + es-MX norteño). 6 vitest cases (3 new sort tests). 8 entries fetched from feed; channel publishes mostly long-form not <60s shorts (no API key for duration filter).