### PR TITLE
feat(player): wave 24c — podcast episode scroller with sort + transcripts

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/bryanchasko/code/websites/cloud-del-norte-website/node_modules

--- a/scripts/fetch-feeds.mjs
+++ b/scripts/fetch-feeds.mjs
@@ -145,8 +145,83 @@ async function fetchFeed(url, limit) {
 	}));
 }
 
+/** Parse iTunes duration string to seconds.
+ *  Accepts: "HH:MM:SS", "MM:SS", "M:SS", or a bare integer (seconds). */
+function parseDurationToSeconds(raw) {
+	if (raw === null || raw === undefined) return 0;
+	const s = String(raw).trim();
+	if (!s) return 0;
+	if (/^\d+$/.test(s)) return Number(s);
+	const parts = s.split(":").map((p) => Number(p.trim()));
+	if (parts.some((n) => Number.isNaN(n))) return 0;
+	if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+	if (parts.length === 2) return parts[0] * 60 + parts[1];
+	if (parts.length === 1) return parts[0];
+	return 0;
+}
+
+/** Extract the first podcast:transcript URL from an item, if present.
+ *  Handles the colon-prefixed key fast-xml-parser preserves with
+ *  ignoreAttributes:false, plus the rare itunes:transcript fallback.
+ *  Returns null when no transcript tag is found. */
+function extractTranscriptUrl(item) {
+	const candidates = [
+		item["podcast:transcript"],
+		item.podcast_transcript,
+		item["itunes:transcript"],
+		item.itunes_transcript,
+	];
+	for (const cand of candidates) {
+		if (!cand) continue;
+		const list = Array.isArray(cand) ? cand : [cand];
+		for (const node of list) {
+			if (!node) continue;
+			if (typeof node === "string" && node) return node;
+			const url = node["@_url"];
+			if (typeof url === "string" && url) return url;
+		}
+	}
+	return null;
+}
+
+/** Build episode rows (up to MAX_EPISODES) from a parsed RSS items array. */
+const MAX_EPISODES = 50;
+function buildEpisodes(items) {
+	return items.slice(0, MAX_EPISODES).map((item, idx) => {
+		const title = decodeEntities(
+			getText(item.title)
+				.replace(/<!\[CDATA\[|\]\]>/g, "")
+				.trim(),
+		);
+		const enclosureUrl =
+			item?.enclosure?.["@_url"] ?? item?.enclosure?.url ?? "";
+		const guid = String(
+			item.guid?.["#text"] ?? item.guid ?? enclosureUrl ?? `idx-${idx}`,
+		).trim();
+		const pubDateRaw = item.pubDate ?? item.published ?? item.updated ?? null;
+		let pubDate = "";
+		try {
+			pubDate = pubDateRaw ? new Date(pubDateRaw).toISOString() : "";
+		} catch {
+			pubDate = String(pubDateRaw ?? "");
+		}
+		const duration = parseDurationToSeconds(
+			item["itunes:duration"] ?? item.itunes_duration ?? null,
+		);
+		const transcriptUrl = extractTranscriptUrl(item);
+		return {
+			guid: guid || `idx-${idx}`,
+			title: title || "(untitled)",
+			pubDate,
+			duration,
+			enclosureUrl: String(enclosureUrl || ""),
+			...(transcriptUrl ? { transcriptUrl } : {}),
+		};
+	});
+}
+
 /** Fetch latest episode metadata from a podcast RSS feed.
- *  Returns { title, subtitle, display, enclosureUrl } or null on failure.
+ *  Returns { title, subtitle, display, enclosureUrl, episodes } or null on failure.
  *
  *  enclosureUrl (wave 28c): the playable audio URL for the latest episode,
  *  pulled from <item><enclosure url="..."/></item>. Hydrated into
@@ -154,7 +229,11 @@ async function fetchFeed(url, limit) {
  *  the freshest URL — eliminating the stale-enclosure failure mode where a
  *  hardcoded streams.ts URL points to an expired Triton signed CDN link or
  *  a rotated captivate UUID. The frontend prefers this over the streams.ts
- *  url and falls back to the streams.ts url only when this is missing. */
+ *  url and falls back to the streams.ts url only when this is missing.
+ *
+ *  episodes (wave 24c): array (up to MAX_EPISODES) of EpisodeRow shapes
+ *  consumed by the podcast-episode-scroller. Existing consumers that only
+ *  read .display continue to work unchanged. */
 async function fetchPodcastLatest(url) {
 	const res = await fetch(url, {
 		headers: { "User-Agent": "AWSUGCloudDelNorte-fetch-feeds" },
@@ -200,11 +279,14 @@ async function fetchPodcastLatest(url) {
 			? String(encNode["@_url"] ?? "").trim() || null
 			: null;
 
+	const episodes = buildEpisodes(items);
+
 	return {
 		title: title || null,
 		subtitle,
 		display,
 		enclosureUrl,
+		episodes,
 	};
 }
 
@@ -240,7 +322,7 @@ for (const { key, url } of PODCAST_FEEDS) {
 		console.log(
 			`[fetch-feeds] podcast ${key}: ${episode?.display ?? "(no display)"}${
 				episode?.enclosureUrl ? ` [enc ok]` : ` [enc missing]`
-			}`,
+			} (${episode?.episodes?.length ?? 0} episodes)`,
 		);
 	} catch (err) {
 		console.warn(

--- a/src/components/persistent-player/index.tsx
+++ b/src/components/persistent-player/index.tsx
@@ -31,6 +31,76 @@ import {
 import { decidePodcastRecovery, pruneHistory } from "./podcast-recovery";
 import "./styles.css";
 
+/**
+ * Wave 24c — episode-swap event name. The episode scroller dispatches this
+ * with detail.url + detail.title when the user picks a back-catalog episode
+ * to play. The persistent player listens (see effect inside
+ * PersistentPlayerBar) and overrides the audio src + plays. Lives on window
+ * so the scroller doesn't need a direct ref into the player tree.
+ */
+const EPISODE_SWAP_EVENT = "cdn:player:swap-episode";
+
+/**
+ * Wave 24c — read-only hook that surfaces the active stream's identifying
+ * fields for sibling components (notably the podcast-episode-scroller). The
+ * scroller cannot import the persisted state directly without polling, so
+ * we publish state changes via a `cdn:player:state` window event from the
+ * player's own state effect and replay the latest snapshot here.
+ *
+ * Returns nullable fields — the player may not have hydrated yet on the
+ * very first paint after a cold load.
+ */
+export interface ActivePlayerStream {
+	readonly stationKey: string | null;
+	readonly stationLabel: string | null;
+	readonly isPodcast: boolean;
+	readonly currentEpisodeUrl: string | null;
+}
+
+const PLAYER_STATE_EVENT = "cdn:player:state";
+
+export function useActivePlayerStream(): ActivePlayerStream {
+	const [snapshot, setSnapshot] = useState<ActivePlayerStream>(() =>
+		readActivePlayerStream(),
+	);
+	useEffect(() => {
+		const handler = () => setSnapshot(readActivePlayerStream());
+		// Window-level focus + storage listeners catch out-of-band updates
+		// (other tabs, hydration races) without requiring the player tree to
+		// share React context with consumers.
+		window.addEventListener(PLAYER_STATE_EVENT, handler);
+		window.addEventListener("storage", handler);
+		// Initial fetch in case the publishing effect already fired before
+		// this hook mounted (race on first paint).
+		handler();
+		return () => {
+			window.removeEventListener(PLAYER_STATE_EVENT, handler);
+			window.removeEventListener("storage", handler);
+		};
+	}, []);
+	return snapshot;
+}
+
+function readActivePlayerStream(): ActivePlayerStream {
+	const persisted = loadPlayerState();
+	if (!persisted) {
+		return {
+			stationKey: null,
+			stationLabel: null,
+			isPodcast: false,
+			currentEpisodeUrl: null,
+		};
+	}
+	const def = STREAMS.find((s) => s.key === persisted.stationKey) ?? null;
+	return {
+		stationKey: persisted.stationKey,
+		stationLabel: persisted.stationLabel ?? def?.label ?? null,
+		isPodcast: def?.type === "podcast",
+		currentEpisodeUrl:
+			persisted.podcastEpisodeUrl ?? persisted.stationUrl ?? null,
+	};
+}
+
 const POLL_MS = 30_000;
 /** how long an audio error/stall must persist before we surface UI to the user */
 const STREAM_ERROR_THRESHOLD_MS = 5_000;
@@ -264,6 +334,40 @@ function PersistentPlayerBar({
 			retryTimerRef.current = null;
 		}
 	}, [state.stationKey]);
+
+	// Wave 24c — episode-swap listener. The podcast-episode-scroller dispatches
+	// `cdn:player:swap-episode` when the user picks a back-catalog episode;
+	// we override the audio src + start playback. Gated to the active podcast
+	// only — radio stations ignore the event entirely.
+	useEffect(() => {
+		if (!isPodcast) return;
+		const handler = (ev: Event) => {
+			const detail = (ev as CustomEvent<{ url?: string; title?: string }>)
+				.detail;
+			if (!detail?.url) return;
+			setRssAudioUrl(detail.url);
+			if (detail.title) setNowPlaying(detail.title);
+			// best-effort autoplay — same pattern as the play() callback below.
+			// failure (e.g. browser blocks autoplay) sets the blocked state via
+			// the existing audio.play() catch chain.
+			const audio = audioRef.current;
+			if (audio) {
+				// give React a tick to flush the new src before kicking play
+				queueMicrotask(() => {
+					try {
+						audio.load();
+						audio.play().catch(() => setBlocked(true));
+					} catch {
+						setBlocked(true);
+					}
+				});
+			}
+		};
+		window.addEventListener(EPISODE_SWAP_EVENT, handler as EventListener);
+		return () => {
+			window.removeEventListener(EPISODE_SWAP_EVENT, handler as EventListener);
+		};
+	}, [isPodcast]);
 
 	// auto-advance on persistent failure — when streamHealth reaches 'failed'
 	// (auto-retry exhausted), advance to the next station after a 2s grace
@@ -1108,6 +1212,15 @@ function PersistentPlayerInner() {
 			metaUrl: first.metaUrl,
 		});
 	}, []);
+
+	// Wave 24c — publish the active stream snapshot for sibling consumers
+	// (podcast-episode-scroller). Re-fires whenever the resolved station
+	// changes so useActivePlayerStream can pick up the new identity.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: state is the change-detection trigger; the effect body intentionally just signals
+	useEffect(() => {
+		if (typeof window === "undefined") return;
+		window.dispatchEvent(new CustomEvent(PLAYER_STATE_EVENT));
+	}, [state]);
 
 	// skip station — direction +1 advances, -1 rewinds. Checks reachability
 	// before switching; skips up to 3 unreachable stations. If all 3 fail,

--- a/src/components/podcast-episode-scroller/__tests__/index.test.tsx
+++ b/src/components/podcast-episode-scroller/__tests__/index.test.tsx
@@ -1,0 +1,364 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/**
+ * Wave 24c — PodcastEpisodeScroller component tests.
+ *
+ * Verifies:
+ *   1. render gates (hidden when isPodcast=false, visible when true)
+ *   2. sort toggle reorders the visible list (newest ↔ oldest) and persists
+ *      the choice to localStorage
+ *   3. clicking an episode's play button triggers onEpisodeSelect(url, title)
+ *   4. load-more pagination expands the list past PAGE_SIZE
+ *   5. transcript link only renders for episodes whose feed shipped a
+ *      <podcast:transcript> URL
+ *   6. empty-state copy renders when the active podcast has no episodes
+ *
+ * Cloudscape Container/Header/Button/SegmentedControl are mocked to plain
+ * DOM so the test stays focused on scroller behaviour without pulling the
+ * full Cloudscape rendering stack into jsdom.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type AnyProps = Record<string, unknown> & {
+	children?: React.ReactNode;
+	header?: React.ReactNode;
+};
+
+vi.mock("@cloudscape-design/components/container", () => ({
+	default: ({ children, header }: AnyProps) =>
+		React.createElement(
+			"section",
+			{ "data-testid": "container" },
+			header,
+			children,
+		),
+}));
+
+vi.mock("@cloudscape-design/components/header", () => ({
+	default: ({ children }: AnyProps) =>
+		React.createElement("h3", { "data-testid": "scroller-header" }, children),
+}));
+
+vi.mock("@cloudscape-design/components/button", () => ({
+	default: ({ children, onClick }: AnyProps) =>
+		React.createElement(
+			"button",
+			{
+				type: "button",
+				"data-testid": "load-more-button",
+				onClick: onClick as React.MouseEventHandler,
+			},
+			children,
+		),
+}));
+
+vi.mock("@cloudscape-design/components/segmented-control", () => ({
+	default: ({
+		selectedId,
+		onChange,
+		options,
+	}: {
+		selectedId: string;
+		onChange: (e: { detail: { selectedId: string } }) => void;
+		options: { id: string; text: string }[];
+	}) =>
+		React.createElement(
+			"div",
+			{ "data-testid": "sort-segmented-control" },
+			...options.map((opt) =>
+				React.createElement(
+					"button",
+					{
+						key: opt.id,
+						type: "button",
+						"data-testid": `sort-option-${opt.id}`,
+						"data-selected": selectedId === opt.id ? "true" : "false",
+						onClick: () => onChange({ detail: { selectedId: opt.id } }),
+					},
+					opt.text,
+				),
+			),
+		),
+}));
+
+// Locale provider — supplies the t() / locale used by the component.
+import { LocaleProvider } from "../../../contexts/locale-context";
+import { PodcastEpisodeScroller } from "../index";
+
+function withLocale(node: React.ReactNode) {
+	return React.createElement(LocaleProvider, { locale: "us" }, node);
+}
+
+const FIXED_NEWEST = "2026-05-15T00:00:00.000Z";
+const FIXED_MIDDLE = "2026-04-01T00:00:00.000Z";
+const FIXED_OLDEST = "2026-01-10T00:00:00.000Z";
+
+function makeFixture() {
+	const episodes = [
+		{
+			guid: "ep-newest",
+			title: "Newest episode",
+			pubDate: FIXED_NEWEST,
+			duration: 1800,
+			enclosureUrl: "https://example.com/ep-newest.mp3",
+			transcriptUrl: "https://example.com/ep-newest.html",
+		},
+		{
+			guid: "ep-middle",
+			title: "Middle episode",
+			pubDate: FIXED_MIDDLE,
+			duration: 2400,
+			enclosureUrl: "https://example.com/ep-middle.mp3",
+		},
+		{
+			guid: "ep-oldest",
+			title: "Oldest episode",
+			pubDate: FIXED_OLDEST,
+			duration: 3600,
+			enclosureUrl: "https://example.com/ep-oldest.mp3",
+		},
+	];
+	return {
+		talk_python: {
+			title: "Newest episode",
+			subtitle: null,
+			display: "Newest episode",
+			episodes,
+		},
+	};
+}
+
+function makeManyEpisodes(count: number) {
+	const episodes = Array.from({ length: count }, (_, i) => {
+		// each step ~1 day apart so sort order is deterministic
+		const ts = Date.UTC(2026, 0, 1 + i);
+		return {
+			guid: `ep-${i}`,
+			title: `Episode ${i}`,
+			pubDate: new Date(ts).toISOString(),
+			duration: 600 + i,
+			enclosureUrl: `https://example.com/ep-${i}.mp3`,
+		};
+	});
+	return {
+		talk_python: {
+			title: "Talk Python",
+			subtitle: null,
+			display: "Talk Python",
+			episodes,
+		},
+	};
+}
+
+function mockFetchOnce(payload: unknown) {
+	globalThis.fetch = vi.fn(async () =>
+		Promise.resolve(
+			new Response(JSON.stringify(payload), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		),
+	) as unknown as typeof fetch;
+}
+
+describe("PodcastEpisodeScroller (wave 24c)", () => {
+	beforeEach(() => {
+		try {
+			localStorage.clear();
+		} catch {
+			// ignore — jsdom should always have localStorage
+		}
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("renders nothing when isPodcast=false", () => {
+		const onSelect = vi.fn();
+		const { container } = render(
+			withLocale(
+				React.createElement(PodcastEpisodeScroller, {
+					isPodcast: false,
+					currentStreamKey: "krux",
+					currentEpisodeUrl: "",
+					onEpisodeSelect: onSelect,
+				}),
+			),
+		);
+		expect(container.querySelector("[data-testid='container']")).toBeNull();
+	});
+
+	it("renders header + episode rows when isPodcast=true and data has episodes", async () => {
+		mockFetchOnce(makeFixture());
+		const onSelect = vi.fn();
+		render(
+			withLocale(
+				React.createElement(PodcastEpisodeScroller, {
+					isPodcast: true,
+					currentStreamKey: "talk_python",
+					currentEpisodeUrl: "",
+					onEpisodeSelect: onSelect,
+				}),
+			),
+		);
+		await waitFor(() => {
+			expect(screen.getByText("Newest episode")).toBeInTheDocument();
+		});
+		expect(screen.getByText("Middle episode")).toBeInTheDocument();
+		expect(screen.getByText("Oldest episode")).toBeInTheDocument();
+		// header includes the suffix copy
+		expect(screen.getByTestId("scroller-header").textContent).toMatch(
+			/episodes/,
+		);
+	});
+
+	it("default sort is newest first; toggling to oldest reorders the list and persists to localStorage", async () => {
+		mockFetchOnce(makeFixture());
+		const onSelect = vi.fn();
+		const { container } = render(
+			withLocale(
+				React.createElement(PodcastEpisodeScroller, {
+					isPodcast: true,
+					currentStreamKey: "talk_python",
+					currentEpisodeUrl: "",
+					onEpisodeSelect: onSelect,
+				}),
+			),
+		);
+
+		await waitFor(() => {
+			expect(screen.getByText("Newest episode")).toBeInTheDocument();
+		});
+
+		const titlesNewest = Array.from(
+			container.querySelectorAll(".cdn-podcast-scroller__title"),
+		).map((el) => el.textContent);
+		expect(titlesNewest).toEqual([
+			"Newest episode",
+			"Middle episode",
+			"Oldest episode",
+		]);
+
+		fireEvent.click(screen.getByTestId("sort-option-oldest"));
+
+		await waitFor(() => {
+			const titlesOldest = Array.from(
+				container.querySelectorAll(".cdn-podcast-scroller__title"),
+			).map((el) => el.textContent);
+			expect(titlesOldest).toEqual([
+				"Oldest episode",
+				"Middle episode",
+				"Newest episode",
+			]);
+		});
+
+		expect(localStorage.getItem("cdn:podcast-scroller:sort:v1")).toBe("oldest");
+	});
+
+	it("clicking a play button fires onEpisodeSelect with the enclosure URL + title", async () => {
+		mockFetchOnce(makeFixture());
+		const onSelect = vi.fn();
+		render(
+			withLocale(
+				React.createElement(PodcastEpisodeScroller, {
+					isPodcast: true,
+					currentStreamKey: "talk_python",
+					currentEpisodeUrl: "",
+					onEpisodeSelect: onSelect,
+				}),
+			),
+		);
+		await waitFor(() => {
+			expect(screen.getByText("Newest episode")).toBeInTheDocument();
+		});
+		const playBtn = screen.getByLabelText("Play Middle episode");
+		fireEvent.click(playBtn);
+		expect(onSelect).toHaveBeenCalledTimes(1);
+		expect(onSelect).toHaveBeenCalledWith(
+			"https://example.com/ep-middle.mp3",
+			"Middle episode",
+		);
+	});
+
+	it("transcript link renders only for episodes whose feed shipped a <podcast:transcript> URL", async () => {
+		mockFetchOnce(makeFixture());
+		render(
+			withLocale(
+				React.createElement(PodcastEpisodeScroller, {
+					isPodcast: true,
+					currentStreamKey: "talk_python",
+					currentEpisodeUrl: "",
+					onEpisodeSelect: vi.fn(),
+				}),
+			),
+		);
+		await waitFor(() => {
+			expect(screen.getByText("Newest episode")).toBeInTheDocument();
+		});
+		// Newest has transcriptUrl — link present
+		const transcriptLinks = screen.getAllByText("transcript");
+		expect(transcriptLinks).toHaveLength(1);
+		expect(transcriptLinks[0]).toHaveAttribute(
+			"href",
+			"https://example.com/ep-newest.html",
+		);
+		expect(transcriptLinks[0]).toHaveAttribute("target", "_blank");
+		expect(transcriptLinks[0]).toHaveAttribute("rel", "noopener noreferrer");
+	});
+
+	it("load-more button appears when episodes exceed PAGE_SIZE; click expands the list", async () => {
+		mockFetchOnce(makeManyEpisodes(75));
+		render(
+			withLocale(
+				React.createElement(PodcastEpisodeScroller, {
+					isPodcast: true,
+					currentStreamKey: "talk_python",
+					currentEpisodeUrl: "",
+					onEpisodeSelect: vi.fn(),
+				}),
+			),
+		);
+		await waitFor(() => {
+			// PAGE_SIZE=50; with 75 episodes, expect 50 visible rows + load-more
+			const rows = document.querySelectorAll(".cdn-podcast-scroller__row");
+			expect(rows.length).toBe(50);
+		});
+		const loadMore = screen.getByTestId("load-more-button");
+		fireEvent.click(loadMore);
+		await waitFor(() => {
+			const rows = document.querySelectorAll(".cdn-podcast-scroller__row");
+			expect(rows.length).toBe(75);
+		});
+		// no more pages — button should be gone
+		expect(screen.queryByTestId("load-more-button")).toBeNull();
+	});
+
+	it("renders empty-state copy when the active podcast has no episodes", async () => {
+		mockFetchOnce({
+			talk_python: {
+				title: null,
+				subtitle: null,
+				display: null,
+				episodes: [],
+			},
+		});
+		render(
+			withLocale(
+				React.createElement(PodcastEpisodeScroller, {
+					isPodcast: true,
+					currentStreamKey: "talk_python",
+					currentEpisodeUrl: "",
+					onEpisodeSelect: vi.fn(),
+				}),
+			),
+		);
+		await waitFor(() => {
+			expect(screen.getByText("No episodes available yet")).toBeInTheDocument();
+		});
+	});
+});

--- a/src/components/podcast-episode-scroller/index.tsx
+++ b/src/components/podcast-episode-scroller/index.tsx
@@ -1,0 +1,292 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import SegmentedControl from "@cloudscape-design/components/segmented-control";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "../../hooks/useTranslation";
+import { STREAMS } from "../../lib/streams-order";
+import "./styles.css";
+
+/**
+ * Wave 24c — Podcast episode scroller.
+ *
+ * Surfaces the last-N episodes of the active podcast feed below the
+ * persistent player pill. Reads from the build-time
+ * `/data/podcast-episodes.json` cache (extended by scripts/fetch-feeds.mjs
+ * to include up to 50 episodes per podcast key, with date / duration /
+ * optional <podcast:transcript> URL).
+ *
+ * Renders nothing when the active stream is not a podcast — the wrapper
+ * mounted in the awsug shell can call this unconditionally and rely on
+ * the gate.
+ *
+ * Sort: newest / oldest first. Selection persisted to localStorage so it
+ * survives page reloads. Pagination: PAGE_SIZE rows per "load more" click.
+ *
+ * Accessibility: list region announces sort changes via aria-live=polite;
+ * each play button gets an aria-label containing the episode title; the
+ * currently-playing row exposes aria-current=true.
+ */
+
+export interface PodcastEpisode {
+	readonly guid: string;
+	readonly title: string;
+	/** ISO 8601 datetime — empty string when feed omits pubDate */
+	readonly pubDate: string;
+	/** seconds; 0 when feed omits itunes:duration */
+	readonly duration: number;
+	readonly enclosureUrl: string;
+	readonly transcriptUrl?: string;
+}
+
+interface PodcastEpisodeData {
+	readonly title?: string | null;
+	readonly subtitle?: string | null;
+	readonly display?: string | null;
+	readonly episodes?: PodcastEpisode[];
+}
+
+export interface PodcastEpisodeScrollerProps {
+	/** When false the component renders nothing (radio stations skip it). */
+	readonly isPodcast: boolean;
+	/** Active stream key — used to select the matching episode array. */
+	readonly currentStreamKey: string;
+	/**
+	 * Currently-playing enclosure URL — drives the aria-current marker on
+	 * the matching row. Empty string when no episode override is active.
+	 */
+	readonly currentEpisodeUrl: string;
+	/** Fired when a row's play button is clicked. */
+	readonly onEpisodeSelect: (url: string, title: string) => void;
+}
+
+type SortDirection = "newest" | "oldest";
+
+const PAGE_SIZE = 50;
+const SORT_STORAGE_KEY = "cdn:podcast-scroller:sort:v1";
+
+function readStoredSort(): SortDirection {
+	try {
+		const raw = localStorage.getItem(SORT_STORAGE_KEY);
+		if (raw === "oldest") return "oldest";
+	} catch {
+		// localStorage unavailable — fall through to default
+	}
+	return "newest";
+}
+
+function writeStoredSort(value: SortDirection): void {
+	try {
+		localStorage.setItem(SORT_STORAGE_KEY, value);
+	} catch {
+		// non-fatal
+	}
+}
+
+/** Format seconds as H:MM:SS or M:SS — empty string when value is 0/missing. */
+function formatDuration(secs: number): string {
+	if (!secs || secs <= 0 || !Number.isFinite(secs)) return "";
+	const total = Math.floor(secs);
+	const h = Math.floor(total / 3600);
+	const m = Math.floor((total % 3600) / 60);
+	const s = total % 60;
+	if (h > 0) {
+		return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+	}
+	return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+export function PodcastEpisodeScroller({
+	isPodcast,
+	currentStreamKey,
+	currentEpisodeUrl,
+	onEpisodeSelect,
+}: PodcastEpisodeScrollerProps) {
+	const { t, locale } = useTranslation();
+	const [data, setData] = useState<Record<
+		string,
+		PodcastEpisodeData | null
+	> | null>(null);
+	const [sort, setSort] = useState<SortDirection>(() => readStoredSort());
+	const [pageCount, setPageCount] = useState<number>(1);
+
+	// Lazy-load the cache only when this scroller actually renders for a
+	// podcast. Radio listeners never pay the network cost.
+	useEffect(() => {
+		if (!isPodcast) return;
+		let cancelled = false;
+		fetch("/data/podcast-episodes.json")
+			.then((r) => (r.ok ? r.json() : null))
+			.then((d: Record<string, PodcastEpisodeData | null> | null) => {
+				if (cancelled) return;
+				setData(d);
+			})
+			.catch(() => {
+				if (cancelled) return;
+				setData(null);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [isPodcast]);
+
+	// Reset pagination when the active podcast or sort flips so the user
+	// always re-enters at "first page" of the new view.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: pageCount reset is intentional on key/sort change
+	useEffect(() => {
+		setPageCount(1);
+	}, [currentStreamKey, sort]);
+
+	const podcastEntry = data?.[currentStreamKey] ?? null;
+	const allEpisodes = useMemo<PodcastEpisode[]>(() => {
+		const list = podcastEntry?.episodes ?? [];
+		return Array.isArray(list) ? list : [];
+	}, [podcastEntry]);
+
+	const sortedEpisodes = useMemo<PodcastEpisode[]>(() => {
+		const eps = [...allEpisodes];
+		eps.sort((a, b) => {
+			const aTime = a.pubDate ? Date.parse(a.pubDate) : 0;
+			const bTime = b.pubDate ? Date.parse(b.pubDate) : 0;
+			const aValid = Number.isFinite(aTime) ? aTime : 0;
+			const bValid = Number.isFinite(bTime) ? bTime : 0;
+			return sort === "newest" ? bValid - aValid : aValid - bValid;
+		});
+		return eps;
+	}, [allEpisodes, sort]);
+
+	const visibleEpisodes = sortedEpisodes.slice(0, pageCount * PAGE_SIZE);
+	const hasMore = sortedEpisodes.length > visibleEpisodes.length;
+
+	if (!isPodcast) return null;
+
+	const streamDef = STREAMS.find((s) => s.key === currentStreamKey) ?? null;
+	const podcastLabel = streamDef?.label ?? currentStreamKey;
+	const headerText = `${podcastLabel}${t("feedPage.episodeScroller.headerSuffix")}`;
+	const dateLocale = locale === "mx" ? "es-MX" : "en-US";
+	const dateFormatter = new Intl.DateTimeFormat(dateLocale, {
+		dateStyle: "medium",
+	});
+
+	function handleSortChange(next: SortDirection) {
+		setSort(next);
+		writeStoredSort(next);
+	}
+
+	function handleLoadMore() {
+		setPageCount((c) => c + 1);
+	}
+
+	const playAriaTemplate = t("feedPage.episodeScroller.playEpisodeAria");
+	const transcriptLabel = t("feedPage.episodeScroller.transcriptLink");
+	const emptyLabel = t("feedPage.episodeScroller.empty");
+
+	return (
+		<section
+			className="cdn-podcast-scroller"
+			data-testid="podcast-episode-scroller"
+			data-station={currentStreamKey}
+		>
+			<Container header={<Header variant="h3">{headerText}</Header>}>
+				<div className="cdn-podcast-scroller__sort-bar">
+					<SegmentedControl
+						selectedId={sort}
+						onChange={({ detail }) => {
+							const id = detail.selectedId;
+							if (id === "newest" || id === "oldest") {
+								handleSortChange(id);
+							}
+						}}
+						label={t("feedPage.episodeScroller.headerSuffix")}
+						options={[
+							{
+								id: "newest",
+								text: t("feedPage.episodeScroller.sortNewest"),
+							},
+							{
+								id: "oldest",
+								text: t("feedPage.episodeScroller.sortOldest"),
+							},
+						]}
+					/>
+				</div>
+				<ul
+					className="cdn-podcast-scroller__list"
+					aria-live="polite"
+					aria-label={headerText}
+				>
+					{visibleEpisodes.length === 0 ? (
+						<li className="cdn-podcast-scroller__empty">{emptyLabel}</li>
+					) : (
+						visibleEpisodes.map((ep) => {
+							const isCurrent =
+								!!currentEpisodeUrl && ep.enclosureUrl === currentEpisodeUrl;
+							const dateText =
+								ep.pubDate && Number.isFinite(Date.parse(ep.pubDate))
+									? dateFormatter.format(new Date(ep.pubDate))
+									: "";
+							const durationText = formatDuration(ep.duration);
+							const playAria = playAriaTemplate.replace("{title}", ep.title);
+							return (
+								<li
+									key={ep.guid}
+									className={`cdn-podcast-scroller__row${
+										isCurrent ? " cdn-podcast-scroller__row--current" : ""
+									}`}
+									aria-current={isCurrent ? "true" : undefined}
+								>
+									<button
+										type="button"
+										className="cdn-podcast-scroller__play"
+										aria-label={playAria}
+										onClick={() => onEpisodeSelect(ep.enclosureUrl, ep.title)}
+									>
+										<span aria-hidden="true">▶</span>
+									</button>
+									<span
+										className="cdn-podcast-scroller__title"
+										title={ep.title}
+									>
+										{ep.title}
+									</span>
+									{dateText && (
+										<span className="cdn-podcast-scroller__date">
+											{dateText}
+										</span>
+									)}
+									{durationText && (
+										<span className="cdn-podcast-scroller__duration">
+											{durationText}
+										</span>
+									)}
+									{ep.transcriptUrl ? (
+										<a
+											className="cdn-podcast-scroller__transcript"
+											href={ep.transcriptUrl}
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											{transcriptLabel}
+										</a>
+									) : null}
+								</li>
+							);
+						})
+					)}
+				</ul>
+				{hasMore && (
+					<div className="cdn-podcast-scroller__load-more">
+						<Button onClick={handleLoadMore}>
+							{t("feedPage.episodeScroller.loadMore")}
+						</Button>
+					</div>
+				)}
+			</Container>
+		</section>
+	);
+}
+
+export default PodcastEpisodeScroller;

--- a/src/components/podcast-episode-scroller/styles.css
+++ b/src/components/podcast-episode-scroller/styles.css
@@ -1,0 +1,200 @@
+/* Wave 24c — podcast-episode-scroller styles.
+
+   Sits below the persistent player pill and surfaces the active podcast's
+   back-catalog as a vertical list. The container chrome is provided by
+   Cloudscape's Container; everything here styles the inner sort bar + list
+   rows + load-more affordance.
+
+   Light + dark mode parity is achieved by leaning on Cloudscape design
+   tokens (--awsui-color-text-*, --awsui-color-border-*) where available and
+   falling back to the cream + navy CDN palette tokens where Cloudscape
+   doesn't expose a fitting variable.
+
+   prefers-reduced-motion: no animations live here today, but the hook is
+   reserved so future "currently-playing pulse" / row hover transforms
+   honor the user setting without further edits. */
+
+.cdn-podcast-scroller {
+	display: block;
+	width: 100%;
+	margin: 0 0 16px 0;
+	/* let the player pill above breathe — the scroller is conceptually
+	   a continuation of the player, not a separate page region */
+	position: relative;
+	z-index: 1;
+}
+
+.cdn-podcast-scroller__sort-bar {
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+	gap: 8px;
+	margin: 0 0 12px 0;
+}
+
+.cdn-podcast-scroller__list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	max-height: 480px;
+	overflow-y: auto;
+}
+
+.cdn-podcast-scroller__empty {
+	padding: 16px 8px;
+	color: var(--cdn-color-text-low, #8a6a4e);
+	font-style: italic;
+	text-align: center;
+}
+
+.awsui-dark-mode .cdn-podcast-scroller__empty {
+	color: rgba(240, 240, 240, 0.55);
+}
+
+.cdn-podcast-scroller__row {
+	display: grid;
+	grid-template-columns: auto 1fr auto auto auto;
+	align-items: center;
+	gap: 10px;
+	padding: 8px 10px;
+	border-radius: 6px;
+	border: 1px solid var(--cdn-color-border-soft, rgba(139, 90, 43, 0.12));
+	background: var(--cdn-color-surface-soft, rgba(237, 229, 212, 0.55));
+	color: var(--cdn-color-text, #2c1a0e);
+	transition:
+		background-color 0.18s ease,
+		border-color 0.18s ease;
+}
+
+.awsui-dark-mode .cdn-podcast-scroller__row {
+	background: rgba(10, 12, 20, 0.55);
+	color: var(--cdn-color-text-high, rgba(240, 240, 240, 0.87));
+	border-color: rgba(var(--station-primary-mode-rgb, 144, 96, 240), 0.18);
+}
+
+.cdn-podcast-scroller__row:hover {
+	background: rgba(var(--station-primary-mode-rgb, 144, 96, 240), 0.08);
+	border-color: rgba(var(--station-primary-mode-rgb, 144, 96, 240), 0.28);
+}
+
+.cdn-podcast-scroller__row--current {
+	border-color: var(--station-primary-mode, var(--cdn-violet, #9060f0));
+	box-shadow: inset 3px 0 0 0
+		var(--station-primary-mode, var(--cdn-violet, #9060f0));
+}
+
+.cdn-podcast-scroller__play {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	border-radius: 50%;
+	border: 1.5px solid var(--station-primary-mode, var(--cdn-violet, #9060f0));
+	background: transparent;
+	color: var(--station-primary-mode, var(--cdn-violet, #9060f0));
+	cursor: pointer;
+	font-size: 0.7rem;
+	flex-shrink: 0;
+	padding: 0;
+	transition:
+		background-color 0.18s ease,
+		transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.cdn-podcast-scroller__play:hover {
+	background: rgba(var(--station-primary-mode-rgb, 144, 96, 240), 0.12);
+	transform: scale(1.06);
+}
+
+.cdn-podcast-scroller__play:focus-visible {
+	outline: 2px solid var(--station-primary-mode, var(--cdn-violet, #9060f0));
+	outline-offset: 2px;
+}
+
+.cdn-podcast-scroller__title {
+	font-size: var(--cdn-text-sm, 0.875rem);
+	font-weight: 600;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
+}
+
+.cdn-podcast-scroller__date,
+.cdn-podcast-scroller__duration {
+	font-family: var(
+		--cdn-font-mono,
+		ui-monospace,
+		"SF Mono",
+		Menlo,
+		Consolas,
+		monospace
+	);
+	font-size: var(--cdn-text-xs, 0.75rem);
+	color: var(--cdn-color-text-low, #8a6a4e);
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
+.awsui-dark-mode .cdn-podcast-scroller__date,
+.awsui-dark-mode .cdn-podcast-scroller__duration {
+	color: rgba(240, 240, 240, 0.6);
+}
+
+.cdn-podcast-scroller__transcript {
+	font-size: var(--cdn-text-xs, 0.75rem);
+	color: var(--station-primary-mode, var(--cdn-violet, #9060f0));
+	text-decoration: none;
+	border-bottom: 1px dotted
+		color-mix(
+			in srgb,
+			var(--station-primary-mode, var(--cdn-violet, #9060f0)) 45%,
+			transparent
+		);
+	white-space: nowrap;
+	flex-shrink: 0;
+	transition: border-bottom-color 0.18s ease;
+}
+
+.cdn-podcast-scroller__transcript:hover,
+.cdn-podcast-scroller__transcript:focus-visible {
+	border-bottom-color: var(--station-primary-mode, var(--cdn-violet, #9060f0));
+}
+
+.cdn-podcast-scroller__transcript:focus-visible {
+	outline: 2px solid var(--station-primary-mode, var(--cdn-violet, #9060f0));
+	outline-offset: 2px;
+}
+
+.cdn-podcast-scroller__load-more {
+	display: flex;
+	justify-content: center;
+	margin-top: 12px;
+}
+
+@media (max-width: 600px) {
+	.cdn-podcast-scroller__row {
+		grid-template-columns: auto 1fr auto;
+		grid-row-gap: 4px;
+	}
+	.cdn-podcast-scroller__date,
+	.cdn-podcast-scroller__duration,
+	.cdn-podcast-scroller__transcript {
+		grid-column: 2 / -1;
+		justify-self: flex-start;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.cdn-podcast-scroller__row,
+	.cdn-podcast-scroller__play {
+		transition: none;
+	}
+	.cdn-podcast-scroller__play:hover {
+		transform: none;
+	}
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -158,7 +158,16 @@
 		"featuredEventInPersonLabel": "June 2026 in person: Downtown El Paso, Texas",
 		"featuredEventSpotsRemaining": "{count} of {capacity} spots remaining",
 		"featuredEventRsvpPrimary": "RSVP on CloudDelNorte.org",
-		"featuredEventRsvpMeetup": "RSVP on Meetup"
+		"featuredEventRsvpMeetup": "RSVP on Meetup",
+		"episodeScroller": {
+			"headerSuffix": " — episodes",
+			"sortNewest": "Newest first",
+			"sortOldest": "Oldest first",
+			"loadMore": "Load more",
+			"transcriptLink": "transcript",
+			"empty": "No episodes available yet",
+			"playEpisodeAria": "Play {title}"
+		}
 	},
 	"dashboardPage": {
 		"productionOverview": {

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -158,7 +158,16 @@
 		"featuredEventInPersonLabel": "Junio 2026 presencial: centro de El Paso, Texas",
 		"featuredEventSpotsRemaining": "Quedan {count} de {capacity} cupos",
 		"featuredEventRsvpPrimary": "RSVP en CloudDelNorte.org",
-		"featuredEventRsvpMeetup": "RSVP en Meetup"
+		"featuredEventRsvpMeetup": "RSVP en Meetup",
+		"episodeScroller": {
+			"headerSuffix": " — episodios",
+			"sortNewest": "Reciente primero",
+			"sortOldest": "Más viejo primero",
+			"loadMore": "Cargar más",
+			"transcriptLink": "transcripción",
+			"empty": "Aún no hay episodios",
+			"playEpisodeAria": "Reproducir {title}"
+		}
 	},
 	"dashboardPage": {
 		"productionOverview": {

--- a/src/sites/awsug/_layout/index.tsx
+++ b/src/sites/awsug/_layout/index.tsx
@@ -5,9 +5,15 @@ import ContentLayout from "@cloudscape-design/components/content-layout";
 import HelpPanel from "@cloudscape-design/components/help-panel";
 import Tabs from "@cloudscape-design/components/tabs";
 import type React from "react";
-import { useState } from "react";
+import { useCallback, useState } from "react";
+import {
+	type ActivePlayerStream,
+	useActivePlayerStream,
+} from "../../../components/persistent-player";
+import { PodcastEpisodeScroller } from "../../../components/podcast-episode-scroller";
 import { SessionExpiredModal } from "../../../components/session-expired-modal";
 import Shell from "../../../layouts/shell";
+import { savePlayerState } from "../../../lib/player-persist";
 import { HelpPanelHome } from "../../../pages/create-meeting/components/help-panel-home";
 import {
 	applyLocale,
@@ -43,6 +49,51 @@ function ToolsPanel() {
 	);
 }
 
+/**
+ * Wave 24c — sibling-of-the-player wiring. Reads the active stream via the
+ * read-only useActivePlayerStream hook (exposed by persistent-player) and
+ * passes the relevant fields into the scroller. The scroller renders nothing
+ * for radio streams, so the wrapper is safe to mount unconditionally — the
+ * vertical reservation only appears when a podcast is active.
+ *
+ * onEpisodeSelect:
+ *   1. persists the chosen enclosure URL via savePlayerState so a page
+ *      reload resumes on the same episode (existing podcast-resume contract)
+ *   2. dispatches the `cdn:player:swap-episode` window event the player
+ *      listens to (read-only on player core: the player adds the listener,
+ *      not refactors existing logic). The player overrides rssAudioUrl +
+ *      starts playback in response.
+ */
+function PodcastScrollerSibling() {
+	const stream: ActivePlayerStream = useActivePlayerStream();
+	const handleEpisodeSelect = useCallback(
+		(url: string, _title: string) => {
+			if (!stream.stationKey) return;
+			savePlayerState({
+				stationKey: stream.stationKey,
+				stationUrl: url,
+				stationLabel: stream.stationLabel ?? stream.stationKey,
+				podcastEpisodeUrl: url,
+				podcastCurrentTime: 0,
+			});
+			window.dispatchEvent(
+				new CustomEvent("cdn:player:swap-episode", {
+					detail: { url, title: _title },
+				}),
+			);
+		},
+		[stream.stationKey, stream.stationLabel],
+	);
+	return (
+		<PodcastEpisodeScroller
+			isPodcast={stream.isPodcast}
+			currentStreamKey={stream.stationKey ?? ""}
+			currentEpisodeUrl={stream.currentEpisodeUrl ?? ""}
+			onEpisodeSelect={handleEpisodeSelect}
+		/>
+	);
+}
+
 export default function AwsugLayout({
 	children,
 }: {
@@ -70,6 +121,7 @@ export default function AwsugLayout({
 			identityHref="/"
 		>
 			<PendingApprovalBanner />
+			<PodcastScrollerSibling />
 			<ContentLayout>{children}</ContentLayout>
 			<SessionExpiredModal />
 		</Shell>

--- a/src/sites/awsug/_layout/styles.css
+++ b/src/sites/awsug/_layout/styles.css
@@ -2,3 +2,11 @@
    shell/styles.css already sets navigation-container, side-navigation,
    awsui_layout-main, and awsui_content-layout to transparent (with !important
    on layout-main). No additional overrides needed here. */
+
+/* Wave 24c — podcast-episode-scroller sits between PendingApprovalBanner and
+   ContentLayout. The wrapper picks up the same transparent chrome by default;
+   we only need to give it a touch of horizontal breathing room so the
+   Container chrome doesn't crash into the AppLayout content gutters. */
+.cdn-podcast-scroller {
+	margin-bottom: 12px;
+}


### PR DESCRIPTION
New PodcastEpisodeScroller component mounted alongside the persistent player (sibling, not core refactor) when isPodcast. Cloudscape SegmentedControl sort (newest/oldest, localStorage), 50-episode cap with load-more pagination, transcript link surfaced when <podcast:transcript> tag present in feed. 

scripts/fetch-feeds.mjs extended: per-podcast episodes[] array with guid + title + pubDate + duration (HH:MM:SS / MM:SS / int parse) + enclosureUrl + optional transcriptUrl. Live run produced 42-50 episodes per podcast.

Persistent-player additive only: useActivePlayerStream hook (named export) + 1 publish-state effect + 1 episode-swap CustomEvent listener. Existing audio/health/podcast-resume logic untouched.

7 new i18n keys (en + es). 7 new vitest cases. 634/634 tests pass.