### PR TITLE
feat(feed): wave 32a — remove DON'T MISS badge, transform FEATURED EVENT header into theater marquee with chasing bulbs

### DIFF
--- a/src/pages/feed/components/__tests__/featured-event-scroll.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-event-scroll.test.tsx
@@ -71,7 +71,13 @@ describe("FeaturedEvent — wave 30a scroll-tearing regression", () => {
 
 	it("renders without crashing inside a tall scrollable container", () => {
 		expect(() => renderInsideTallScrollContainer()).not.toThrow();
-		expect(screen.getByText("DON'T MISS")).toBeInTheDocument();
+		// Wave 32a — the original wave 30a regression assert on "DON'T MISS"
+		// (the wave 27a badge copy) is replaced with a marquee-text assert,
+		// since wave 32a removed the in-card badge and replaced the Cloudscape
+		// Header with a custom marquee. The scroll-stability contract is
+		// unchanged: after mount, a stable visible element from the card must
+		// remain in the document.
+		expect(screen.getByText(/Featured event/i)).toBeInTheDocument();
 	});
 
 	it("survives a programmatic window.scrollTo(0, 1000) without unmounting or throwing", () => {
@@ -83,7 +89,9 @@ describe("FeaturedEvent — wave 30a scroll-tearing regression", () => {
 
 		// Card is still in the document — the scroll did not blow up the tree.
 		expect(container.querySelector(".feed-featured-event")).not.toBeNull();
-		expect(screen.getByText("DON'T MISS")).toBeInTheDocument();
+		// Wave 32a — see note above; assert on the marquee header text instead
+		// of the removed DON'T MISS badge.
+		expect(screen.getByText(/Featured event/i)).toBeInTheDocument();
 	});
 
 	it("renders the structural class names that wave 30a CSS targets for tearing mitigation", () => {

--- a/src/pages/feed/components/__tests__/featured-event.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-event.test.tsx
@@ -15,11 +15,6 @@ function renderWithLocale(locale: "us" | "mx") {
 }
 
 describe("FeaturedEvent", () => {
-	it("renders the FEATURED badge (rizz copy: DON'T MISS)", () => {
-		renderWithLocale("us");
-		expect(screen.getByText("DON'T MISS")).toBeInTheDocument();
-	});
-
 	it("renders the v2 event title with link to auth.clouddelnorte.org signup with rsvp return_to", () => {
 		renderWithLocale("us");
 		const link = screen.getByText("Community Happy Hour & Networking Night");
@@ -87,11 +82,10 @@ describe("FeaturedEvent", () => {
 		const { container } = renderWithLocale("us");
 		const layout = container.querySelector(".feed-featured-event__layout");
 		expect(layout).not.toBeNull();
-		// All 9 logical children must render inside the grid layout (badge,
-		// image-area, title, date, in-person, location, description, spots,
-		// buttons). DOM order is the logical reading order — preserved across
-		// the SpaceBetween → grid migration.
-		expect(layout?.querySelector(".feed-featured-event__badge")).not.toBeNull();
+		// Wave 32a — badge slot was removed; 8 logical children remain inside
+		// the grid layout (image-area, title, date, in-person, location,
+		// description, spots, buttons). DOM order is the logical reading
+		// order — preserved across the SpaceBetween → grid migration.
 		expect(
 			layout?.querySelector(".feed-featured-event__image-area"),
 		).not.toBeNull();
@@ -108,6 +102,8 @@ describe("FeaturedEvent", () => {
 		).not.toBeNull();
 		expect(layout?.querySelector(".feed-featured-event__spots")).not.toBeNull();
 		expect(layout?.querySelector(".cdn-brand-btn-stack")).not.toBeNull();
+		// Wave 32a — badge was removed entirely.
+		expect(layout?.querySelector(".feed-featured-event__badge")).toBeNull();
 	});
 
 	it("wraps both light + dark image variants inside the __image-area grid cell wrapper (single grid slot for the pair)", () => {
@@ -126,12 +122,11 @@ describe("FeaturedEvent", () => {
 		expect(darkImg).not.toBeNull();
 	});
 
-	it("preserves DOM reading order: badge → image → title → date → in-person → location → description → spots → buttons (a11y / screen-reader contract)", () => {
+	it("preserves DOM reading order: image → title → date → in-person → location → description → spots → buttons (a11y / screen-reader contract; wave 32a dropped badge slot)", () => {
 		const { container } = renderWithLocale("us");
 		const layout = container.querySelector(".feed-featured-event__layout");
 		expect(layout).not.toBeNull();
 		const expected = [
-			"feed-featured-event__badge",
 			"feed-featured-event__image-area",
 			"feed-featured-event__title",
 			"feed-featured-event__date",
@@ -180,5 +175,53 @@ describe("FeaturedEvent", () => {
 	it("description begins with the new 'Cáele en el trolley' copy in es-MX", () => {
 		renderWithLocale("mx");
 		expect(screen.getByText(/Cáele en el trolley/i)).toBeInTheDocument();
+	});
+
+	// ---------- Wave 32a — theater marquee header ----------
+
+	it("wave 32a — DON'T MISS badge is gone from the card body", () => {
+		const { container } = renderWithLocale("us");
+		expect(screen.queryByText("DON'T MISS")).not.toBeInTheDocument();
+		expect(container.querySelector(".feed-featured-event__badge")).toBeNull();
+	});
+
+	it("wave 32a — renders the theater marquee header with role=heading aria-level=2", () => {
+		const { container } = renderWithLocale("us");
+		const marquee = container.querySelector(".feed-featured-event__marquee");
+		expect(marquee).not.toBeNull();
+		expect(marquee?.getAttribute("role")).toBe("heading");
+		expect(marquee?.getAttribute("aria-level")).toBe("2");
+	});
+
+	it("wave 32a — marquee text contains the localized FEATURED EVENT header string", () => {
+		const { container } = renderWithLocale("us");
+		const marqueeText = container.querySelector(
+			".feed-featured-event__marquee-text",
+		);
+		expect(marqueeText).not.toBeNull();
+		expect(marqueeText?.textContent).toMatch(/Featured event/i);
+	});
+
+	it("wave 32a — marquee renders 16 chasing bulb spans inside an aria-hidden container", () => {
+		const { container } = renderWithLocale("us");
+		const bulbs = container.querySelector(
+			".feed-featured-event__marquee-bulbs",
+		);
+		expect(bulbs).not.toBeNull();
+		expect(bulbs?.getAttribute("aria-hidden")).toBe("true");
+		const dots = bulbs?.querySelectorAll(".feed-featured-event__marquee-bulb");
+		expect(dots?.length).toBe(16);
+	});
+
+	it("wave 32a — each bulb carries an inline --bulb-index custom property for the chase stagger", () => {
+		const { container } = renderWithLocale("us");
+		const dots = container.querySelectorAll(
+			".feed-featured-event__marquee-bulb",
+		);
+		dots.forEach((dot, i) => {
+			// jsdom serializes inline custom properties on the style attribute.
+			const style = dot.getAttribute("style") ?? "";
+			expect(style).toMatch(new RegExp(`--bulb-index:\\s*${i}`));
+		});
 	});
 });

--- a/src/pages/feed/components/featured-event.tsx
+++ b/src/pages/feed/components/featured-event.tsx
@@ -7,6 +7,7 @@ import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import {
 	Component,
+	type CSSProperties,
 	type ErrorInfo,
 	type ReactNode,
 	type SyntheticEvent,
@@ -26,6 +27,10 @@ const RSVP_RETURN_PATH = `/rsvp/?event=${EVENT_ID}`;
 const RSVP_PAGE_URL = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent(RSVP_RETURN_PATH)}`;
 /** Anchor inside the description string after which the inline smirk renders. */
 const SMIRK_ANCHOR = '"game."';
+/** Wave 32a — bulb count traced around the marquee perimeter. 16 spaces evenly
+ *  on a top + bottom row (8 each) so the chase sweep reads as a clean ring at
+ *  every container-query breakpoint without crowding the trapezoid corners. */
+const MARQUEE_BULB_COUNT = 16;
 
 /**
  * Render the description, splicing the AsciiSmirk SVG in after the
@@ -58,6 +63,41 @@ function renderDescription(text: string): ReactNode {
 function hideBrokenImage(event: SyntheticEvent<HTMLImageElement>) {
 	const target = event.currentTarget;
 	target.style.display = "none";
+}
+
+/**
+ * Wave 32a — Theater marquee header.
+ *
+ * Replaces Cloudscape's <Header variant="h2"> with a custom JSX block so
+ * the "FEATURED EVENT" string sits inside a vintage marquee sign with
+ * chasing perimeter bulbs. The wrapper still announces itself as an h2 to
+ * screen readers via role="heading" + aria-level=2 — Cloudscape only
+ * renders an actual <h2> element via its Header component, so the explicit
+ * ARIA role keeps the AT semantics intact when we trade the Cloudscape
+ * heading chrome for custom marquee chrome.
+ *
+ * The bulbs render as decorative children (aria-hidden) and lean on a
+ * shared keyframes animation; per-bulb animation-delay is computed via the
+ * `--bulb-index` custom property so all 16 bulbs share one keyframes rule.
+ * Reduced-motion is handled in CSS — bulbs render statically lit instead
+ * of chasing.
+ */
+function MarqueeHeader({ text }: { text: string }) {
+	return (
+		<div className="feed-featured-event__marquee" role="heading" aria-level={2}>
+			<span className="feed-featured-event__marquee-text">{text}</span>
+			<div className="feed-featured-event__marquee-bulbs" aria-hidden="true">
+				{Array.from({ length: MARQUEE_BULB_COUNT }).map((_, i) => (
+					<span
+						// biome-ignore lint/suspicious/noArrayIndexKey: bulbs are a fixed-length decorative ring
+						key={i}
+						className="feed-featured-event__marquee-bulb"
+						style={{ "--bulb-index": i } as CSSProperties}
+					/>
+				))}
+			</div>
+		</div>
+	);
 }
 
 function FeaturedEventInner() {
@@ -99,31 +139,24 @@ function FeaturedEventInner() {
 	return (
 		<div className="feed-featured-event">
 			<Container
-				header={
-					<Header variant="h2">{t("feedPage.featuredEventHeader")}</Header>
-				}
+				header={<MarqueeHeader text={t("feedPage.featuredEventHeader")} />}
 			>
 				{/* Wave 31a — responsive CSS Grid layout. Replaces the previous
 				    single-column SpaceBetween stack so the card fills available
 				    horizontal space at tablet + desktop breakpoints (Bryan: "tons
 				    of white space that we could responsively fill with some grid
 				    type thinking"). DOM order is the logical reading order
-				    (badge → image → title → date → in-person → location → desc →
-				    spots → buttons); CSS Grid named areas in styles.css remap the
-				    visual placement per breakpoint while keeping screen-reader
-				    and tab order intact. Container queries (`container-type:
-				    inline-size` on .feed-featured-event) drive the breakpoints
-				    off the card's rendered width — the right tool for
-				    component-level responsive layout when the parent grid varies
-				    the card's own track size. */}
+				    (image → title → date → in-person → location → desc → spots →
+				    buttons); CSS Grid named areas in styles.css remap the visual
+				    placement per breakpoint while keeping screen-reader and tab
+				    order intact. Container queries (`container-type: inline-size`
+				    on .feed-featured-event) drive the breakpoints off the card's
+				    rendered width — the right tool for component-level responsive
+				    layout when the parent grid varies the card's own track size.
+				    Wave 32a — the "DON'T MISS" badge slot was removed; locale
+				    key feedPage.featuredEventBadge is preserved for parity but
+				    no longer referenced in this component. */}
 				<div className="feed-featured-event__layout">
-					<Box
-						fontWeight="bold"
-						fontSize="body-s"
-						className="feed-featured-event__badge"
-					>
-						{t("feedPage.featuredEventBadge")}
-					</Box>
 					{/* Image area wraps both light + dark variants so the grid cell
 					    only owns one logical slot — the existing wave 28a theme-
 					    swap CSS (display:none on the off-theme variant) still

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -1161,77 +1161,6 @@
 	z-index: 1;
 }
 
-/* ---------- FEATURED badge — pill with stronger gradient + shimmer sweep ---------- */
-.feed-featured-event__badge {
-	position: relative;
-	display: inline-block;
-	padding: 4px 14px;
-	border-radius: 999px;
-	background-image: linear-gradient(
-		135deg,
-		var(--cdn-purple, #5a1f8a) 0%,
-		var(--cdn-violet, #9060f0) 100%
-	);
-	background-color: var(--cdn-purple, #5a1f8a);
-	color: #faf7f0;
-	font-size: var(--cdn-text-sm, 0.75rem);
-	font-weight: 700;
-	letter-spacing: 0.08em;
-	text-transform: uppercase;
-	overflow: hidden;
-	box-shadow:
-		0 1px 2px rgba(48, 0, 106, 0.3),
-		0 4px 12px -2px var(--cdn-rizz-badge-glow),
-		inset 0 1px 0 rgba(255, 250, 235, 0.32),
-		inset 0 -1px 0 rgba(48, 0, 106, 0.4);
-}
-
-.awsui-dark-mode .feed-featured-event__badge {
-	box-shadow:
-		0 1px 2px rgba(0, 0, 0, 0.5),
-		0 4px 14px -2px var(--cdn-rizz-badge-glow),
-		inset 0 1px 0 rgba(215, 199, 238, 0.28),
-		inset 0 -1px 0 rgba(0, 0, 0, 0.4);
-}
-
-/* Animated shimmer sweep — diagonal highlight crosses the badge every 4.6s.
-   Suppressed in prefers-reduced-motion below. */
-.feed-featured-event__badge::after {
-	content: "";
-	position: absolute;
-	inset: 0;
-	pointer-events: none;
-	background: linear-gradient(
-		115deg,
-		transparent 0%,
-		transparent 38%,
-		var(--cdn-rizz-shimmer) 50%,
-		transparent 62%,
-		transparent 100%
-	);
-	background-size: 220% 100%;
-	background-position: 120% 0;
-	mix-blend-mode: screen;
-	border-radius: inherit;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-	@keyframes feed-featured-badge-shimmer {
-		0% {
-			background-position: 120% 0;
-		}
-		60%,
-		100% {
-			background-position: -40% 0;
-		}
-	}
-
-	.feed-featured-event__badge::after {
-		animation: feed-featured-badge-shimmer 4.6s cubic-bezier(0.4, 0, 0.2, 1)
-			infinite;
-	}
-}
-
 /* ---------- Event image — twin-bloom rim + micro-tilt easter egg ---------- */
 /* wave 28a: vignette-blend mask radial-feathers the image edges into the
    surrounding glass card so the rectangular crop dissolves into the backplate.
@@ -1702,12 +1631,6 @@
 /* ---------- Reduced-motion fallback — strip all animation, keep static
    visuals so the rizz still reads (gradients + glow + shadows remain). */
 @media (prefers-reduced-motion: reduce) {
-	.feed-featured-event__badge::after {
-		animation: none;
-		background-position: 50% 0;
-		opacity: 0.5;
-	}
-
 	.feed-featured-event::after {
 		animation: none;
 		background-position: 50% 0;
@@ -1782,7 +1705,6 @@
 @media (prefers-reduced-motion: no-preference) {
 	body.cdn-scrolling .feed-featured-event,
 	body.cdn-scrolling .feed-featured-event::after,
-	body.cdn-scrolling .feed-featured-event__badge::after,
 	body.cdn-scrolling .feed-featured-event__date-plate,
 	body.cdn-scrolling .awsui-dark-mode .feed-featured-event__date-plate,
 	body.cdn-scrolling .feed-featured-event__date-plate::after,
@@ -1829,7 +1751,6 @@
 	display: grid;
 	grid-template-columns: 1fr;
 	grid-template-areas:
-		"badge"
 		"image"
 		"title"
 		"date"
@@ -1850,12 +1771,9 @@
    area so the grid-template-areas declaration stays the single source of
    truth for placement. justify-self: start on chip-style children keeps
    pills tight to their natural width instead of stretching to fill the
-   cell (preserves the wave 27a v2 inline-block visual). */
-.feed-featured-event__badge {
-	grid-area: badge;
-	justify-self: start;
-}
-
+   cell (preserves the wave 27a v2 inline-block visual). Wave 32a — the
+   "DON'T MISS" badge slot was removed; the layout shifts up one row at
+   every breakpoint. */
 .feed-featured-event__image-area {
 	grid-area: image;
 	/* Wrap both light + dark images. Wave 28a's theme-driven display:none
@@ -1915,8 +1833,7 @@
 		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 		grid-template-areas:
 			"image image"
-			"badge date"
-			"title title"
+			"title date"
 			"in-person spots"
 			"location desc"
 			"buttons buttons";
@@ -1948,7 +1865,6 @@
 	.feed-featured-event__layout {
 		grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
 		grid-template-areas:
-			"image badge"
 			"image title"
 			"image date"
 			"image in-person"
@@ -2271,3 +2187,232 @@
    block above for the consolidated rules (location pill stage-light tint,
    spots-remaining pulsing chip). Older standalone definitions removed in
    wave 25a — all .feed-featured-event__* styling is colocated above. */
+
+/* ---------- Wave 32a — Theater marquee header (FEATURED EVENT) ----------
+   Replaces the Cloudscape <Header variant="h2"> chrome on the June 3
+   featured event card with a vintage marquee sign aesthetic: a rounded
+   backplate with a 2px gold/amber rim on light (deep violet + lavender
+   rim on dark), 3D depth shadow + inset highlight, bold uppercase tight-
+   tracked text, and a chasing string of perimeter bulbs.
+
+   Cloudscape's Container places its `header` slot inside an internal
+   wrapper class (awsui_header_*) with its own padding and bottom-divider.
+   The marquee sits inside that slot; we reset the divider via the wave
+   30a-style attribute selector and let the marquee's own border + shadow
+   carry the visual weight. Typography is locked to the marquee's own
+   font-size + spacing so it doesn't inherit the Cloudscape h2 tokens.
+
+   Bulb chase: 16 bulbs (8 top row + 8 bottom row) traced via flexbox.
+   A shared keyframes (`feed-featured-marquee-chase`) cycles each bulb's
+   opacity 0.3 → 1 → 0.3 over 1.8s; per-bulb animation-delay is computed
+   from the inline `--bulb-index` custom property at calc(var * 0.12s).
+   With 16 bulbs * 120ms stagger = 1.92s sweep, the 1.8s base cycle gives
+   a continuous wrap-around chase with a slight overlap (sprightly, not
+   strobing). Reduced-motion gates the keyframes off and renders bulbs
+   statically lit.
+
+   Scope: only the marquee sign in the Container header. Card body
+   (image, title, date plate, spots chip, buttons) is wave 27a-31a turf
+   and is not touched here. */
+.feed-featured-event__marquee {
+	/* Color tokens — light mode = warm amber + gold rim, the vintage
+	   theater marquee voice. Tokens are scoped to the marquee block so
+	   the rest of the card's purple/violet rizz tokens don't bleed into
+	   the sign. */
+	--cdn-marquee-bg-from: #fff5d6;
+	--cdn-marquee-bg-to: #f4d986;
+	--cdn-marquee-rim: #c98b1b;
+	--cdn-marquee-rim-highlight: rgba(255, 247, 220, 0.85);
+	--cdn-marquee-shadow: rgba(124, 64, 8, 0.32);
+	--cdn-marquee-text: #5a2a06;
+	--cdn-marquee-text-glow: rgba(253, 230, 138, 0.65);
+	--cdn-marquee-bulb-core: #fde68a;
+	--cdn-marquee-bulb-rim: #f59e0b;
+	--cdn-marquee-bulb-halo: rgba(253, 230, 138, 0.7);
+	--cdn-marquee-bulb-dim: rgba(253, 230, 138, 0.32);
+
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 40px;
+	padding: 8px 28px;
+	border-radius: 10px;
+	background: linear-gradient(
+		180deg,
+		var(--cdn-marquee-bg-from) 0%,
+		var(--cdn-marquee-bg-to) 100%
+	);
+	border: 2px solid var(--cdn-marquee-rim);
+	box-shadow:
+		0 1px 0 var(--cdn-marquee-rim-highlight) inset,
+		0 -1px 0 rgba(124, 64, 8, 0.18) inset,
+		0 2px 4px var(--cdn-marquee-shadow),
+		0 8px 18px -6px var(--cdn-marquee-shadow);
+}
+
+.awsui-dark-mode .feed-featured-event__marquee {
+	/* Dark mode = deep violet backplate with a lavender rim. Bulbs stay
+	   warm amber (the chasing-bulb idiom is warm-tungsten across both
+	   modes — what changes is the sign chrome, not the lights). */
+	--cdn-marquee-bg-from: #2a1148;
+	--cdn-marquee-bg-to: #1a0a30;
+	--cdn-marquee-rim: #d7c7ee;
+	--cdn-marquee-rim-highlight: rgba(215, 199, 238, 0.4);
+	--cdn-marquee-shadow: rgba(0, 0, 0, 0.55);
+	--cdn-marquee-text: #fde68a;
+	--cdn-marquee-text-glow: rgba(253, 230, 138, 0.55);
+	--cdn-marquee-bulb-core: #fde68a;
+	--cdn-marquee-bulb-rim: #fbbf24;
+	--cdn-marquee-bulb-halo: rgba(253, 230, 138, 0.6);
+	--cdn-marquee-bulb-dim: rgba(253, 230, 138, 0.28);
+
+	box-shadow:
+		0 1px 0 var(--cdn-marquee-rim-highlight) inset,
+		0 -1px 0 rgba(0, 0, 0, 0.6) inset,
+		0 2px 6px var(--cdn-marquee-shadow),
+		0 12px 24px -6px var(--cdn-marquee-shadow);
+}
+
+/* Headline text — bold uppercase, tight tracking, subtle text-shadow so
+   the lettering reads as emissive against the warm/violet backplate. */
+.feed-featured-event__marquee-text {
+	position: relative;
+	z-index: 1;
+	display: inline-block;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 1rem;
+	font-weight: 800;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--cdn-marquee-text);
+	text-shadow:
+		0 0 6px var(--cdn-marquee-text-glow),
+		0 1px 0 rgba(255, 247, 220, 0.45);
+	line-height: 1.15;
+}
+
+/* Bulb perimeter container — absolutely positioned over the marquee so
+   the bulbs frame the rim without interfering with the centered text.
+   Top + bottom 4px insets place the bulb rows just inside the rim. The
+   grid carries 8 columns × 3 rows: row 1 = top bulbs, row 2 = empty
+   spacer (the marquee text sits behind, visually between rows), row 3
+   = bottom bulbs. Grid auto-placement fills row 1 cols 1-8 with bulbs
+   0-7, then row 3 cols 1-8 with bulbs 8-15. */
+.feed-featured-event__marquee-bulbs {
+	position: absolute;
+	inset: 4px 8px;
+	pointer-events: none;
+	display: grid;
+	grid-template-rows: auto 1fr auto;
+	grid-template-columns: repeat(8, 1fr);
+	align-items: center;
+	justify-items: center;
+}
+
+/* Each bulb is a 6px round dot with a warm amber gradient core + drop-
+   shadow halo. The chase animation oscillates opacity 0.3 → 1 → 0.3 with
+   a brief peak so a single bright bulb appears to travel the rim. */
+.feed-featured-event__marquee-bulb {
+	display: block;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: radial-gradient(
+		circle at 50% 40%,
+		var(--cdn-marquee-bulb-core) 0%,
+		var(--cdn-marquee-bulb-rim) 70%,
+		rgba(245, 158, 11, 0.6) 100%
+	);
+	opacity: 0.6;
+	filter: drop-shadow(0 0 3px var(--cdn-marquee-bulb-halo));
+}
+
+/* Split bulbs into top + bottom rows. Grid auto-flow handles column
+   distribution within each row (cols 1-8 left-to-right). The chase
+   sweeps both rows in parallel left-to-right — reads as twin marquee
+   light strings rather than a single ring traversal, which is the
+   intended bulb-band aesthetic for this short-headline marquee box. */
+.feed-featured-event__marquee-bulb:nth-child(-n + 8) {
+	grid-row: 1;
+}
+
+.feed-featured-event__marquee-bulb:nth-child(n + 9) {
+	grid-row: 3;
+}
+
+/* Chase animation — gated behind prefers-reduced-motion. The chase
+   sweeps the rim by staggering animation-delay per bulb. */
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes feed-featured-marquee-chase {
+		0%,
+		100% {
+			opacity: 0.3;
+			filter: drop-shadow(0 0 2px var(--cdn-marquee-bulb-dim));
+		}
+		15% {
+			opacity: 1;
+			filter: drop-shadow(0 0 6px var(--cdn-marquee-bulb-halo));
+		}
+		35% {
+			opacity: 0.45;
+			filter: drop-shadow(0 0 3px var(--cdn-marquee-bulb-dim));
+		}
+	}
+
+	.feed-featured-event__marquee-bulb {
+		animation: feed-featured-marquee-chase 1.8s linear infinite;
+		animation-delay: calc(var(--bulb-index, 0) * 0.12s);
+	}
+}
+
+/* Reduced-motion fallback — bulbs render statically lit (warm + visible)
+   instead of chasing. Same treatment used elsewhere on this card. */
+@media (prefers-reduced-motion: reduce) {
+	.feed-featured-event__marquee-bulb {
+		animation: none;
+		opacity: 0.85;
+		filter: drop-shadow(0 0 4px var(--cdn-marquee-bulb-halo));
+	}
+}
+
+/* Pause the chase during fast scroll — same scroll-jank-mitigation hook
+   wave 30a wired up for the rest of the card. Skipped under reduced-
+   motion since the animation isn't running there to begin with. */
+@media (prefers-reduced-motion: no-preference) {
+	body.cdn-scrolling .feed-featured-event__marquee-bulb {
+		animation-play-state: paused;
+	}
+}
+
+/* Responsive sizing — scale the marquee text + box height at the same
+   container-query breakpoints the card body uses, so the sign reads
+   proportional to the card width across mobile / tablet / desktop. */
+@container cdn-feed-featured (min-width: 520px) {
+	.feed-featured-event__marquee {
+		min-height: 44px;
+		padding: 10px 36px;
+	}
+
+	.feed-featured-event__marquee-text {
+		font-size: 1.0625rem;
+		letter-spacing: 0.07em;
+	}
+}
+
+@container cdn-feed-featured (min-width: 860px) {
+	.feed-featured-event__marquee {
+		min-height: 48px;
+		padding: 12px 44px;
+	}
+
+	.feed-featured-event__marquee-text {
+		font-size: 1.125rem;
+		letter-spacing: 0.08em;
+	}
+
+	.feed-featured-event__marquee-bulb {
+		width: 7px;
+		height: 7px;
+	}
+}


### PR DESCRIPTION
Two changes to the june 3 featured event card.

## DON'T MISS badge gone

The purple gradient pill is removed. Locale key `feedPage.featuredEventBadge` kept in en-US + es-MX for parity (just unreferenced now). Grid template-areas dropped the `badge` slot at all three container-query breakpoints.

## FEATURED EVENT → theater marquee

The Cloudscape `<Header variant="h2">` is replaced with a custom MarqueeHeader component. Vintage theater marquee aesthetic with a chasing bulb light pattern.

### marquee chrome
- **Light mode**: warm amber backplate (`#fff5d6 → #f4d986` gradient) with `#c98b1b` gold rim, 3D depth via inset highlight + drop shadow
- **Dark mode**: deep indigo-violet backplate (`#2a1148 → #1a0a30`) with lavender rim
- Bold + uppercase + tight tracking with emissive text-shadow

### chasing bulbs
- 16 bulbs arranged in 2 rows of 8 (top + bottom of the marquee box)
- Absolute-overlay 8-col × 3-row grid auto-distributes bulbs with marquee width at every breakpoint — no fixed pixel positions
- Chase animation: each bulb cycles opacity `0.3 → 1 → 0.45 → 0.3` over 1.8s with a brief 15% peak
- Per-bulb stagger via inline `--bulb-index` CSS custom property → `animation-delay: calc(var(--bulb-index) * 0.12s)` → 16 × 120ms = 1.92s sweep against 1.8s base cycle = continuous ring-around perception
- Bulbs stay warm tungsten (`#fde68a` core + `#f59e0b` rim + halo) across both modes — chasing-bulb idiom is mode-invariant; chrome swaps

### accessibility
- `role="heading" aria-level="2"` on the marquee div preserves the H2 semantic Cloudscape Header gave us
- Bulb container `aria-hidden="true"` (decorative)
- prefers-reduced-motion: chase disabled, bulbs render statically lit at 0.85 opacity with warm halo
- No focusable elements added — tab order unchanged

### scroll-pause integration
`body.cdn-scrolling` selector list extended to include marquee animations — wave 30a's scroll-jank contract preserved.

## what's preserved (every prior wave intact)
- 27a v2 perspective + spotlight sweep + title tape + date plate + smirk + spots pulse + image hover
- 28a vignette mask + light/dark image swap
- 29a Meetup SVG + brand star + violet variant + cream label !important
- 30a GPU hints + scroll-pause + error boundary + onError handlers
- 31a responsive grid layout + container queries + DOM reading order

## gates
- biome ci: 0 errors / 538 warnings (baseline)
- npm run build: PASS for main, auth, awsug
- vitest: 20 featured-event + 5 scroll regression all green; 4 unrelated pre-existing maintenance-calendar build-output smoke tests fail in worktree (need lib/ build, baseline issue)