### PR TITLE
style(theme): wave 33d — light mode tone-down (warm off-white bg, softened shadows, reduced saturation)

### DIFF
--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -361,11 +361,15 @@
 :root:not(.awsui-dark-mode) .cdn-card {
 	background-color: var(--cdn-color-surface, #faf7f0);
 	background-image: var(--cdn-card-gradient-light);
+	/* wave 33d — softened the additional inline cream highlight from 0.85 to
+	   0.55 so it doesn't double-up on top of the already-softened rim-light
+	   inset (now 0.6 in tokens.css). prior 0.85 here + 0.85 in --cdn-card-rim-light
+	   stacked into a near-opaque cream rim that read as "everything pops". */
 	box-shadow:
 		var(--cdn-card-rim-light),
-		inset 0 1px 0 rgba(255, 250, 235, 0.85);
+		inset 0 1px 0 rgba(255, 250, 235, 0.55);
 	border-radius: var(--cdn-radius-md, 8px);
-	border: 1px solid rgba(139, 90, 43, 0.22);
+	border: 1px solid rgba(139, 90, 43, 0.18);
 }
 
 @supports (backdrop-filter: blur(0)) {
@@ -974,28 +978,33 @@
    prefers-reduced-motion. Light + dark mode parity. */
 
 .feed-featured-event {
-	/* light-mode rizz tokens — warm tungsten stage light + brand violet bloom */
-	--cdn-rizz-spot-warm: rgba(201, 162, 63, 0.22);
-	--cdn-rizz-spot-violet: rgba(144, 96, 240, 0.16);
-	--cdn-rizz-bloom-purple: rgba(90, 31, 138, 0.22);
-	--cdn-rizz-bloom-gold: rgba(201, 162, 63, 0.28);
-	--cdn-rizz-shimmer: rgba(255, 250, 235, 0.6);
-	--cdn-rizz-badge-glow: rgba(144, 96, 240, 0.45);
-	--cdn-rizz-image-rim-1: rgba(90, 31, 138, 0.32);
-	--cdn-rizz-image-rim-2: rgba(201, 162, 63, 0.28);
-	--cdn-rizz-spots-glow: rgba(144, 96, 240, 0.4);
-	/* wave-27a v2 depth + sweep tokens — light mode */
-	--cdn-v2-stage-rim: rgba(255, 250, 235, 0.08);
-	--cdn-v2-spot-sweep: rgba(144, 96, 240, 0.18);
-	--cdn-v2-ambient-bloom: rgba(90, 31, 138, 0.14);
-	--cdn-v2-date-plate-from: rgba(201, 162, 63, 0.22);
-	--cdn-v2-date-plate-to: rgba(255, 184, 71, 0.14);
-	--cdn-v2-date-plate-border: rgba(139, 90, 43, 0.42);
+	/* light-mode rizz tokens — warm tungsten stage light + brand violet bloom.
+	   wave 33d — softened spot-warm / spot-violet / bloom alphas to ~70% of
+	   prior values. on cream the prior 0.22 / 0.16 / 0.22 / 0.28 stack added
+	   to the page-wide light-mode eye-strain Bryan flagged. token-only edit;
+	   the radial spotlight + bloom geometry is unchanged. */
+	--cdn-rizz-spot-warm: rgba(201, 162, 63, 0.15);
+	--cdn-rizz-spot-violet: rgba(144, 96, 240, 0.11);
+	--cdn-rizz-bloom-purple: rgba(90, 31, 138, 0.16);
+	--cdn-rizz-bloom-gold: rgba(201, 162, 63, 0.2);
+	--cdn-rizz-shimmer: rgba(255, 250, 235, 0.5);
+	--cdn-rizz-badge-glow: rgba(144, 96, 240, 0.36);
+	--cdn-rizz-image-rim-1: rgba(90, 31, 138, 0.24);
+	--cdn-rizz-image-rim-2: rgba(201, 162, 63, 0.22);
+	--cdn-rizz-spots-glow: rgba(144, 96, 240, 0.32);
+	/* wave-27a v2 depth + sweep tokens — light mode
+	   wave 33d — also softened ambient-bloom + date-plate shimmer alphas */
+	--cdn-v2-stage-rim: rgba(255, 250, 235, 0.06);
+	--cdn-v2-spot-sweep: rgba(144, 96, 240, 0.13);
+	--cdn-v2-ambient-bloom: rgba(90, 31, 138, 0.1);
+	--cdn-v2-date-plate-from: rgba(201, 162, 63, 0.16);
+	--cdn-v2-date-plate-to: rgba(255, 184, 71, 0.1);
+	--cdn-v2-date-plate-border: rgba(139, 90, 43, 0.36);
 	--cdn-v2-date-text: var(--cdn-purple-deep, #30006a);
-	--cdn-v2-date-glow: rgba(90, 31, 138, 0.38);
-	--cdn-v2-date-shimmer: rgba(255, 250, 235, 0.55);
-	--cdn-v2-title-tape: rgba(255, 250, 235, 0.45);
-	--cdn-v2-spots-ring: rgba(144, 96, 240, 0.22);
+	--cdn-v2-date-glow: rgba(90, 31, 138, 0.3);
+	--cdn-v2-date-shimmer: rgba(255, 250, 235, 0.45);
+	--cdn-v2-title-tape: rgba(255, 250, 235, 0.38);
+	--cdn-v2-spots-ring: rgba(144, 96, 240, 0.18);
 
 	position: relative;
 	isolation: isolate;
@@ -2220,14 +2229,19 @@
 	/* Color tokens — light mode = warm amber + gold rim, the vintage
 	   theater marquee voice. Tokens are scoped to the marquee block so
 	   the rest of the card's purple/violet rizz tokens don't bleed into
-	   the sign. */
-	--cdn-marquee-bg-from: #fff5d6;
-	--cdn-marquee-bg-to: #f4d986;
+	   the sign.
+	   wave 33d — toned bg-from / bg-to away from the prior #fff5d6 → #f4d986
+	   range. those values pushed into vibrant near-yellow saturation that
+	   "vibrated" against the cream feed page background, contributing to
+	   the cumulative light-mode eye-strain. softer values keep the warm
+	   tungsten marquee voice without the saturation peak. */
+	--cdn-marquee-bg-from: #f5ead0;
+	--cdn-marquee-bg-to: #e8c97a;
 	--cdn-marquee-rim: #c98b1b;
-	--cdn-marquee-rim-highlight: rgba(255, 247, 220, 0.85);
-	--cdn-marquee-shadow: rgba(124, 64, 8, 0.32);
+	--cdn-marquee-rim-highlight: rgba(255, 247, 220, 0.7);
+	--cdn-marquee-shadow: rgba(124, 64, 8, 0.24);
 	--cdn-marquee-text: #5a2a06;
-	--cdn-marquee-text-glow: rgba(253, 230, 138, 0.65);
+	--cdn-marquee-text-glow: rgba(253, 230, 138, 0.55);
 	--cdn-marquee-bulb-core: #fde68a;
 	--cdn-marquee-bulb-rim: #f59e0b;
 	--cdn-marquee-bulb-halo: rgba(253, 230, 138, 0.7);

--- a/src/styles/__tests__/wave-33d-light-mode-tone.test.ts
+++ b/src/styles/__tests__/wave-33d-light-mode-tone.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * wave 33d — light mode tone-down regression guard.
+ *
+ * Bryan: "light mode looks particularly hard on the eyes right now".
+ * The accumulated waves produced too many high-saturation warm/violet/amber
+ * accents + high-alpha shadows + near-pure-white control surfaces in light
+ * mode. Wave 33d softened a focused set of light-mode tokens.
+ *
+ * This test pins the post-wave-33d values so a future contributor can't drift
+ * back toward the brighter pre-wave-33d state without intentionally updating
+ * this fixture. We assert raw substring presence in the CSS source rather
+ * than getComputedStyle() because:
+ *   - the tokens.css block we care about is light-mode only, but the test
+ *     env (jsdom) doesn't paint, so getComputedStyle on :root would return
+ *     whichever side wins via cascade — not a stable signal.
+ *   - the values we're regressing on are inline literals inside :root + body
+ *     blocks, so a textual pin is exactly the right granularity.
+ *
+ * If wave-NN changes one of these intentionally, update the fixture in the
+ * same PR with a comment explaining why the new value is tone-appropriate.
+ */
+
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+
+describe("wave 33d — light mode tone-down tokens", () => {
+	const tokensCss = readFileSync(
+		resolve(REPO_ROOT, "src/styles/tokens.css"),
+		"utf-8",
+	);
+	const feedCss = readFileSync(
+		resolve(REPO_ROOT, "src/pages/feed/styles.css"),
+		"utf-8",
+	);
+
+	it("--cdn-card-rim-light light-mode inset highlight is softened to 0.6", () => {
+		// rim-light :root block — first inset 0 1px 0 rgba(255, 250, 235, X)
+		// pin: was 0.85, now 0.6 (~30% softer).
+		expect(tokensCss).toContain(
+			"inset 0 1px 0 rgba(255, 250, 235, 0.6),\n\t\tinset 0 -1px 0 rgba(139, 90, 43, 0.06)",
+		);
+		// regression: the prior 0.85 value should not be present in the
+		// :root rim-light block. We allow it elsewhere (the replacement
+		// inline rule in feed/styles.css is now 0.55, also softer).
+		expect(tokensCss).not.toContain("inset 0 1px 0 rgba(255, 250, 235, 0.85)");
+	});
+
+	it("--cdn-shadow-card-light is reduced to ~70% of pre-33d alphas", () => {
+		// pin the new value: 0.07 / 0.08 / 0.05 (was 0.10 / 0.12 / 0.08)
+		expect(tokensCss).toContain(
+			"--cdn-shadow-card-light:\n\t\t0 1px 3px rgba(139, 90, 43, 0.07), 0 4px 10px -2px rgba(139, 90, 43, 0.08),\n\t\t0 8px 20px -4px rgba(139, 90, 43, 0.05);",
+		);
+	});
+
+	it("Cloudscape light-mode control surfaces unify on the warm cream #faf7f0 (no near-pure-white #fdfcf8 / #fefcf8)", () => {
+		// the body override block should no longer contain the old
+		// near-pure-white values — they were causing accumulated bright
+		// surfaces against the warm-cream container backgrounds.
+		const bodyBlockMatch = tokensCss.match(
+			/html:not\(\.awsui-dark-mode\) body \{[^}]+\}/,
+		);
+		expect(bodyBlockMatch).not.toBeNull();
+		const bodyBlock = bodyBlockMatch?.[0] ?? "";
+		// strip /* ... */ comments so we only assert against actual
+		// declarations (the wave 33d migration note inside the block
+		// names the prior values for context, but those are textual
+		// references and shouldn't trigger this regression check).
+		const bodyDecls = bodyBlock.replace(/\/\*[\s\S]*?\*\//g, "");
+		expect(bodyDecls).not.toMatch(/#fdfcf8/);
+		expect(bodyDecls).not.toMatch(/#fefcf8/);
+		// pin the unified value
+		expect(bodyDecls).toContain(
+			"--color-background-input-default-ifz5bb: #faf7f0",
+		);
+		expect(bodyDecls).toContain(
+			"--color-background-button-normal-default-7f99mv: #faf7f0",
+		);
+		expect(bodyDecls).toContain("--color-background-popover-e20fy8: #faf7f0");
+	});
+
+	it("featured-event light-mode marquee bg-from / bg-to is toned away from vibrant near-yellow", () => {
+		// the marquee header lives in feed/styles.css and only had a
+		// light-mode rule (dark mode uses indigo/violet). Pre-wave-33d:
+		//   --cdn-marquee-bg-from: #fff5d6;  /* near-pure cream-yellow */
+		//   --cdn-marquee-bg-to:   #f4d986;  /* saturated amber-yellow */
+		// Post-wave-33d: softer, lower-saturation values.
+		expect(feedCss).toContain("--cdn-marquee-bg-from: #f5ead0;");
+		expect(feedCss).toContain("--cdn-marquee-bg-to: #e8c97a;");
+		expect(feedCss).not.toContain("--cdn-marquee-bg-from: #fff5d6;");
+		expect(feedCss).not.toContain("--cdn-marquee-bg-to: #f4d986;");
+	});
+
+	it("featured-event rizz spot tokens softened (~70% of prior alphas)", () => {
+		// the rizz spotlight + bloom alphas pre-33d totalled 0.22 + 0.16 +
+		// 0.22 + 0.28 across four tokens — too much warmth + violet on a
+		// cream page. Pin the softened set.
+		expect(feedCss).toContain(
+			"--cdn-rizz-spot-warm: rgba(201, 162, 63, 0.15);",
+		);
+		expect(feedCss).toContain(
+			"--cdn-rizz-spot-violet: rgba(144, 96, 240, 0.11);",
+		);
+		expect(feedCss).toContain(
+			"--cdn-rizz-bloom-purple: rgba(90, 31, 138, 0.16);",
+		);
+	});
+});

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -132,18 +132,23 @@
 	/* Cloudscape light-mode token overrides moved to :root:not(.awsui-dark-mode) block below
 	   to avoid !important bleeding into dark mode. See that block for the actual overrides. */
 
-	/* ---------- Warm shadow system — light mode ---------- */
+	/* ---------- Warm shadow system — light mode ----------
+	   wave 33d — reduced shadow alphas to ~70% of prior values across the
+	   card + container + nav stack. accumulating 0.10-0.18 alpha shadows
+	   across 5+ stacked feed cards on a cream page produced too much "pop"
+	   against the warm background. softening the alphas keeps the warm-amber
+	   directional-light feel without making every surface visually shout. */
 	--cdn-shadow-container-light:
-		0 1px 4px rgba(139, 90, 43, 0.1), 0 4px 12px rgba(139, 90, 43, 0.06);
+		0 1px 4px rgba(139, 90, 43, 0.07), 0 4px 12px rgba(139, 90, 43, 0.04);
 	--cdn-shadow-card-light:
-		0 1px 3px rgba(139, 90, 43, 0.1), 0 4px 10px -2px rgba(139, 90, 43, 0.12),
-		0 8px 20px -4px rgba(139, 90, 43, 0.08);
+		0 1px 3px rgba(139, 90, 43, 0.07), 0 4px 10px -2px rgba(139, 90, 43, 0.08),
+		0 8px 20px -4px rgba(139, 90, 43, 0.05);
 	--cdn-shadow-card-hover-light:
-		0 4px 8px rgba(139, 90, 43, 0.14), 0 12px 28px -4px rgba(139, 90, 43, 0.18),
-		0 20px 40px -8px rgba(139, 90, 43, 0.1),
-		0 0 0 1px rgba(139, 90, 43, 0.06);
-	--cdn-shadow-input-light: inset 0 1px 3px rgba(139, 90, 43, 0.08);
-	--cdn-shadow-nav-light: 2px 0 8px rgba(139, 90, 43, 0.08);
+		0 4px 8px rgba(139, 90, 43, 0.1), 0 12px 28px -4px rgba(139, 90, 43, 0.13),
+		0 20px 40px -8px rgba(139, 90, 43, 0.07),
+		0 0 0 1px rgba(139, 90, 43, 0.05);
+	--cdn-shadow-input-light: inset 0 1px 3px rgba(139, 90, 43, 0.06);
+	--cdn-shadow-nav-light: 2px 0 8px rgba(139, 90, 43, 0.06);
 
 	/* ---------- Typography scale ---------- */
 	--cdn-text-xs: 0.6875rem; /* 11px — micro labels, card meta */
@@ -210,17 +215,23 @@ html:not(.awsui-dark-mode) body {
 	--color-background-container-content-6u8rvp: #ede5d4 !important;
 	--color-background-container-header-gs3mbe: #ede5d4 !important;
 	--color-background-layout-panel-content-xto15e: #ede5d4 !important;
-	--color-background-input-default-ifz5bb: #fdfcf8 !important;
-	--color-background-control-default-4jb21l: #fdfcf8 !important;
+	/* wave 33d — unified near-white control/input/popover surfaces onto the
+	   warm-cream brand value #faf7f0 (was #fdfcf8 / #fefcf8). prior values
+	   sat 1-2pp away from pure white and produced cumulative eye-strain on
+	   light mode against the cream container backgrounds. #faf7f0 is already
+	   the brand card surface (see --color-background-card-p5vrq0 below)
+	   so this also unifies the surface palette. */
+	--color-background-input-default-ifz5bb: #faf7f0 !important;
+	--color-background-control-default-4jb21l: #faf7f0 !important;
 	--color-text-body-default-vvtq8u: #2c1a0e !important;
 	--color-text-heading-default-izpp46: #1a0f05 !important;
 	--color-border-divider-default-nr68jt: rgba(139, 90, 43, 0.18) !important;
 	--color-background-card-p5vrq0: #faf7f0 !important;
-	--color-background-popover-e20fy8: #fefcf8 !important;
-	--color-background-dropdown-item-default-qmc033: #fdfcf8 !important;
-	--color-background-button-normal-default-7f99mv: #fdfcf8 !important;
-	--color-background-button-normal-disabled-hl039l: #fdfcf8 !important;
-	--color-background-segment-default-b0r494: #fdfcf8 !important;
+	--color-background-popover-e20fy8: #faf7f0 !important;
+	--color-background-dropdown-item-default-qmc033: #faf7f0 !important;
+	--color-background-button-normal-default-7f99mv: #faf7f0 !important;
+	--color-background-button-normal-disabled-hl039l: #faf7f0 !important;
+	--color-background-segment-default-b0r494: #faf7f0 !important;
 	--color-background-table-header-hdjxos: #ede8db !important;
 }
 
@@ -645,29 +656,38 @@ html:not(.awsui-dark-mode) body {
 
 /* shared gradient + shadow tokens — single source of truth, both modes
    wave 23.5: strengthened gradients + layered shadow stack inspired by
-   fiona end-credits popout (multi-layer glow + radial accent bloom) */
+   fiona end-credits popout (multi-layer glow + radial accent bloom)
+   wave 33d: light-mode tokens softened — gradient stops dropped to ~70%
+   of prior alpha and rim-light inset highlight reduced from 0.85 → 0.6.
+   the bright cream highlight inset on every card surface was a primary
+   contributor to cumulative eye-strain on the feed page (5+ stacked
+   cards each painting an 0.85-alpha cream rim against the page cream).
+   dark-mode tokens unchanged. */
 :root {
 	/* light mode: warm cream → amber radial accent → cream edge
-	   stronger than prior 4-6% alpha — reads as warm directional light */
+	   softened from prior alpha set — reads as warm directional light
+	   without making the card "shout" against the page background */
 	--cdn-card-gradient-light:
 		radial-gradient(
 			ellipse at 30% 0%,
-			rgba(201, 162, 63, 0.1) 0%,
+			rgba(201, 162, 63, 0.07) 0%,
 			transparent 60%
 		),
 		linear-gradient(
 			135deg,
-			rgba(255, 250, 235, 0.7) 0%,
-			rgba(232, 215, 180, 0.28) 45%,
-			rgba(250, 244, 230, 0.6) 100%
+			rgba(255, 250, 235, 0.5) 0%,
+			rgba(232, 215, 180, 0.18) 45%,
+			rgba(250, 244, 230, 0.42) 100%
 		);
-	/* layered shadow: close contact + medium spread + ambient depth (fiona-credits inspired) */
+	/* layered shadow: close contact + medium spread + ambient depth.
+	   wave 33d — inset highlight 0.85 → 0.6, drop alphas reduced ~30%
+	   so cards no longer "pop" off the cream page surface. */
 	--cdn-card-rim-light:
-		inset 0 1px 0 rgba(255, 250, 235, 0.85),
-		inset 0 -1px 0 rgba(139, 90, 43, 0.08),
-		0 1px 2px rgba(139, 90, 43, 0.12),
-		0 4px 8px -2px rgba(139, 90, 43, 0.1),
-		0 8px 20px -4px rgba(139, 90, 43, 0.14);
+		inset 0 1px 0 rgba(255, 250, 235, 0.6),
+		inset 0 -1px 0 rgba(139, 90, 43, 0.06),
+		0 1px 2px rgba(139, 90, 43, 0.08),
+		0 4px 8px -2px rgba(139, 90, 43, 0.07),
+		0 8px 20px -4px rgba(139, 90, 43, 0.1);
 }
 
 .awsui-dark-mode {


### PR DESCRIPTION
Bryan: 'light mode looks particularly hard on the eyes right now'.

## what changes
Site-wide light-mode token softening — accumulated brightness from recent feature waves was creating eye-strain. Dark mode entirely untouched.

### tokens.css (light only)
Cloudscape control surfaces unified to brand cream `#faf7f0` (was `#fdfcf8`/`#fefcf8`). Card shadow alpha stack reduced ~30% (`.10/.12/.08` → `.07/.08/.05`). Hover/container/input/nav shadows similarly softened. `--cdn-card-rim-light` cream highlight 0.85→0.6. Card gradient amber radial 0.10→0.07; cream linear stops .70/.28/.60→.50/.18/.42.

### feed/styles.css (light only)
All `--cdn-rizz-*` and `--cdn-v2-*` token alphas reduced ~20-30%. Marquee bg-from/to softened from vibrant `#fff5d6/#f4d986` to gentler `#f5ead0/#e8c97a` — was the single highest eye-strain source.

### WCAG verification
- text on body bg: 13.4:1 (AAA)
- text on control bg: 15.6:1 (AAA)
- marquee text on bg-to: 7.4:1 (AAA)
- marquee text on bg-from: 9.9:1 (AAA)

### gates
- biome ci: 0 errors
- npm run build: PASS
- vitest: 674 / 674 PASS (5 new wave-33d regression tests added)

### regression guard
`src/styles/__tests__/wave-33d-light-mode-tone.test.ts` pins 5 representative post-tone-down values so future drift fails CI.