### PR TITLE
feat(feed): wave 33a — next-meetup card uplift (marquee header, date plate, gradient title, depth stack)

### DIFF
--- a/src/pages/feed/components/__tests__/next-meetup.test.tsx
+++ b/src/pages/feed/components/__tests__/next-meetup.test.tsx
@@ -1,0 +1,186 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/**
+ * Wave 33a — Next meetup card uplift regression coverage.
+ *
+ * The wave 33a uplift brings the Next Meetup card up to the visual standard
+ * set by the wave 32a featured-event card: theater marquee header (cooler
+ * steel-blue / deep-teal palette + scrolling-tape shimmer), date-plate VFX,
+ * gradient/scrolling-tape title link, depth stack (perspective + preserve-3d
+ * + GPU compositing hints + 1px stage-rim inset), and an error boundary that
+ * mirrors FeaturedEventErrorBoundary so a render failure on this card shows
+ * fallback chrome instead of crashing the rest of the feed page.
+ *
+ * jsdom does not compute layered styles from external CSS, so we cannot
+ * assert getComputedStyle(card).willChange === "transform" — that value
+ * lives in src/pages/feed/styles.css, which jsdom parses but does not apply
+ * to the cascade. What we CAN assert is the structural contract that the
+ * wave 33a CSS targets:
+ *
+ *   - The marquee wrapper carries .feed-next-meetup__marquee with
+ *     role="heading" + aria-level=2 (a11y semantic preserved when we
+ *     replaced the Cloudscape <Header variant="h2"> with custom chrome).
+ *   - The card root carries .feed-next-meetup so the body.cdn-scrolling
+ *     pause selectors target the right element.
+ *   - There is no <img> element in the next-meetup card today, so the
+ *     "onError handler hides broken images" contract from the wave 33a
+ *     brief is documented as "no image element renders in the loading or
+ *     fallback states; if a future revision adds one, this test fails
+ *     until the new image carries an onError hook".
+ *
+ * Companion coverage for the @media (prefers-reduced-motion) and
+ * body.cdn-scrolling CSS hooks lives in the styles.css text — we read the
+ * file directly and assert the wave 33a selectors are wired in.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../../../../contexts/locale-context";
+import NextMeetup, { NextMeetupErrorBoundary } from "../next-meetup";
+
+function renderWithLocale(locale: "us" | "mx") {
+	return render(
+		<LocaleProvider locale={locale}>
+			<NextMeetup />
+		</LocaleProvider>,
+	);
+}
+
+describe("NextMeetup — wave 33a uplift", () => {
+	it("renders the theater marquee header with role=heading aria-level=2 (a11y semantic preserved when Cloudscape <Header> was replaced)", () => {
+		const { container } = renderWithLocale("us");
+		const marquee = container.querySelector(".feed-next-meetup__marquee");
+		expect(marquee).not.toBeNull();
+		expect(marquee?.getAttribute("role")).toBe("heading");
+		expect(marquee?.getAttribute("aria-level")).toBe("2");
+	});
+
+	it("renders the marquee text inside the marquee wrapper with the localized 'Next Meetup' header copy", () => {
+		const { container } = renderWithLocale("us");
+		const marqueeText = container.querySelector(
+			".feed-next-meetup__marquee-text",
+		);
+		expect(marqueeText).not.toBeNull();
+		expect(marqueeText?.textContent).toMatch(/Next Meetup/i);
+	});
+
+	it("renders the scrolling-tape shimmer span (the differentiator vs. featured-event's chasing bulbs) marked aria-hidden", () => {
+		const { container } = renderWithLocale("us");
+		const tape = container.querySelector(".feed-next-meetup__marquee-tape");
+		expect(tape).not.toBeNull();
+		expect(tape?.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	it("renders the localized header in es-MX too (Próximo Meetup)", () => {
+		const { container } = renderWithLocale("mx");
+		const marqueeText = container.querySelector(
+			".feed-next-meetup__marquee-text",
+		);
+		expect(marqueeText?.textContent).toMatch(/Próximo Meetup/i);
+	});
+
+	it("renders the structural class names that the wave 33a CSS targets for depth stack + scroll pause", () => {
+		const { container } = renderWithLocale("us");
+		// Card root — perspective + preserve-3d + will-change/contain/translate3d
+		// + the body.cdn-scrolling pause selector all attach to this exact class.
+		expect(container.querySelector(".feed-next-meetup")).not.toBeNull();
+		// Marquee chrome — cooler steel-blue/deep-teal palette + scrolling-tape
+		// shimmer all hang off this class.
+		expect(
+			container.querySelector(".feed-next-meetup__marquee"),
+		).not.toBeNull();
+	});
+
+	it("does not render an <img> element in the loading or fallback states (wave 33a brief: 'onError handler hides broken images, or whatever applies if there's no image element' — documenting the deliberate absence)", () => {
+		const { container: us } = renderWithLocale("us");
+		expect(us.querySelectorAll("img").length).toBe(0);
+		const { container: mx } = renderWithLocale("mx");
+		expect(mx.querySelectorAll("img").length).toBe(0);
+	});
+
+	it("renders the NextMeetupErrorBoundary fallback when a child throws (wave 33a render-failure containment)", () => {
+		const Boom = () => {
+			throw new Error("simulated wave 33a render failure");
+		};
+
+		// Suppress the boundary's intentional console.error + React's caught-
+		// error log so they don't pollute test stdout.
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+			// intentionally empty — see comment above
+		});
+
+		try {
+			const { container } = render(
+				<LocaleProvider locale="us">
+					<NextMeetupErrorBoundary
+						fallbackHeader="Next Meetup"
+						fallbackMessage="Meetup details temporarily unavailable. Please refresh the page."
+					>
+						<Boom />
+					</NextMeetupErrorBoundary>
+				</LocaleProvider>,
+			);
+
+			// Fallback chrome reuses the same .feed-next-meetup wrapper so the
+			// empty state still anchors visually in the same slot in the feed.
+			expect(container.querySelector(".feed-next-meetup")).not.toBeNull();
+			expect(screen.getByText("Next Meetup")).toBeInTheDocument();
+			expect(
+				screen.getByText(/Meetup details temporarily unavailable/i),
+			).toBeInTheDocument();
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+});
+
+describe("NextMeetup — wave 33a CSS hooks (prefers-reduced-motion + cdn-scrolling)", () => {
+	// jsdom doesn't apply external CSS to the cascade, so we read the
+	// stylesheet text directly and assert the wave 33a selectors are present.
+	// This is the same approach featured-event-scroll.test.tsx documents
+	// for its wave 30a CSS hook contract.
+	const stylesPath = join(__dirname, "..", "..", "styles.css");
+	const stylesText = readFileSync(stylesPath, "utf8");
+
+	it("registers a body.cdn-scrolling pause rule for the next-meetup card (extends the wave 30a featured-event pause list)", () => {
+		// The pause list must include at least the card root + the marquee
+		// tape (the new sustained animation introduced by wave 33a).
+		expect(stylesText).toMatch(
+			/body\.cdn-scrolling \.feed-next-meetup__marquee-tape/,
+		);
+		expect(stylesText).toMatch(/body\.cdn-scrolling \.feed-next-meetup\b/);
+	});
+
+	it("gates every new sustained animation behind @media (prefers-reduced-motion: no-preference) and provides a reduced-motion fallback", () => {
+		// no-preference branch — animations enabled
+		expect(stylesText).toMatch(
+			/@media \(prefers-reduced-motion: no-preference\)/,
+		);
+		// reduce branch — static fallback present
+		expect(stylesText).toMatch(/@media \(prefers-reduced-motion: reduce\)/);
+
+		// And specifically the wave 33a scrolling-tape shimmer animation is
+		// declared inside a no-preference block.
+		expect(stylesText).toMatch(/feed-next-meetup-marquee-tape-sweep/);
+		// The reduced-motion branch must also reset the tape shimmer so the
+		// static fallback renders correctly.
+		const reducedBlock = stylesText.match(
+			/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.feed-next-meetup__marquee-tape \{[\s\S]*?animation: none;/,
+		);
+		expect(reducedBlock).not.toBeNull();
+	});
+
+	it("declares the cooler steel-blue / deep-teal palette tokens that differentiate next-meetup from featured-event's warm amber+violet", () => {
+		// Light-mode card token
+		expect(stylesText).toMatch(/--cdn-nm-spot-cool: rgba\(56, 110, 165/);
+		// Dark-mode card token (deep teal)
+		expect(stylesText).toMatch(/--cdn-nm-ambient-bloom: rgba\(6, 78, 59/);
+		// Marquee light-mode steel-blue rim
+		expect(stylesText).toMatch(/--cdn-nm-marquee-rim: #2c5282/);
+		// Marquee dark-mode lighter teal rim
+		expect(stylesText).toMatch(/--cdn-nm-marquee-rim: #5eead4/);
+	});
+});

--- a/src/pages/feed/components/next-meetup.tsx
+++ b/src/pages/feed/components/next-meetup.tsx
@@ -20,6 +20,25 @@
  *     the CTA card if the file is absent or stale (>30 days old)
  *   - File schema: { summary, dtstart (ISO 8601), location, url, description }
  *   - Dispatch to Harald as issue: "feat(feed): CI step for next-meetup.json static gen"
+ *
+ * Wave 33a — visual uplift to match the wave 32a featured-event card. The
+ * card now carries:
+ *   - A theater-marquee header (cooler steel-blue / deep-teal palette) with
+ *     a scrolling-tape shimmer across the backplate (no chasing bulbs — the
+ *     adjacent-but-distinct mood vs. featured's warm amber + bulb chase).
+ *   - A date-plate VFX backplate behind the meetup date string in the same
+ *     cooler palette.
+ *   - The title link gets a steel-blue → cyan gradient with the same
+ *     scrolling-tape treatment used on the featured-event title.
+ *   - The same depth stack: perspective(1200px) + preserve-3d on the card
+ *     root, will-change/contain/translate3d compositing hints, and a 1px
+ *     stage-rim inset in the box-shadow.
+ *   - An error boundary mirroring FeaturedEventErrorBoundary so a render
+ *     failure shows fallback chrome instead of crashing the feed.
+ *   - All animations gated behind prefers-reduced-motion: no-preference;
+ *     reduced-motion users see a static, fully-legible fallback.
+ *   - The body.cdn-scrolling pause integration is extended to cover the
+ *     new sustained animations (marquee shimmer, title tape, date breathe).
  */
 
 import Box from "@cloudscape-design/components/box";
@@ -28,8 +47,13 @@ import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import type React from "react";
-import { useEffect, useState } from "react";
+import {
+	Component,
+	type ErrorInfo,
+	type ReactNode,
+	useEffect,
+	useState,
+} from "react";
 import { SkeletonLine, SkeletonTitle } from "../../../components/skeleton";
 import { useTranslation } from "../../../hooks/useTranslation";
 
@@ -134,7 +158,29 @@ function parseIcal(text: string): MeetupEvent | null {
 
 type LoadState = "loading" | "loaded" | "fallback";
 
-export default function NextMeetup() {
+/**
+ * Wave 33a — Theater marquee header (steel-blue / deep-teal palette).
+ *
+ * Mirrors the spirit of the wave 32a featured-event marquee but with a
+ * deliberately different mood: cooler palette + a scrolling-tape shimmer
+ * sweep instead of chasing bulbs. The header still announces itself as
+ * an h2 to assistive tech via role="heading" + aria-level=2.
+ *
+ * The scrolling-tape shimmer is a single ::after gradient band defined
+ * in styles.css; it travels horizontally across the marquee backplate on
+ * a slow loop. Reduced-motion gates the keyframes off and the shimmer
+ * settles to a static centered glow.
+ */
+function MarqueeHeader({ text }: { text: string }) {
+	return (
+		<div className="feed-next-meetup__marquee" role="heading" aria-level={2}>
+			<span className="feed-next-meetup__marquee-text">{text}</span>
+			<span className="feed-next-meetup__marquee-tape" aria-hidden="true" />
+		</div>
+	);
+}
+
+function NextMeetupInner() {
 	const { t, locale } = useTranslation();
 	const [state, setState] = useState<LoadState>("loading");
 	const [event, setEvent] = useState<MeetupEvent | null>(null);
@@ -201,9 +247,9 @@ export default function NextMeetup() {
 		}
 	};
 
-	const header = <Header variant="h2">{t("feedPage.nextMeetupHeader")}</Header>;
+	const header = <MarqueeHeader text={t("feedPage.nextMeetupHeader")} />;
 
-	let content: React.ReactNode;
+	let content: ReactNode;
 
 	if (state === "loading") {
 		content = (
@@ -224,7 +270,11 @@ export default function NextMeetup() {
 					<Box color="text-body-secondary" fontSize="body-s" fontWeight="bold">
 						{t("feedPage.pastMeetupBadge")}
 					</Box>
-					<Box fontWeight="bold" fontSize="heading-m">
+					<Box
+						fontWeight="bold"
+						fontSize="heading-m"
+						className="feed-next-meetup__title"
+					>
 						<Link href={PAST_MEETUP_MX_URL} external>
 							{t("feedPage.pastMeetupTitle")}
 						</Link>
@@ -292,7 +342,11 @@ export default function NextMeetup() {
 						{t("feedPage.nextMeetupPastLabel")}
 					</Box>
 				)}
-				<Box fontWeight="bold" fontSize="heading-m">
+				<Box
+					fontWeight="bold"
+					fontSize="heading-m"
+					className="feed-next-meetup__title"
+				>
 					{event.url ? (
 						<Link href={event.url} external>
 							{event.summary}
@@ -301,9 +355,16 @@ export default function NextMeetup() {
 						event.summary
 					)}
 				</Box>
-				<Box color="text-body-secondary" fontSize="body-s">
-					{formatDate(event.dtstart)}
-				</Box>
+				{/* Wave 33a — date-plate VFX. Date string itself is plain HTML
+				    output from Intl.DateTimeFormat (no SVG, no canvas, no string
+				    splitting). The wrapper div carries the layout margin; the
+				    inner span is the steel-blue / deep-teal backplate with a
+				    soft pulsing text-shadow glow + diagonal sweep shimmer. */}
+				<div className="feed-next-meetup__date">
+					<span className="feed-next-meetup__date-plate">
+						{formatDate(event.dtstart)}
+					</span>
+				</div>
 				{event.location && (
 					<Box color="text-body-secondary" fontSize="body-s">
 						{event.location}
@@ -323,5 +384,76 @@ export default function NextMeetup() {
 		<div className="feed-next-meetup">
 			<Container header={header}>{content}</Container>
 		</div>
+	);
+}
+
+/**
+ * Wave 33a — error boundary scoped to the NextMeetup card.
+ *
+ * Mirrors FeaturedEventErrorBoundary in featured-event.tsx. The card now
+ * carries the same depth stack + sustained animations as the featured
+ * event card, plus the iCal/static-JSON fetch path + Intl.DateTimeFormat;
+ * if any of those pieces throw at render time, this boundary catches it
+ * locally so the rest of the feed (FeaturedEvent, UpcomingVirtualEvent,
+ * BuilderCenterCard, the live hero, the shuffled grid) keeps rendering.
+ *
+ * The fallback UI reuses the standard Cloudscape Container + Header chrome
+ * so the empty state still anchors visually in the same slot. The header
+ * resolves through the existing locale key (no new locale strings); the
+ * body fallback message is hard-coded English (the wave 33a hard scope
+ * forbids new locale keys, and this path only fires on render errors —
+ * exceptional, brief, primarily a dev-visible signal in console.error).
+ */
+interface NextMeetupErrorBoundaryState {
+	hasError: boolean;
+}
+
+export class NextMeetupErrorBoundary extends Component<
+	{ children: ReactNode; fallbackHeader: string; fallbackMessage: string },
+	NextMeetupErrorBoundaryState
+> {
+	state: NextMeetupErrorBoundaryState = { hasError: false };
+
+	static getDerivedStateFromError(): NextMeetupErrorBoundaryState {
+		return { hasError: true };
+	}
+
+	componentDidCatch(error: Error, info: ErrorInfo): void {
+		// Single console.error so the failure is visible in devtools without
+		// piping crash data to a third-party endpoint. The boundary's render
+		// fallback is the user-visible signal; this is the developer signal.
+		console.error("[NextMeetup] render failure", error, info);
+	}
+
+	render(): ReactNode {
+		if (this.state.hasError) {
+			return (
+				<div className="feed-next-meetup">
+					<Container
+						header={<Header variant="h2">{this.props.fallbackHeader}</Header>}
+					>
+						<Box color="text-body-secondary" fontSize="body-s">
+							{this.props.fallbackMessage}
+						</Box>
+					</Container>
+				</div>
+			);
+		}
+		return this.props.children;
+	}
+}
+
+/**
+ * Default export: NextMeetup wrapped in its own error boundary.
+ */
+export default function NextMeetup() {
+	const { t } = useTranslation();
+	return (
+		<NextMeetupErrorBoundary
+			fallbackHeader={t("feedPage.nextMeetupHeader")}
+			fallbackMessage="Meetup details temporarily unavailable. Please refresh the page."
+		>
+			<NextMeetupInner />
+		</NextMeetupErrorBoundary>
 	);
 }

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -1970,12 +1970,12 @@
 	display: none;
 }
 
-/* ---------- Next meetup card — stable height across loading/fallback/loaded ---------- */
-/* Reserve enough height for the loaded state (title + date + location + description)
-   so the transition from loading does not shift the page layout. */
-.feed-next-meetup {
-	min-height: 180px;
-}
+/* ---------- Next meetup card — base styling consolidated into wave 33a block ----------
+   The wave 33a uplift block at the bottom of this file owns all .feed-next-meetup
+   rules now (depth stack, marquee header, date-plate VFX, gradient title, scroll
+   pause hooks, reduced-motion fallbacks). The legacy stable-height min-height
+   rule was folded into the wave 33a card-root declaration so the same selector
+   isn't duplicated across the file. */
 
 /* ---------- Past meetup spotlight (es-MX fallback) ---------- */
 /* Renders inside the NextMeetup container when locale === "mx" + no upcoming
@@ -2416,5 +2416,631 @@
 	.feed-featured-event__marquee-bulb {
 		width: 7px;
 		height: 7px;
+	}
+}
+
+/* ==========================================================================
+   Wave 33a — Next meetup card uplift
+   ==========================================================================
+
+   Brings the Next Meetup card up to the visual standard set by the wave 32a
+   featured-event card, but with a deliberately differentiated mood: cooler
+   palette (steel-blue gradient on light, deep teal on dark) and a scrolling-
+   tape shimmer instead of chasing bulbs on the marquee header.
+
+   Mirrors in style/spirit (NOT copy-paste) the featured-event treatments:
+     - perspective(1200px) + preserve-3d on card root
+     - will-change / contain / translate3d GPU compositing hints
+     - 1px stage-rim inset on the box-shadow
+     - title link gets a gradient + scrolling-tape sweep
+     - date-plate VFX backplate behind the meetup date string
+     - theater-marquee header chrome (cooler palette, shimmer instead of bulbs)
+     - cdn-scrolling pause hooks for sustained animations
+     - prefers-reduced-motion gates on every animation; static fallbacks read
+
+   Class prefix: .feed-next-meetup__ (per wave 33a naming discipline).
+   Local CSS variables scoped to .feed-next-meetup keep the wave-23.5 token
+   baseline untouched (do NOT mutate src/styles/tokens.css). Light + dark
+   mode parity. */
+
+.feed-next-meetup {
+	/* Wave 33a — light-mode cool tokens. Steel blue stage-light + a soft
+	   cyan bloom replaces the warm tungsten / violet of featured-event. */
+	--cdn-nm-stage-rim: rgba(245, 250, 255, 0.1);
+	--cdn-nm-spot-cool: rgba(56, 110, 165, 0.18);
+	--cdn-nm-spot-cyan: rgba(94, 234, 212, 0.12);
+	--cdn-nm-ambient-bloom: rgba(44, 82, 130, 0.16);
+	--cdn-nm-date-plate-from: rgba(190, 215, 240, 0.55);
+	--cdn-nm-date-plate-to: rgba(220, 240, 248, 0.32);
+	--cdn-nm-date-plate-border: rgba(44, 82, 130, 0.42);
+	--cdn-nm-date-text: #0f3457;
+	--cdn-nm-date-glow: rgba(56, 110, 165, 0.4);
+	--cdn-nm-date-shimmer: rgba(245, 252, 255, 0.6);
+	--cdn-nm-title-from: #0f3457;
+	--cdn-nm-title-mid: #2c5282;
+	--cdn-nm-title-tape: rgba(245, 252, 255, 0.5);
+
+	/* Wave 33a — keep the existing reserved min-height so the loading →
+	   loaded state transition does not shift page layout. */
+	min-height: 180px;
+
+	position: relative;
+	isolation: isolate;
+	border-left: 4px solid var(--cdn-nm-title-mid, #2c5282);
+	border-radius: var(--cdn-radius-md, 8px);
+	overflow: hidden;
+	/* perspective + preserve-3d enable child translateZ() pop without
+	   loading a runtime 3D engine. 1200px = subtle, ambient depth. Same
+	   value as featured-event for visual rhyme. */
+	perspective: 1200px;
+	transform-style: preserve-3d;
+	/* Mirror the wave 30a tearing mitigations from featured-event:
+	   - contain: layout paint style isolates this card's paint operations
+	   - translate3d(0,0,0) forces its own GPU compositor layer
+	   - will-change: transform proactively promotes the layer up-front */
+	contain: layout paint style;
+	transform: translate3d(0, 0, 0);
+	will-change: transform;
+	/* Layered ambient bloom + 1px stage-rim inset (the same idiom featured
+	   uses to give the card a "stage edge" line under varied backgrounds). */
+	box-shadow:
+		0 1px 2px rgba(15, 52, 87, 0.08),
+		0 8px 28px -8px var(--cdn-nm-ambient-bloom),
+		0 18px 48px -12px var(--cdn-nm-ambient-bloom),
+		inset 0 0 0 1px var(--cdn-nm-stage-rim);
+}
+
+.awsui-dark-mode .feed-next-meetup {
+	/* Wave 33a — dark-mode cool tokens. Deep teal/forest + lighter teal
+	   highlights replace the indigo/violet of featured-event. */
+	--cdn-nm-stage-rim: rgba(167, 243, 208, 0.1);
+	--cdn-nm-spot-cool: rgba(20, 83, 81, 0.42);
+	--cdn-nm-spot-cyan: rgba(94, 234, 212, 0.22);
+	--cdn-nm-ambient-bloom: rgba(6, 78, 59, 0.36);
+	--cdn-nm-date-plate-from: rgba(6, 78, 59, 0.62);
+	--cdn-nm-date-plate-to: rgba(20, 83, 81, 0.42);
+	--cdn-nm-date-plate-border: rgba(94, 234, 212, 0.48);
+	--cdn-nm-date-text: #99f6e4;
+	--cdn-nm-date-glow: rgba(94, 234, 212, 0.55);
+	--cdn-nm-date-shimmer: rgba(167, 243, 208, 0.42);
+	--cdn-nm-title-from: #5eead4;
+	--cdn-nm-title-mid: #99f6e4;
+	--cdn-nm-title-tape: rgba(232, 252, 247, 0.5);
+
+	box-shadow:
+		0 2px 6px rgba(0, 0, 0, 0.5),
+		0 10px 30px -8px var(--cdn-nm-ambient-bloom),
+		0 22px 56px -12px var(--cdn-nm-ambient-bloom),
+		inset 0 0 0 1px var(--cdn-nm-stage-rim);
+}
+
+/* Stage-light gradient backplate — two cross-faded radial spotlights:
+   cool steel-blue key from upper-left, soft cyan fill from lower-right.
+   Sits behind all content via z-index:0. Children stack on z-index:1. */
+.feed-next-meetup::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+	background:
+		radial-gradient(
+			ellipse 70% 50% at 14% 8%,
+			var(--cdn-nm-spot-cool) 0%,
+			transparent 62%
+		),
+		radial-gradient(
+			ellipse 65% 55% at 88% 92%,
+			var(--cdn-nm-spot-cyan) 0%,
+			transparent 65%
+		);
+	opacity: 0.95;
+}
+
+/* Slow cool spotlight depth layer — crosses the card on a 7s ease cycle.
+   Mirrors featured-event's ::after but with the cooler palette. Sits
+   behind content (z-index:0). Same translateZ(0) layer-isolation +
+   will-change as featured to keep the sweep on its own GPU layer. */
+.feed-next-meetup::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+	background: linear-gradient(
+		115deg,
+		transparent 0%,
+		transparent 30%,
+		var(--cdn-nm-spot-cool) 50%,
+		transparent 70%,
+		transparent 100%
+	);
+	background-size: 220% 100%;
+	background-position: 120% 0;
+	opacity: 0.7;
+	transform: translateZ(0);
+	transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+	will-change: opacity, transform;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes feed-next-meetup-spotlight-sweep {
+		0% {
+			background-position: 120% 0;
+		}
+		60%,
+		100% {
+			background-position: -40% 0;
+		}
+	}
+
+	.feed-next-meetup::after {
+		animation: feed-next-meetup-spotlight-sweep 7s cubic-bezier(0.4, 0, 0.2, 1)
+			infinite;
+	}
+
+	/* Hover parallax — same pattern as featured-event. */
+	.feed-next-meetup:hover::after {
+		transform: translateZ(8px);
+	}
+}
+
+/* All direct content children sit above the spotlight backplate. */
+.feed-next-meetup > * {
+	position: relative;
+	z-index: 1;
+}
+
+/* ---------- Wave 33a — Theater marquee header (cooler palette, shimmer)
+   ----------
+
+   Replaces the Cloudscape <Header variant="h2"> chrome on the next-meetup
+   card with a marquee sign aesthetic that rhymes with featured-event but
+   carries a cooler mood: steel-blue gradient backplate + steel/cyan rim on
+   light mode; deep-teal backplate + lighter teal rim on dark mode. Where
+   featured uses 16 chasing perimeter bulbs, next-meetup uses a single
+   horizontal scrolling-tape shimmer that slides across the backplate on
+   a slow loop — adjacent in spirit, distinct in execution.
+
+   Cloudscape's Container places its `header` slot inside an internal
+   wrapper class; the marquee sits inside that slot and carries its own
+   border + shadow + typography so it doesn't inherit the Cloudscape h2
+   tokens. The wrapping div announces itself to assistive tech as h2 via
+   role="heading" + aria-level=2 (handled in the React component).
+
+   Reduced-motion gates the keyframes off; the shimmer settles to a
+   static centered glow that still reads as a soft highlight. */
+.feed-next-meetup__marquee {
+	/* Color tokens — light-mode steel-blue marquee chrome. Scoped here so
+	   they don't bleed into the rest of the card's cool tokens. */
+	--cdn-nm-marquee-bg-from: #e8f0f8;
+	--cdn-nm-marquee-bg-to: #b9d2e6;
+	--cdn-nm-marquee-rim: #2c5282;
+	--cdn-nm-marquee-rim-highlight: rgba(245, 250, 255, 0.85);
+	--cdn-nm-marquee-shadow: rgba(15, 52, 87, 0.32);
+	--cdn-nm-marquee-text: #0f3457;
+	--cdn-nm-marquee-text-glow: rgba(245, 252, 255, 0.7);
+	--cdn-nm-marquee-tape: rgba(245, 252, 255, 0.55);
+	--cdn-nm-marquee-tape-edge: rgba(245, 252, 255, 0);
+
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 40px;
+	padding: 8px 28px;
+	border-radius: 10px;
+	overflow: hidden;
+	background: linear-gradient(
+		180deg,
+		var(--cdn-nm-marquee-bg-from) 0%,
+		var(--cdn-nm-marquee-bg-to) 100%
+	);
+	border: 2px solid var(--cdn-nm-marquee-rim);
+	box-shadow:
+		0 1px 0 var(--cdn-nm-marquee-rim-highlight) inset,
+		0 -1px 0 rgba(15, 52, 87, 0.18) inset,
+		0 2px 4px var(--cdn-nm-marquee-shadow),
+		0 8px 18px -6px var(--cdn-nm-marquee-shadow);
+	/* Sustained shimmer animation — promote to its own GPU layer so the
+	   sweep doesn't dirty the card-sized parent layer. */
+	will-change: transform;
+}
+
+.awsui-dark-mode .feed-next-meetup__marquee {
+	/* Dark-mode deep-teal marquee chrome with lighter teal rim. */
+	--cdn-nm-marquee-bg-from: #064e3b;
+	--cdn-nm-marquee-bg-to: #042f2e;
+	--cdn-nm-marquee-rim: #5eead4;
+	--cdn-nm-marquee-rim-highlight: rgba(167, 243, 208, 0.4);
+	--cdn-nm-marquee-shadow: rgba(0, 0, 0, 0.55);
+	--cdn-nm-marquee-text: #d6fff4;
+	--cdn-nm-marquee-text-glow: rgba(94, 234, 212, 0.55);
+	--cdn-nm-marquee-tape: rgba(167, 243, 208, 0.42);
+	--cdn-nm-marquee-tape-edge: rgba(167, 243, 208, 0);
+
+	box-shadow:
+		0 1px 0 var(--cdn-nm-marquee-rim-highlight) inset,
+		0 -1px 0 rgba(0, 0, 0, 0.6) inset,
+		0 2px 6px var(--cdn-nm-marquee-shadow),
+		0 12px 24px -6px var(--cdn-nm-marquee-shadow);
+}
+
+/* Headline text — bold uppercase, tight tracking. Subtle text-shadow so
+   the lettering reads as emissive against the steel/teal backplate. */
+.feed-next-meetup__marquee-text {
+	position: relative;
+	z-index: 2;
+	display: inline-block;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 1rem;
+	font-weight: 800;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--cdn-nm-marquee-text);
+	text-shadow:
+		0 0 6px var(--cdn-nm-marquee-text-glow),
+		0 1px 0 rgba(245, 252, 255, 0.45);
+	line-height: 1.15;
+}
+
+/* Scrolling-tape shimmer — a horizontal gradient band that slides across
+   the marquee backplate. This is the differentiator vs. featured-event's
+   chasing perimeter bulbs: same theater-marquee mood, different mechanic.
+   The band is wider than the marquee so the entry/exit eased gradient
+   doesn't pop on each loop. */
+.feed-next-meetup__marquee-tape {
+	position: absolute;
+	inset: 0;
+	z-index: 1;
+	pointer-events: none;
+	background: linear-gradient(
+		115deg,
+		var(--cdn-nm-marquee-tape-edge) 0%,
+		var(--cdn-nm-marquee-tape-edge) 38%,
+		var(--cdn-nm-marquee-tape) 50%,
+		var(--cdn-nm-marquee-tape-edge) 62%,
+		var(--cdn-nm-marquee-tape-edge) 100%
+	);
+	background-size: 240% 100%;
+	background-position: 120% 0;
+	opacity: 0.85;
+	border-radius: inherit;
+	mix-blend-mode: screen;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes feed-next-meetup-marquee-tape-sweep {
+		0% {
+			background-position: 120% 0;
+		}
+		70%,
+		100% {
+			background-position: -40% 0;
+		}
+	}
+
+	.feed-next-meetup__marquee-tape {
+		animation: feed-next-meetup-marquee-tape-sweep 5.6s
+			cubic-bezier(0.4, 0, 0.2, 1) infinite;
+	}
+}
+
+/* Reduced-motion fallback — tape settles to a soft centered highlight
+   instead of sweeping. Still reads as a subtle marquee glow. */
+@media (prefers-reduced-motion: reduce) {
+	.feed-next-meetup__marquee-tape {
+		animation: none;
+		background-position: 50% 0;
+		opacity: 0.4;
+	}
+}
+
+/* ---------- Wave 33a — Title link — gradient + scrolling-tape ----------
+
+   Mirrors .feed-featured-event__title a in mechanic (background-clip: text
+   over an animated gradient that shifts background-position) but uses the
+   cooler steel-blue → cyan palette so the two cards read as a family with
+   distinct moods. Applied via .feed-next-meetup__title a, where the title
+   wrapper carries the class on the loaded-state and past-meetup-spotlight
+   branches in the component. */
+.feed-next-meetup__title {
+	letter-spacing: -0.005em;
+	line-height: 1.22;
+}
+
+.feed-next-meetup__title a {
+	background-image: linear-gradient(
+		90deg,
+		var(--cdn-nm-title-from, #0f3457) 0%,
+		var(--cdn-nm-title-mid, #2c5282) 38%,
+		var(--cdn-nm-title-tape, rgba(245, 252, 255, 0.5)) 50%,
+		var(--cdn-nm-title-mid, #2c5282) 62%,
+		var(--cdn-nm-title-from, #0f3457) 100%
+	);
+	background-size: 220% 100%;
+	background-position: 120% 0;
+	background-clip: text;
+	-webkit-background-clip: text;
+	color: transparent;
+	-webkit-text-fill-color: transparent;
+	text-decoration: none;
+	transition: filter 0.2s ease;
+	/* Scroll-tearing mitigation — same hints featured-event uses. */
+	text-rendering: optimizeSpeed;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+.awsui-dark-mode .feed-next-meetup__title a {
+	background-image: linear-gradient(
+		90deg,
+		var(--cdn-nm-title-from, #5eead4) 0%,
+		var(--cdn-nm-title-mid, #99f6e4) 38%,
+		var(--cdn-nm-title-tape, rgba(232, 252, 247, 0.5)) 50%,
+		var(--cdn-nm-title-mid, #99f6e4) 62%,
+		var(--cdn-nm-title-from, #5eead4) 100%
+	);
+	background-size: 220% 100%;
+	background-position: 120% 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes feed-next-meetup-title-tape {
+		0% {
+			background-position: 120% 0;
+		}
+		70%,
+		100% {
+			background-position: -40% 0;
+		}
+	}
+
+	.feed-next-meetup__title a {
+		animation: feed-next-meetup-title-tape 9s cubic-bezier(0.4, 0, 0.2, 1)
+			infinite;
+	}
+}
+
+.feed-next-meetup__title a:hover,
+.feed-next-meetup__title a:focus-visible {
+	filter: brightness(1.1) saturate(1.08);
+}
+
+.feed-next-meetup__title a:focus-visible {
+	outline: 2px solid var(--cdn-nm-title-mid, #2c5282);
+	outline-offset: 3px;
+	border-radius: 2px;
+}
+
+/* ---------- Wave 33a — Date VFX — cool-palette backplate + glow + shimmer
+   ----------
+
+   Same pattern as .feed-featured-event__date-plate but in the cooler
+   steel/teal palette. Date string itself stays plain HTML output from
+   Intl.DateTimeFormat (no SVG, no canvas, no string-split). The wrapper
+   div carries the layout margin; the inner span is the backplate.
+   prefers-reduced-motion: no-preference gates the breathe + shimmer. */
+.feed-next-meetup__date {
+	display: block;
+	margin: 4px 0 2px;
+	font-variant-numeric: tabular-nums;
+}
+
+.feed-next-meetup__date-plate {
+	position: relative;
+	display: inline-block;
+	padding: 6px 14px;
+	border-radius: 8px;
+	background: linear-gradient(
+		135deg,
+		var(--cdn-nm-date-plate-from) 0%,
+		var(--cdn-nm-date-plate-to) 100%
+	);
+	border: 1px solid var(--cdn-nm-date-plate-border);
+	color: var(--cdn-nm-date-text);
+	/* Same scale as featured-event date plate for visual rhyme. */
+	font-size: 1.5rem;
+	font-weight: 800;
+	line-height: 1.15;
+	letter-spacing: 0.01em;
+	font-variant-numeric: tabular-nums;
+	overflow: hidden;
+	box-shadow:
+		inset 0 1px 0 rgba(245, 252, 255, 0.5),
+		0 2px 6px -1px rgba(15, 52, 87, 0.18),
+		0 6px 18px -6px var(--cdn-nm-date-glow);
+	/* Small CSS 3D pop — sits 4px above the card surface so the perspective
+	   on the parent gives it a stamped-floating-above feel. */
+	transform: translateZ(4px);
+	will-change: transform, opacity;
+}
+
+.awsui-dark-mode .feed-next-meetup__date-plate {
+	box-shadow:
+		inset 0 1px 0 rgba(167, 243, 208, 0.22),
+		0 2px 8px -2px rgba(0, 0, 0, 0.4),
+		0 6px 22px -6px var(--cdn-nm-date-glow);
+}
+
+/* Diagonal shimmer sweep across the date plate — slower than the marquee
+   tape (5.6s) so the eye registers each glow individually. */
+.feed-next-meetup__date-plate::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	background: linear-gradient(
+		115deg,
+		transparent 0%,
+		transparent 38%,
+		var(--cdn-nm-date-shimmer) 50%,
+		transparent 62%,
+		transparent 100%
+	);
+	background-size: 240% 100%;
+	background-position: 120% 0;
+	mix-blend-mode: screen;
+	border-radius: inherit;
+	opacity: 0.65;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes feed-next-meetup-date-glow {
+		0%,
+		100% {
+			text-shadow:
+				0 0 0 transparent,
+				0 1px 0 rgba(245, 252, 255, 0.45);
+			box-shadow:
+				inset 0 1px 0 rgba(245, 252, 255, 0.5),
+				0 2px 6px -1px rgba(15, 52, 87, 0.18),
+				0 6px 18px -6px var(--cdn-nm-date-glow);
+		}
+		50% {
+			text-shadow:
+				0 0 6px var(--cdn-nm-date-glow),
+				0 1px 0 rgba(245, 252, 255, 0.45);
+			box-shadow:
+				inset 0 1px 0 rgba(245, 252, 255, 0.6),
+				0 2px 8px -1px rgba(15, 52, 87, 0.22),
+				0 8px 24px -6px var(--cdn-nm-date-glow);
+		}
+	}
+
+	@keyframes feed-next-meetup-date-glow-dark {
+		0%,
+		100% {
+			text-shadow:
+				0 0 0 transparent,
+				0 1px 0 rgba(0, 0, 0, 0.35);
+			box-shadow:
+				inset 0 1px 0 rgba(167, 243, 208, 0.22),
+				0 2px 8px -2px rgba(0, 0, 0, 0.4),
+				0 6px 22px -6px var(--cdn-nm-date-glow);
+		}
+		50% {
+			text-shadow:
+				0 0 8px var(--cdn-nm-date-glow),
+				0 1px 0 rgba(0, 0, 0, 0.35);
+			box-shadow:
+				inset 0 1px 0 rgba(167, 243, 208, 0.3),
+				0 2px 10px -2px rgba(0, 0, 0, 0.45),
+				0 10px 28px -6px var(--cdn-nm-date-glow);
+		}
+	}
+
+	@keyframes feed-next-meetup-date-shimmer {
+		0% {
+			background-position: 120% 0;
+		}
+		70%,
+		100% {
+			background-position: -40% 0;
+		}
+	}
+
+	.feed-next-meetup__date-plate {
+		animation: feed-next-meetup-date-glow 4s ease-in-out infinite;
+	}
+
+	.awsui-dark-mode .feed-next-meetup__date-plate {
+		animation: feed-next-meetup-date-glow-dark 4s ease-in-out infinite;
+	}
+
+	.feed-next-meetup__date-plate::after {
+		animation: feed-next-meetup-date-shimmer 6.5s cubic-bezier(0.4, 0, 0.2, 1)
+			infinite;
+	}
+}
+
+/* ---------- Wave 33a — Reduced-motion fallback ----------
+   Strip every new sustained animation, keep static visuals (gradients, glow,
+   shadows) so the rizz still reads. Drop the will-change GPU hints since
+   no animation is running — holding a dedicated compositor layer per element
+   would be wasted memory. */
+@media (prefers-reduced-motion: reduce) {
+	.feed-next-meetup::after {
+		animation: none;
+		background-position: 50% 0;
+		opacity: 0.4;
+		transform: none;
+	}
+
+	.feed-next-meetup:hover::after {
+		transform: none;
+	}
+
+	.feed-next-meetup__title a,
+	.awsui-dark-mode .feed-next-meetup__title a {
+		animation: none;
+		background-position: 0 0;
+	}
+
+	.feed-next-meetup__date-plate,
+	.awsui-dark-mode .feed-next-meetup__date-plate {
+		animation: none;
+	}
+
+	.feed-next-meetup__date-plate::after {
+		animation: none;
+		background-position: 50% 0;
+		opacity: 0.4;
+	}
+
+	.feed-next-meetup,
+	.feed-next-meetup::after,
+	.feed-next-meetup__marquee,
+	.feed-next-meetup__date-plate {
+		will-change: auto;
+	}
+}
+
+/* ---------- Wave 33a — Pause animations during fast scroll ----------
+   Extends the existing body.cdn-scrolling pause list (wave 30a featured-
+   event) to cover the new sustained animations on the next-meetup card.
+   Skipped under prefers-reduced-motion since those animations are already
+   off in that branch. */
+@media (prefers-reduced-motion: no-preference) {
+	body.cdn-scrolling .feed-next-meetup,
+	body.cdn-scrolling .feed-next-meetup::after,
+	body.cdn-scrolling .feed-next-meetup__marquee-tape,
+	body.cdn-scrolling .feed-next-meetup__title a,
+	body.cdn-scrolling .feed-next-meetup__date-plate,
+	body.cdn-scrolling .awsui-dark-mode .feed-next-meetup__date-plate,
+	body.cdn-scrolling .feed-next-meetup__date-plate::after {
+		animation-play-state: paused;
+	}
+}
+
+/* ---------- Wave 33a — Responsive marquee sizing ----------
+   Scale the marquee text + box height with the card's rendered width so
+   the sign reads proportional across mobile / tablet / desktop. Uses
+   plain min-width media queries since .feed-next-meetup is not yet a
+   CSS container query context (no internal grid layout to query — the
+   card body is still a SpaceBetween stack). If a future wave adds a
+   container-query layout to the next-meetup card, swap these for
+   @container rules to mirror the featured-event pattern. */
+@media (min-width: 520px) {
+	.feed-next-meetup__marquee {
+		min-height: 44px;
+		padding: 10px 36px;
+	}
+
+	.feed-next-meetup__marquee-text {
+		font-size: 1.0625rem;
+		letter-spacing: 0.07em;
+	}
+}
+
+@media (min-width: 860px) {
+	.feed-next-meetup__marquee {
+		min-height: 48px;
+		padding: 12px 44px;
+	}
+
+	.feed-next-meetup__marquee-text {
+		font-size: 1.125rem;
+		letter-spacing: 0.08em;
 	}
 }


### PR DESCRIPTION
Bryan: next-meetup card lacking style by comparison to featured-event.

## what ships
Brings next-meetup to wave 32a featured-event quality, with a deliberately differentiated palette so the cards feel like a family rather than copies.

### palette differentiation
- featured-event: warm amber + chasing bulbs
- **next-meetup (this PR): steel-blue (light) / deep-teal (dark) + scrolling-tape shimmer**
- upcoming-virtual-event (parallel PR): violet+lavender + starfield twinkle

### applied
- Theater marquee header w/ scrolling-tape shimmer span (vs featured's chasing bulbs)
- Date-plate VFX backplate behind meetup date
- Gradient/scrolling-tape title link
- perspective(1200px) + preserve-3d + GPU compositing hints (will-change, contain, translate3d, 1px stage rim)
- NextMeetupErrorBoundary class component mirroring FeaturedEventErrorBoundary
- cdn-scrolling pause integration on all new sustained animations
- prefers-reduced-motion: every animation gated, static fallbacks render correctly

### no image element
The next-meetup card has no <img> today (loading skeleton + CTA fallback + es-MX past-event spotlight). Test #6 explicitly asserts img count = 0; if a future revision adds an image, that test fails until the new img carries an onError hook.

### gates
- biome ci: 0 errors
- npm run build: PASS for main, auth, awsug
- vitest: 679 / 679 PASS (10 new wave-33a tests)