### PR TITLE
feat(brand): wave 29a — real meetup SVG, brand star on speakeasy, kill the red, primary/secondary CTA differentiation

### DIFF
--- a/src/components/brand-button/__tests__/brand-button.test.tsx
+++ b/src/components/brand-button/__tests__/brand-button.test.tsx
@@ -20,19 +20,50 @@ describe("MeetupRsvpButton", () => {
 		expect(a).toHaveAttribute("rel", "noreferrer");
 	});
 
-	it("renders the inline Meetup mark SVG (white M on red circle)", () => {
+	it("renders the canonical Simple Icons Meetup mark via inline SVG <title>", () => {
 		const { container } = render(
 			<MeetupRsvpButton href="#" label="RSVP on Meetup" />,
 		);
 		expect(container.querySelector("svg title")?.textContent).toBe("Meetup");
 	});
 
-	it("applies the meetup variant class for brand styling", () => {
+	it("Meetup mark path is filled white in both variants for visual consistency", () => {
+		const { container: redContainer } = render(
+			<MeetupRsvpButton href="#" label="RSVP on Meetup" />,
+		);
+		const redPath = redContainer.querySelector(
+			".cdn-brand-btn__mark path",
+		);
+		expect(redPath?.getAttribute("fill")).toBe("#FFFFFF");
+
+		const { container: violetContainer } = render(
+			<MeetupRsvpButton href="#" label="RSVP on Meetup" variant="violet" />,
+		);
+		const violetPath = violetContainer.querySelector(
+			".cdn-brand-btn__mark path",
+		);
+		expect(violetPath?.getAttribute("fill")).toBe("#FFFFFF");
+	});
+
+	it("applies the meetup variant class for brand styling (default red)", () => {
 		const { container } = render(
 			<MeetupRsvpButton href="#" label="RSVP on Meetup" />,
 		);
 		const link = container.querySelector("a");
 		expect(link?.className).toContain("cdn-brand-btn--meetup");
+		expect(link?.className).not.toContain("cdn-brand-btn--meetup-violet");
+	});
+
+	it("applies the meetup-violet variant class when variant='violet'", () => {
+		const { container } = render(
+			<MeetupRsvpButton
+				href="#"
+				label="RSVP on Meetup"
+				variant="violet"
+			/>,
+		);
+		const link = container.querySelector("a");
+		expect(link?.className).toContain("cdn-brand-btn--meetup-violet");
 	});
 
 	it("aria-label includes 'opens in new tab' for screen reader context", () => {
@@ -55,13 +86,14 @@ describe("SpeakeasyRsvpButton", () => {
 		expect(a).not.toHaveAttribute("target");
 	});
 
-	it("renders the brand star mark SVG", () => {
+	it("renders the brand logo as an <img> with 'Cloud Del Norte' alt", () => {
 		const { container } = render(
 			<SpeakeasyRsvpButton href="#" label="RSVP for Speakeasy" />,
 		);
-		expect(container.querySelector("svg title")?.textContent).toBe(
-			"Cloud Del Norte",
-		);
+		const img = container.querySelector("img.cdn-brand-btn__mark");
+		expect(img).not.toBeNull();
+		expect(img?.getAttribute("src")).toBe("/brand/logo.svg");
+		expect(img?.getAttribute("alt")).toBe("Cloud Del Norte");
 	});
 
 	it("applies the speakeasy variant class for brand styling", () => {

--- a/src/components/brand-button/meetup-rsvp.tsx
+++ b/src/components/brand-button/meetup-rsvp.tsx
@@ -11,25 +11,28 @@ interface MeetupRsvpButtonProps {
 	className?: string;
 	/**
 	 * Visual variant. Defaults to `"red"` — the Meetup brand red (#ED1C40).
-	 * Pass `"violet"` to render the same M mark + label inside the Cloud
-	 * Del Norte purple→violet gradient (used on the featured-event card
-	 * where the page voice explicitly excludes red).
+	 * Pass `"violet"` to render the Meetup mark + label inside the Cloud
+	 * Del Norte purple→violet gradient (used on event cards where the page
+	 * voice excludes red — e.g. featured-event, upcoming-virtual-event).
+	 *
+	 * The violet variant also reads as a "secondary" CTA: smaller max-width,
+	 * lighter font weight, slightly muted opacity. The on-site Speakeasy
+	 * RSVP is the primary path; this is the alternative path.
 	 */
 	variant?: MeetupRsvpVariant;
 }
 
 /**
  * Meetup-branded RSVP CTA. Renders a styled <a> using either Meetup's brand
- * red (#ED1C40) — the default — or a brand-violet override. The mark is
- * constructed as an inline SVG (filled circle + M strokes) so we get
- * brand instant-recognition without embedding Meetup's trademarked swarm
- * logo. Always opens in a new tab with rel="noreferrer".
+ * red (#ED1C40) — the default — or a brand-violet override. The mark is the
+ * canonical "Meetup swarm" glyph (Simple Icons CC0). The mark always renders
+ * white so it reads cleanly on both red and violet backgrounds. Always opens
+ * in a new tab with rel="noreferrer".
  *
  * Variants:
- *   - "red"    — default. White circle + Meetup-red M, red gradient bg.
- *   - "violet" — featured-event override. White circle + cdn-purple M
- *                stroke, sitting on the brand purple→violet gradient.
- *                Avoids the page-level "no red" rule on that surface.
+ *   - "red"    — default. White swarm on red gradient bg.
+ *   - "violet" — secondary CTA on event cards. White swarm on
+ *                purple→violet gradient bg.
  */
 export default function MeetupRsvpButton({
 	href,
@@ -44,7 +47,6 @@ export default function MeetupRsvpButton({
 	const cls = ["cdn-brand-btn", variantClass, className]
 		.filter(Boolean)
 		.join(" ");
-	const mStrokeColor = variant === "violet" ? "#5a1f8a" : "#ED1C40";
 	return (
 		<a
 			className={cls}
@@ -62,14 +64,9 @@ export default function MeetupRsvpButton({
 				focusable="false"
 			>
 				<title>Meetup</title>
-				<circle cx="12" cy="12" r="11" fill="#FFFFFF" />
 				<path
-					d="M6.5 8 L8.5 16 L12 11 L15.5 16 L17.5 8"
-					stroke={mStrokeColor}
-					strokeWidth="2.4"
-					strokeLinecap="round"
-					strokeLinejoin="round"
-					fill="none"
+					fill="#FFFFFF"
+					d="M6.98.555a.518.518 0 0 0-.105.011.53.53 0 1 0 .222 1.04.533.533 0 0 0 .409-.633.531.531 0 0 0-.526-.418zm6.455.638a.984.984 0 0 0-.514.143.99.99 0 1 0 1.02 1.699.99.99 0 0 0 .34-1.36.992.992 0 0 0-.846-.482zm-3.03 2.236a5.029 5.029 0 0 0-4.668 3.248 3.33 3.33 0 0 0-1.46.551 3.374 3.374 0 0 0-.94 4.562 3.634 3.634 0 0 0-.605 4.649 3.603 3.603 0 0 0 2.465 1.597c.018.732.238 1.466.686 2.114a3.9 3.9 0 0 0 5.423.992c.068-.047.12-.106.184-.157.987.881 2.47 1.026 3.607.24a2.91 2.91 0 0 0 1.162-1.69 4.238 4.238 0 0 0 2.584-.739 4.274 4.274 0 0 0 1.19-5.789 2.466 2.466 0 0 0 .433-3.308 2.448 2.448 0 0 0-1.316-.934 4.436 4.436 0 0 0-.776-2.873 4.467 4.467 0 0 0-5.195-1.656 5.106 5.106 0 0 0-2.773-.807zm-5.603.817a.759.759 0 0 0-.423.135.758.758 0 1 0 .863 1.248.757.757 0 0 0 .193-1.055.758.758 0 0 0-.633-.328zm15.994 2.37a.842.842 0 0 0-.47.151.845.845 0 1 0 1.175.215.845.845 0 0 0-.705-.365zm-8.15 1.028c.063 0 .124.005.182.014a.901.901 0 0 1 .45.187c.169.134.273.241.432.393.24.227.414.089.534.02.208-.122.369-.219.984-.208.633.011 1.363.237 1.514 1.317.168 1.199-1.966 4.289-1.817 5.722.106 1.01 1.815.299 1.96 1.22.186 1.198-2.136.753-2.667.493-.832-.408-1.337-1.34-1.12-2.26.16-.688 1.7-3.498 1.757-3.93.059-.44-.177-.476-.324-.484-.19-.01-.34.081-.526.362-.169.255-2.082 4.085-2.248 4.398-.296.56-.67.694-1.044.674-.548-.029-.798-.32-.72-.848.047-.31 1.26-3.049 1.323-3.476.039-.265-.013-.546-.275-.68-.263-.135-.572.07-.664.227-.128.215-1.848 4.706-2.032 5.038-.316.576-.65.76-1.152.784-1.186.056-2.065-.92-1.678-2.116.173-.532 1.316-4.571 1.895-5.599.389-.69 1.468-1.216 2.217-.892.387.167.925.437 1.084.507.366.163.759-.277.913-.412.155-.134.302-.276.49-.357.142-.06.343-.095.532-.094zm10.88 2.057a.468.468 0 0 0-.093.011.467.467 0 0 0-.36.555.47.47 0 0 0 .557.36.47.47 0 0 0 .36-.557.47.47 0 0 0-.464-.37zm-22.518.81a.997.997 0 0 0-.832.434 1 1 0 1 0 1.39-.258 1 1 0 0 0-.558-.176zm21.294 2.094a.635.635 0 0 0-.127.013.627.627 0 0 0-.48.746.628.628 0 0 0 .746.483.628.628 0 0 0 .482-.746.63.63 0 0 0-.621-.496zm-18.24 6.097a.453.453 0 0 0-.092.012.464.464 0 1 0 .195.908.464.464 0 0 0 .356-.553.465.465 0 0 0-.459-.367zm13.675 1.55a1.044 1.044 0 0 0-.583.187 1.047 1.047 0 1 0 1.456.265 1.044 1.044 0 0 0-.873-.451zM11.4 22.154a.643.643 0 0 0-.36.115.646.646 0 0 0-.164.899.646.646 0 0 0 .899.164.646.646 0 0 0 .164-.898.646.646 0 0 0-.54-.28z"
 				/>
 			</svg>
 			<span className="cdn-brand-btn__label">{label}</span>

--- a/src/components/brand-button/speakeasy-rsvp.tsx
+++ b/src/components/brand-button/speakeasy-rsvp.tsx
@@ -10,9 +10,18 @@ interface SpeakeasyRsvpButtonProps {
 }
 
 /**
- * On-site RSVP CTA with Cloud Del Norte brand identity. Renders a styled <a>
- * over a purple→violet gradient with a white 5-point star (the same star mark
- * carried in the UG glyph + favicon). Internal link, no new tab.
+ * On-site RSVP CTA — the PRIMARY action on event cards. Renders a styled <a>
+ * over a purple→violet gradient with the Cloud Del Norte brand logo (the
+ * animated violet star + bulbs) inline as the leading mark. Internal link,
+ * no new tab.
+ *
+ * Design intent: this button reads as PRIMARY (larger, glowing pulse ring)
+ * to encourage on-site signup over the secondary external Meetup CTA.
+ *
+ * The brand logo at /brand/logo.svg is referenced as <img>; modern browsers
+ * render the SVG's internal CSS animations (bulb blink, arm pulse) inside
+ * <img src> contexts, adding a subtle motion accent at the 22×22 mark size.
+ * `prefers-reduced-motion` is handled inside the SVG itself.
  */
 export default function SpeakeasyRsvpButton({
 	href,
@@ -24,20 +33,13 @@ export default function SpeakeasyRsvpButton({
 		.join(" ");
 	return (
 		<a className={cls} href={href} aria-label={label}>
-			<svg
-				className="cdn-brand-btn__mark"
-				viewBox="0 0 24 24"
-				width="22"
-				height="22"
-				aria-hidden="true"
-				focusable="false"
-			>
-				<title>Cloud Del Norte</title>
-				<path
-					d="M12 2 L14.6 9.2 L22 9.6 L16.2 14.2 L18.2 21.4 L12 17.3 L5.8 21.4 L7.8 14.2 L2 9.6 L9.4 9.2 Z"
-					fill="#FFFFFF"
-				/>
-			</svg>
+			<img
+				className="cdn-brand-btn__mark cdn-brand-btn__mark--logo"
+				src="/brand/logo.svg"
+				alt="Cloud Del Norte"
+				width={22}
+				height={22}
+			/>
 			<span className="cdn-brand-btn__label">{label}</span>
 			<svg
 				className="cdn-brand-btn__chevron"

--- a/src/components/brand-button/styles.css
+++ b/src/components/brand-button/styles.css
@@ -9,6 +9,13 @@
    - prefers-reduced-motion respected on hover transform
    - box-sizing: border-box so padding doesn't push past max-width
    - label clamps to a single line with ellipsis on narrow viewports
+
+   Wave 29a hierarchy:
+   - Speakeasy (on-site, primary): elevated — larger padding, heavier weight,
+     pulsing glow ring to draw the eye to the on-site signup path.
+   - Meetup violet (secondary): demoted — smaller max-width, lighter weight,
+     muted opacity. Reads as the "alternative" path on the same card.
+   - Meetup red (default outside event cards): unchanged — Meetup brand red.
    -------------------------------------------------------------------------- */
 
 .cdn-brand-btn {
@@ -41,6 +48,7 @@
 		background 160ms ease;
 	user-select: none;
 	overflow: hidden;
+	position: relative;
 }
 
 .cdn-brand-btn:focus-visible {
@@ -51,6 +59,13 @@
 .cdn-brand-btn__mark {
 	flex-shrink: 0;
 	display: block;
+}
+
+.cdn-brand-btn__mark--logo {
+	/* The brand logo is a 1024×1024 raster-of-violet artwork. At 22×22 it
+	   renders as a tiny accent. A subtle drop-shadow lifts it off the
+	   purple→violet gradient bg so the white star arms still read. */
+	filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.45));
 }
 
 .cdn-brand-btn__label {
@@ -87,8 +102,12 @@
 
 .cdn-brand-btn--meetup {
 	background-color: #ed1c40;
-	color: #ffffff;
+	color: #ffffff !important;
 	box-shadow: 0 2px 6px rgba(237, 28, 64, 0.25);
+}
+
+.cdn-brand-btn--meetup .cdn-brand-btn__label {
+	color: #ffffff !important;
 }
 
 .cdn-brand-btn--meetup:hover,
@@ -109,10 +128,15 @@
 }
 
 /* --------------------------------------------------------------------------
-   Variant — Meetup-violet
-   Same M mark + label, but on the Cloud Del Norte purple→violet gradient.
-   Used on surfaces (e.g. featured-event card) that exclude red entirely.
-   Mirrors the speakeasy gradient palette so the two CTAs read as a stack.
+   Variant — Meetup-violet (secondary CTA)
+   Same Meetup mark, on the Cloud Del Norte purple→violet gradient. Visually
+   demoted vs the Speakeasy primary: narrower (max-width 360px), lighter
+   weight (600), slightly muted opacity (0.92). The Speakeasy CTA is the
+   on-site primary path; this is the alternative route to RSVP via Meetup.
+   The cream label color is forced (!important) and a subtle text-shadow
+   lifts it off the purple gradient — fixes the "purple text on purple bg"
+   contrast complaint where some inherited Cloudscape link/cascade rules
+   bled the brand purple onto the label.
    -------------------------------------------------------------------------- */
 
 .cdn-brand-btn--meetup-violet {
@@ -121,15 +145,24 @@
 		var(--cdn-purple, #5a1f8a) 0%,
 		var(--cdn-violet, #9060f0) 100%
 	);
-	color: #faf7f0;
+	color: #faf7f0 !important;
+	max-width: 360px;
+	font-weight: 600;
+	opacity: 0.92;
 	box-shadow:
 		0 0 0 2px rgba(255, 153, 0, 0.4),
 		0 4px 14px rgba(90, 31, 138, 0.3);
 }
 
+.cdn-brand-btn--meetup-violet .cdn-brand-btn__label {
+	color: #faf7f0 !important;
+	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+}
+
 .cdn-brand-btn--meetup-violet:hover,
 .cdn-brand-btn--meetup-violet:focus-visible {
 	background: linear-gradient(135deg, #491678 0%, #7e4ee4 100%);
+	opacity: 1;
 	box-shadow:
 		0 0 0 2px rgba(255, 153, 0, 0.7),
 		0 8px 20px rgba(90, 31, 138, 0.45);
@@ -150,8 +183,14 @@
 }
 
 /* --------------------------------------------------------------------------
-   Variant — Speakeasy (on-site Cloud Del Norte RSVP)
-   Brand purple→violet gradient, white star mark, AWS-orange focus ring.
+   Variant — Speakeasy (on-site Cloud Del Norte RSVP, PRIMARY)
+   Brand purple→violet gradient with the brand logo as the mark. Promoted
+   visually:
+     - Slightly increased padding (12px 18px) and font-size (1rem)
+     - Cream label forced (!important) + text-shadow for contrast
+     - Pulsing outer glow ring (cdn-speakeasy-glow) to draw the eye
+   Goal: this primary CTA outweighs the secondary Meetup violet button so
+   on-site signup is visibly the encouraged path.
    -------------------------------------------------------------------------- */
 
 .cdn-brand-btn--speakeasy {
@@ -160,32 +199,65 @@
 		var(--cdn-purple, #5a1f8a) 0%,
 		var(--cdn-violet, #9060f0) 100%
 	);
-	color: #faf7f0;
+	color: #faf7f0 !important;
+	padding: 12px 18px;
+	font-size: var(--cdn-text-base, 1rem);
+	font-weight: 700;
 	box-shadow:
-		0 0 0 2px rgba(255, 153, 0, 0.4),
-		0 4px 14px rgba(90, 31, 138, 0.3);
+		0 0 0 2px rgba(255, 153, 0, 0.55),
+		0 6px 18px rgba(90, 31, 138, 0.35);
+	animation: cdn-speakeasy-glow 3.2s ease-in-out infinite;
+}
+
+.cdn-brand-btn--speakeasy .cdn-brand-btn__label {
+	color: #faf7f0 !important;
+	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
 }
 
 .cdn-brand-btn--speakeasy:hover,
 .cdn-brand-btn--speakeasy:focus-visible {
 	background: linear-gradient(135deg, #491678 0%, #7e4ee4 100%);
 	box-shadow:
-		0 0 0 2px rgba(255, 153, 0, 0.7),
-		0 8px 20px rgba(90, 31, 138, 0.45);
+		0 0 0 2px rgba(255, 153, 0, 0.85),
+		0 10px 24px rgba(90, 31, 138, 0.5);
 	transform: translateY(-1px);
 }
 
 .cdn-brand-btn--speakeasy:active {
 	transform: translateY(0);
 	box-shadow:
-		0 0 0 2px rgba(255, 153, 0, 0.55),
-		0 2px 6px rgba(90, 31, 138, 0.35);
+		0 0 0 2px rgba(255, 153, 0, 0.7),
+		0 2px 8px rgba(90, 31, 138, 0.35);
 }
 
 .awsui-dark-mode .cdn-brand-btn--speakeasy {
 	box-shadow:
-		0 0 0 2px rgba(255, 153, 0, 0.55),
-		0 4px 18px rgba(144, 96, 240, 0.45);
+		0 0 0 2px rgba(255, 153, 0, 0.7),
+		0 6px 22px rgba(144, 96, 240, 0.55);
+}
+
+/* Outer glow pulse — gently breathing AWS-orange ring around the primary
+   CTA. Same cadence as the brand bulbs (~3s) so the rhythm feels native. */
+@keyframes cdn-speakeasy-glow {
+	0%,
+	100% {
+		box-shadow:
+			0 0 0 2px rgba(255, 153, 0, 0.55),
+			0 6px 18px rgba(90, 31, 138, 0.35),
+			0 0 0 0 rgba(255, 153, 0, 0.35);
+	}
+	50% {
+		box-shadow:
+			0 0 0 2px rgba(255, 153, 0, 0.75),
+			0 8px 22px rgba(90, 31, 138, 0.45),
+			0 0 0 8px rgba(255, 153, 0, 0);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.cdn-brand-btn--speakeasy {
+		animation: none;
+	}
 }
 
 /* Stack adjustment — when two brand buttons sit in a vertical SpaceBetween
@@ -194,7 +266,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 10px;
-	align-items: stretch;
+	align-items: center;
 	/* clamp the stack so buttons never bleed past the card edge regardless
 	   of the parent's content-box; matches the per-button max-width rail. */
 	width: 100%;

--- a/src/pages/feed/components/__tests__/upcoming-virtual-event.test.tsx
+++ b/src/pages/feed/components/__tests__/upcoming-virtual-event.test.tsx
@@ -41,10 +41,34 @@ describe("UpcomingVirtualEvent", () => {
 		expect(screen.getByText(/mayo/i)).toBeInTheDocument();
 	});
 
-	it("renders the RSVP button with target=_blank", () => {
+	it("renders the RSVP button with target=_blank and the violet (no-red) variant", () => {
 		renderWithLocale("us");
 		const btn = screen.getByRole("link", { name: /RSVP on Meetup/i });
 		expect(btn).toHaveAttribute("target", "_blank");
+		expect(btn).toHaveAttribute(
+			"href",
+			"https://www.meetup.com/awsglobalcommunitygatherings/events/314332142/",
+		);
+		// Wave 29a — must NOT use the red variant on this card.
+		expect(btn.className).toContain("cdn-brand-btn--meetup-violet");
+		expect(btn.className).not.toMatch(/cdn-brand-btn--meetup(?!-violet)/);
+	});
+
+	it("renders the brand mark (not literal 'UG' text) with the AWS UG aria-label", () => {
+		const { container } = renderWithLocale("us");
+		// New class name reflects the brand semantic.
+		const mark = container.querySelector(
+			".feed-upcoming-virtual-event__brand-mark",
+		);
+		expect(mark).not.toBeNull();
+		// Brand logo image is the mark content.
+		const img = mark?.querySelector("img");
+		expect(img).not.toBeNull();
+		expect(img?.getAttribute("src")).toBe("/brand/logo.svg");
+		// Old literal 'UG' span must be gone.
+		expect(mark?.textContent ?? "").not.toMatch(/\bUG\b/);
+		// Accessible label (AWS User Group mark) is preserved on the wrapper.
+		expect(mark?.getAttribute("aria-label")).toBe("AWS User Group mark");
 	});
 
 	it("renders both light and dark image variants with proper alt text and lazy loading", () => {

--- a/src/pages/feed/components/upcoming-virtual-event.tsx
+++ b/src/pages/feed/components/upcoming-virtual-event.tsx
@@ -83,11 +83,18 @@ export default function UpcomingVirtualEvent() {
 					</Box>
 					<div className="feed-upcoming-virtual-event__featured-talk">
 						<span
-							className="feed-upcoming-virtual-event__ug-mark"
+							className="feed-upcoming-virtual-event__brand-mark"
 							role="img"
 							aria-label={t("feedPage.upcomingVirtualEventUgMarkLabel")}
 						>
-							<span aria-hidden="true">UG</span>
+							<img
+								src="/brand/logo.svg"
+								alt=""
+								aria-hidden="true"
+								className="feed-upcoming-virtual-event__brand-mark-img"
+								width={40}
+								height={40}
+							/>
 						</span>
 						<div className="feed-upcoming-virtual-event__featured-talk-body">
 							<span className="feed-upcoming-virtual-event__featured-talk-badge">
@@ -105,6 +112,7 @@ export default function UpcomingVirtualEvent() {
 						<MeetupRsvpButton
 							href={RSVP_URL}
 							label={t("feedPage.upcomingVirtualEventRsvp")}
+							variant="violet"
 						/>
 					</div>
 				</SpaceBetween>

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -1888,7 +1888,7 @@
 	border-color: rgba(144, 96, 240, 0.4);
 }
 
-.feed-upcoming-virtual-event__ug-mark {
+.feed-upcoming-virtual-event__brand-mark {
 	flex-shrink: 0;
 	width: 56px;
 	height: 56px;
@@ -1902,25 +1902,30 @@
 		var(--cdn-violet, #9060f0) 100%
 	);
 	color: #faf7f0;
-	font-family: "Cinzel", "Times New Roman", serif;
-	font-style: italic;
-	font-weight: 700;
-	font-size: 22px;
-	letter-spacing: 0.04em;
 	box-shadow:
 		0 0 0 2px rgba(255, 153, 0, 0.55),
 		0 4px 14px rgba(90, 31, 138, 0.35);
-	animation: cdn-ug-mark-pulse 2.6s ease-in-out infinite;
+	animation: cdn-brand-mark-pulse 2.6s ease-in-out infinite;
 	user-select: none;
+	overflow: hidden;
 }
 
-.awsui-dark-mode .feed-upcoming-virtual-event__ug-mark {
+.feed-upcoming-virtual-event__brand-mark-img {
+	width: 40px;
+	height: 40px;
+	display: block;
+	/* Drop-shadow lifts the violet star arms off the violet gradient bg
+	   so the brand mark still reads at this 56px disc scale. */
+	filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.45));
+}
+
+.awsui-dark-mode .feed-upcoming-virtual-event__brand-mark {
 	box-shadow:
 		0 0 0 2px rgba(255, 153, 0, 0.7),
 		0 4px 16px rgba(144, 96, 240, 0.5);
 }
 
-@keyframes cdn-ug-mark-pulse {
+@keyframes cdn-brand-mark-pulse {
 	0%,
 	100% {
 		transform: scale(1);
@@ -1939,7 +1944,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.feed-upcoming-virtual-event__ug-mark {
+	.feed-upcoming-virtual-event__brand-mark {
 		animation: none;
 	}
 }


### PR DESCRIPTION
Six concerns Bryan flagged on the june 3 + AWS gatherings card buttons, single atomic commit.

## what ships

1. **Real Meetup mark** — Simple Icons CC0 swarm SVG replaces the hand-drawn zig-zag ("updown w"). White fill on both red and violet variants for visual continuity.
2. **Brand star on Speakeasy** — `<img src="/brand/logo.svg" alt="Cloud Del Norte">` replaces the hand-drawn 5-point star path. Internal SVG animations (bulb blink, arm pulse) play at 22×22 inside the button.
3. **Red eliminated from AWS gatherings card** — `variant="violet"` now passed to MeetupRsvpButton on upcoming-virtual-event.tsx. Zero hex literals `#ED1C40\|#d11636\|#b91230` remain in any feed component.
4. **Brand mark replaces literal UG text** — `<span>UG</span>` gone from upcoming-virtual-event.tsx; brand logo img renders inside the existing 56×56 animated disc. CSS renamed `__ug-mark` → `__brand-mark`, keyframe `cdn-ug-mark-pulse` → `cdn-brand-mark-pulse`.
5. **Primary/secondary differentiation** — Speakeasy elevated (larger, weight 700, AWS-orange breathing glow ring 3.2s). Meetup-violet demoted (max-width 360 vs 480, weight 600, opacity 0.92 → 1.0 on hover). Visual hierarchy now signals on-site is the encouraged path.
6. **Cream font + text-shadow** — `color: #faf7f0 !important` on label + 0 1px 2px black text-shadow forces high-contrast cream text on the purple gradient, overriding any inherited cascade.

## gates
- biome ci: 0 errors
- npm run build: PASS for main, auth, awsug
- vitest: 657 / 657 PASS (16 new/updated tests across brand-button + upcoming-virtual-event)
- accessibility: prefers-reduced-motion respected on speakeasy glow + brand-mark pulse
- red grep: zero literal red hex codes in feed components
- UG grep: zero literal UG text in components