### PR TITLE
copy(feed): replace '48 of 50 spots remaining' with 'Limited space — RSVP now'

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -156,7 +156,7 @@
 		"upcomingVirtualEventFeaturedTalkTitle": "A Migration Story: After 240 Consecutive Months, I Avoided a Charge From Microsoft",
 		"upcomingVirtualEventUgMarkLabel": "AWS User Group mark",
 		"featuredEventInPersonLabel": "June 2026 in person: Downtown El Paso, Texas",
-		"featuredEventSpotsRemaining": "{count} of {capacity} spots remaining",
+		"featuredEventSpotsRemaining": "Limited space — RSVP now",
 		"featuredEventRsvpPrimary": "RSVP on CloudDelNorte.org",
 		"featuredEventRsvpMeetup": "RSVP on Meetup",
 		"episodeScroller": {

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -156,7 +156,7 @@
 		"upcomingVirtualEventFeaturedTalkTitle": "Una historia de migración: después de 240 meses consecutivos, evité un cargo de Microsoft",
 		"upcomingVirtualEventUgMarkLabel": "Marca AWS User Group",
 		"featuredEventInPersonLabel": "Junio 2026 presencial: centro de El Paso, Texas",
-		"featuredEventSpotsRemaining": "Quedan {count} de {capacity} cupos",
+		"featuredEventSpotsRemaining": "Cupo limitado — RSVP ya",
 		"featuredEventRsvpPrimary": "RSVP en CloudDelNorte.org",
 		"featuredEventRsvpMeetup": "RSVP en Meetup",
 		"episodeScroller": {

--- a/src/pages/feed/components/__tests__/featured-event.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-event.test.tsx
@@ -156,10 +156,10 @@ describe("FeaturedEvent", () => {
 		expect(primary).toHaveAttribute("href", expected);
 	});
 
-	it("renders the spots remaining counter (48 of 50 default baseline)", () => {
+	it("renders the limited-space CTA", () => {
 		localStorage.clear();
 		renderWithLocale("us");
-		expect(screen.getByText(/48 of 50 spots remaining/i)).toBeInTheDocument();
+		expect(screen.getByText(/Limited space — RSVP now/i)).toBeInTheDocument();
 	});
 
 	it("inlines the AsciiSmirk SVG inside the description (after the 'game.' hook)", () => {


### PR DESCRIPTION
Bryan's preference — drop the running counter, lead with urgency.

| locale | before | after |
|---|---|---|
| en | {count} of {capacity} spots remaining | Limited space — RSVP now |
| es | Quedan {count} de {capacity} cupos | Cupo limitado — RSVP ya |

`spotsRemaining()` in src/lib/rsvp.ts unchanged — still drives the sold-out state on /rsvp/. Only the visible chip on the featured card swapped from counter to urgency cue. Existing 0-spots gating preserved (chip hides when sold out).