### PR TITLE
fix(test): podcast-episode-scroller test uses JSX (unblocks deploy)

### DIFF
--- a/src/components/brand-button/__tests__/brand-button.test.tsx
+++ b/src/components/brand-button/__tests__/brand-button.test.tsx
@@ -31,9 +31,7 @@ describe("MeetupRsvpButton", () => {
 		const { container: redContainer } = render(
 			<MeetupRsvpButton href="#" label="RSVP on Meetup" />,
 		);
-		const redPath = redContainer.querySelector(
-			".cdn-brand-btn__mark path",
-		);
+		const redPath = redContainer.querySelector(".cdn-brand-btn__mark path");
 		expect(redPath?.getAttribute("fill")).toBe("#FFFFFF");
 
 		const { container: violetContainer } = render(
@@ -56,11 +54,7 @@ describe("MeetupRsvpButton", () => {
 
 	it("applies the meetup-violet variant class when variant='violet'", () => {
 		const { container } = render(
-			<MeetupRsvpButton
-				href="#"
-				label="RSVP on Meetup"
-				variant="violet"
-			/>,
+			<MeetupRsvpButton href="#" label="RSVP on Meetup" variant="violet" />,
 		);
 		const link = container.querySelector("a");
 		expect(link?.className).toContain("cdn-brand-btn--meetup-violet");

--- a/src/components/podcast-episode-scroller/__tests__/index.test.tsx
+++ b/src/components/podcast-episode-scroller/__tests__/index.test.tsx
@@ -90,7 +90,7 @@ import { LocaleProvider } from "../../../contexts/locale-context";
 import { PodcastEpisodeScroller } from "../index";
 
 function withLocale(node: React.ReactNode) {
-	return React.createElement(LocaleProvider, { locale: "us" }, node);
+	return <LocaleProvider locale="us">{node}</LocaleProvider>;
 }
 
 const FIXED_NEWEST = "2026-05-15T00:00:00.000Z";


### PR DESCRIPTION
Wave 28d's test triggered TS2769 because LocaleProviderProps requires children in props, but the test passed children as the third createElement arg. The biome `noChildrenProp` rule and TS strict prop check disagreed. Wave 29a flagged this out-of-scope; it's now blocking deploys.

Fix: JSX directly. `<LocaleProvider locale="us">{node}</LocaleProvider>` satisfies both. One-line surgical fix, no behavior change. Plus a biome format fix on brand-button test (auto-applied).