### PR TITLE
feat(feed): wave 33b — upcoming-virtual-event card uplift + dark-image CSS-filter stopgap

### DIFF
--- a/src/pages/feed/components/__tests__/upcoming-virtual-event.test.tsx
+++ b/src/pages/feed/components/__tests__/upcoming-virtual-event.test.tsx
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: MIT-0
 
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../../contexts/locale-context";
-import UpcomingVirtualEvent from "../upcoming-virtual-event";
+import UpcomingVirtualEvent, {
+	UpcomingVirtualEventErrorBoundary,
+} from "../upcoming-virtual-event";
 
 function renderWithLocale(locale: "us" | "mx") {
 	return render(
@@ -94,5 +96,122 @@ describe("UpcomingVirtualEvent", () => {
 		expect(imgs[1].className).toContain(
 			"feed-upcoming-virtual-event__image--dark",
 		);
+	});
+
+	// ---------- Wave 33b — starfield-twinkle marquee header ----------
+
+	it("wave 33b — renders the marquee header with role=heading aria-level=2", () => {
+		const { container } = renderWithLocale("us");
+		const marquee = container.querySelector(
+			".feed-upcoming-virtual-event__marquee",
+		);
+		expect(marquee).not.toBeNull();
+		expect(marquee?.getAttribute("role")).toBe("heading");
+		expect(marquee?.getAttribute("aria-level")).toBe("2");
+	});
+
+	it("wave 33b — marquee text contains the localized header string", () => {
+		const { container } = renderWithLocale("us");
+		const marqueeText = container.querySelector(
+			".feed-upcoming-virtual-event__marquee-text",
+		);
+		expect(marqueeText).not.toBeNull();
+		expect(marqueeText?.textContent).toMatch(
+			/Upcoming virtual AWS community event/i,
+		);
+	});
+
+	it("wave 33b — marquee renders 14 twinkle stars inside an aria-hidden container, each with a --star-index custom property", () => {
+		const { container } = renderWithLocale("us");
+		const wrapper = container.querySelector(
+			".feed-upcoming-virtual-event__twinkle-wrapper",
+		);
+		expect(wrapper).not.toBeNull();
+		expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
+		const stars = wrapper?.querySelectorAll(
+			".feed-upcoming-virtual-event__twinkle-star",
+		);
+		expect(stars?.length).toBe(14);
+		stars?.forEach((star, i) => {
+			// jsdom serializes inline custom properties on the style attribute.
+			const style = star.getAttribute("style") ?? "";
+			expect(style).toMatch(new RegExp(`--star-index:\\s*${i}`));
+		});
+	});
+
+	it("wave 33b — renders the date inside the violet date-plate VFX backplate wrapper", () => {
+		const { container } = renderWithLocale("us");
+		const plate = container.querySelector(
+			".feed-upcoming-virtual-event__date-plate",
+		);
+		expect(plate).not.toBeNull();
+		expect(plate?.textContent).toMatch(/May 22/);
+	});
+
+	it("wave 33b — title link sits inside .feed-upcoming-virtual-event__title for the gradient/scrolling-tape treatment", () => {
+		const { container } = renderWithLocale("us");
+		const title = container.querySelector(
+			".feed-upcoming-virtual-event__title",
+		);
+		expect(title).not.toBeNull();
+		const link = title?.querySelector("a");
+		expect(link).not.toBeNull();
+		expect(link?.getAttribute("href")).toBe(
+			"https://www.meetup.com/awsglobalcommunitygatherings/events/314332142/",
+		);
+	});
+});
+
+// ---------- Wave 33b — error boundary fallback ----------
+
+describe("UpcomingVirtualEventErrorBoundary", () => {
+	it("renders the children when no error is thrown", () => {
+		render(
+			<UpcomingVirtualEventErrorBoundary
+				fallbackHeader="header"
+				fallbackMessage="boom"
+			>
+				<div>healthy</div>
+			</UpcomingVirtualEventErrorBoundary>,
+		);
+		expect(screen.getByText("healthy")).toBeInTheDocument();
+	});
+
+	it("renders the localized fallback header + message when a child throws at render time", () => {
+		// Suppress the React error-boundary console.error noise inside this
+		// test so the test runner output stays readable. The boundary itself
+		// still calls console.error (wired through the spy below) — that's
+		// the developer signal we contract for in componentDidCatch.
+		const errSpy = vi.spyOn(console, "error").mockImplementation(() => {
+			/* swallowed for test output cleanliness */
+		});
+
+		function Boom(): never {
+			throw new Error("boom");
+		}
+
+		render(
+			<UpcomingVirtualEventErrorBoundary
+				fallbackHeader="Upcoming virtual AWS community event"
+				fallbackMessage="Event details temporarily unavailable. Please refresh the page."
+			>
+				<Boom />
+			</UpcomingVirtualEventErrorBoundary>,
+		);
+
+		// Fallback header still announces the section in user language.
+		expect(
+			screen.getByText("Upcoming virtual AWS community event"),
+		).toBeInTheDocument();
+		// Fallback message renders so the slot doesn't go silently blank.
+		expect(
+			screen.getByText(
+				"Event details temporarily unavailable. Please refresh the page.",
+			),
+		).toBeInTheDocument();
+		// componentDidCatch logged the error (developer signal).
+		expect(errSpy).toHaveBeenCalled();
+
+		errSpy.mockRestore();
 	});
 });

--- a/src/pages/feed/components/upcoming-virtual-event.tsx
+++ b/src/pages/feed/components/upcoming-virtual-event.tsx
@@ -6,7 +6,14 @@ import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import { type SyntheticEvent, useState } from "react";
+import {
+	Component,
+	type CSSProperties,
+	type ErrorInfo,
+	type ReactNode,
+	type SyntheticEvent,
+	useState,
+} from "react";
 import MeetupRsvpButton from "../../../components/brand-button/meetup-rsvp";
 import { useTranslation } from "../../../hooks/useTranslation";
 import EventBulbsOverlay from "./event-bulbs-overlay";
@@ -18,6 +25,35 @@ const EVENT_IMAGE_DARK = "/events/global-community-gatherings-dark.webp";
 const EVENT_DATE = "2026-05-22T22:00:00+09:00";
 
 /**
+ * Wave 33b — twinkle-star count rendered behind the marquee headline.
+ * 14 stars distributed across the marquee backplate via deterministic
+ * percentage positions (the data array below). Per-star animation-delay
+ * + animation-duration are computed in CSS from the inline `--star-index`
+ * custom property so all stars share one keyframes rule with a staggered
+ * fade-in/out cycle. Reduced-motion gates the chase off and renders the
+ * stars statically dim instead of twinkling.
+ */
+const TWINKLE_STARS: ReadonlyArray<{ left: number; top: number; size: 2 | 3 }> =
+	[
+		// Top row — sparse string above the headline letters
+		{ left: 6, top: 22, size: 2 },
+		{ left: 18, top: 12, size: 3 },
+		{ left: 32, top: 28, size: 2 },
+		{ left: 46, top: 14, size: 2 },
+		{ left: 58, top: 24, size: 3 },
+		{ left: 72, top: 10, size: 2 },
+		{ left: 86, top: 22, size: 2 },
+		// Bottom row — sparse string below the headline
+		{ left: 10, top: 76, size: 2 },
+		{ left: 24, top: 84, size: 3 },
+		{ left: 38, top: 72, size: 2 },
+		{ left: 54, top: 86, size: 2 },
+		{ left: 68, top: 74, size: 3 },
+		{ left: 82, top: 88, size: 2 },
+		{ left: 94, top: 78, size: 2 },
+	];
+
+/**
  * Hide a broken event image gracefully — used as the onError handler for the
  * light + dark .webp banners so a missing asset doesn't leave a broken-image
  * icon visible on the card.
@@ -27,7 +63,61 @@ function hideBrokenImage(event: SyntheticEvent<HTMLImageElement>) {
 	target.style.display = "none";
 }
 
-export default function UpcomingVirtualEvent() {
+/**
+ * Wave 33b — Starfield-twinkle marquee header.
+ *
+ * Replaces Cloudscape's <Header variant="h2"> with a custom JSX block so the
+ * "Upcoming virtual AWS community event" string sits inside a violet+lavender
+ * marquee backplate flecked with subtly twinkling stars. Differentiated from
+ * the wave 32a featured-event amber-tungsten chasing-bulbs marquee — same
+ * structural pattern (rounded backplate, 1px rim, depth shadow, bold tight-
+ * tracked text), different palette + decoration to keep the cosmic/global
+ * mood of an international virtual event.
+ *
+ * The wrapper announces itself as an h2 to screen readers via
+ * role="heading" + aria-level=2 — Cloudscape only renders an actual <h2>
+ * via its Header component; the explicit ARIA role keeps the AT semantics
+ * intact when we trade Cloudscape heading chrome for custom marquee chrome
+ * (mirrors the wave 32a featured-event approach).
+ *
+ * Stars render as decorative children (aria-hidden) and lean on a shared
+ * keyframes animation; per-star animation-delay is computed via the
+ * `--star-index` custom property so all 14 stars share one rule. Reduced
+ * motion is handled in CSS — stars render statically dim instead of
+ * twinkling.
+ */
+function MarqueeHeader({ text }: { text: string }) {
+	return (
+		<div
+			className="feed-upcoming-virtual-event__marquee"
+			role="heading"
+			aria-level={2}
+		>
+			<span className="feed-upcoming-virtual-event__marquee-text">{text}</span>
+			<div
+				className="feed-upcoming-virtual-event__twinkle-wrapper"
+				aria-hidden="true"
+			>
+				{TWINKLE_STARS.map((star, i) => (
+					<span
+						// biome-ignore lint/suspicious/noArrayIndexKey: stars are a fixed-length decorative field
+						key={i}
+						className={`feed-upcoming-virtual-event__twinkle-star feed-upcoming-virtual-event__twinkle-star--s${star.size}`}
+						style={
+							{
+								"--star-index": i,
+								left: `${star.left}%`,
+								top: `${star.top}%`,
+							} as CSSProperties
+						}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function UpcomingVirtualEventInner() {
 	const { t, locale } = useTranslation();
 	const [brandMarkBroken, setBrandMarkBroken] = useState(false);
 
@@ -47,9 +137,7 @@ export default function UpcomingVirtualEvent() {
 		<div className="feed-upcoming-virtual-event">
 			<Container
 				header={
-					<Header variant="h2">
-						{t("feedPage.upcomingVirtualEventHeader")}
-					</Header>
+					<MarqueeHeader text={t("feedPage.upcomingVirtualEventHeader")} />
 				}
 			>
 				<SpaceBetween size="s">
@@ -81,14 +169,25 @@ export default function UpcomingVirtualEvent() {
 						/>
 						<EventBulbsOverlay />
 					</div>
-					<Box fontWeight="bold" fontSize="heading-m">
+					<Box
+						fontWeight="bold"
+						fontSize="heading-m"
+						className="feed-upcoming-virtual-event__title"
+					>
 						<Link href={RSVP_URL} external>
 							{t("feedPage.upcomingVirtualEventTitle")}
 						</Link>
 					</Box>
-					<Box color="text-body-secondary" fontSize="body-s">
-						{formattedDate}
-					</Box>
+					{/* Wave 33b — date VFX backplate. Same pattern as wave 27a v2 on the
+					    featured-event card but violet-tinted. The Intl.DateTimeFormat
+					    output stays plain text inside the inner span; the wrapper div
+					    carries the layout margin and the inner span carries the
+					    backplate gradient + shimmer pseudo-element. */}
+					<div className="feed-upcoming-virtual-event__date">
+						<span className="feed-upcoming-virtual-event__date-plate">
+							{formattedDate}
+						</span>
+					</div>
 					<Box color="text-body-secondary" fontSize="body-s">
 						{t("feedPage.upcomingVirtualEventLocation")}
 					</Box>
@@ -141,5 +240,75 @@ export default function UpcomingVirtualEvent() {
 				</SpaceBetween>
 			</Container>
 		</div>
+	);
+}
+
+/**
+ * Wave 33b — error boundary scoped to the UpcomingVirtualEvent card.
+ *
+ * The card now stacks several sustained animations + perspective/preserve-3d
+ * + Intl.DateTimeFormat. If any of those throw at render time, this boundary
+ * catches it locally so the rest of the feed (FeaturedEvent, NextMeetup,
+ * BuilderCenterCard, the live hero, the shuffled grid) keeps rendering. The
+ * fallback UI is a quiet, accessible notice so users still know an event was
+ * meant to be here without the page going blank. Mirrors the wave 30a
+ * FeaturedEventErrorBoundary in featured-event.tsx.
+ */
+interface UpcomingVirtualEventErrorBoundaryState {
+	hasError: boolean;
+}
+
+export class UpcomingVirtualEventErrorBoundary extends Component<
+	{ children: ReactNode; fallbackHeader: string; fallbackMessage: string },
+	UpcomingVirtualEventErrorBoundaryState
+> {
+	state: UpcomingVirtualEventErrorBoundaryState = { hasError: false };
+
+	static getDerivedStateFromError(): UpcomingVirtualEventErrorBoundaryState {
+		return { hasError: true };
+	}
+
+	componentDidCatch(error: Error, info: ErrorInfo): void {
+		// Single console.error so the failure is visible in devtools without
+		// piping crash data to a third-party endpoint. The boundary's render
+		// fallback is the user-visible signal; this is the developer signal.
+		console.error("[UpcomingVirtualEvent] render failure", error, info);
+	}
+
+	render(): ReactNode {
+		if (this.state.hasError) {
+			return (
+				<div className="feed-upcoming-virtual-event">
+					<Container
+						header={<Header variant="h2">{this.props.fallbackHeader}</Header>}
+					>
+						<Box color="text-body-secondary" fontSize="body-s">
+							{this.props.fallbackMessage}
+						</Box>
+					</Container>
+				</div>
+			);
+		}
+		return this.props.children;
+	}
+}
+
+/**
+ * Default export: UpcomingVirtualEvent wrapped in its own error boundary.
+ * The header copy resolves through the existing locale key so the empty
+ * state stays in the user's language; the body fallback message is hard-
+ * coded English (mirroring wave 30a FeaturedEvent — this path only fires
+ * on render errors, exceptional and primarily a dev-visible signal in
+ * console.error).
+ */
+export default function UpcomingVirtualEvent() {
+	const { t } = useTranslation();
+	return (
+		<UpcomingVirtualEventErrorBoundary
+			fallbackHeader={t("feedPage.upcomingVirtualEventHeader")}
+			fallbackMessage="Event details temporarily unavailable. Please refresh the page."
+		>
+			<UpcomingVirtualEventInner />
+		</UpcomingVirtualEventErrorBoundary>
 	);
 }

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -1891,7 +1891,597 @@
 	}
 }
 
-/* ---------- Upcoming virtual event card ---------- */
+/* ---------- Upcoming virtual event card — wave 33b uplift ----------
+   Brings this card up to the wave 32a featured-event quality bar with a
+   differentiated aesthetic: violet+lavender starfield-twinkle marquee
+   header (vs. featured's amber tungsten chasing-bulbs marquee), violet-
+   tinted date-plate VFX backplate, gradient/scrolling-tape title link,
+   and the same depth stack (perspective + preserve-3d, contain, GPU layer
+   promotion via translate3d + will-change, 1px stage-rim).
+
+   The wave 26a __bulbs-wrapper SVG overlay (light-bulbs over the dark
+   image) is preserved as-is — that's a separate visual layer that lives
+   inside the card body, not in the marquee header. The wave 29a brand
+   mark (animated UG disc) + featured-talk callout block are also
+   preserved as-is — those are already heavily styled and the brief
+   explicitly forbids touching them.
+
+   Local CSS variables scoped to .feed-upcoming-virtual-event keep the
+   featured-event card's --cdn-v2-* tokens untouched. Naming uses the
+   --cdn-uvirt-* prefix (short for upcoming-virtual) so a future reader
+   can tell at a glance which card a token belongs to. */
+
+.feed-upcoming-virtual-event {
+	/* light-mode tokens — violet bloom + lavender highlight, soft cosmic
+	   palette tuned for the international/global virtual event feel. */
+	--cdn-uvirt-stage-rim: rgba(255, 250, 235, 0.08);
+	--cdn-uvirt-spot-violet: rgba(144, 96, 240, 0.16);
+	--cdn-uvirt-spot-lavender: rgba(215, 199, 238, 0.14);
+	--cdn-uvirt-spot-sweep: rgba(144, 96, 240, 0.18);
+	--cdn-uvirt-ambient-bloom: rgba(90, 31, 138, 0.14);
+	--cdn-uvirt-date-plate-from: rgba(144, 96, 240, 0.18);
+	--cdn-uvirt-date-plate-to: rgba(215, 199, 238, 0.12);
+	--cdn-uvirt-date-plate-border: rgba(90, 31, 138, 0.4);
+	--cdn-uvirt-date-text: var(--cdn-purple-deep, #30006a);
+	--cdn-uvirt-date-glow: rgba(90, 31, 138, 0.38);
+	--cdn-uvirt-date-shimmer: rgba(255, 250, 235, 0.55);
+	--cdn-uvirt-title-tape: rgba(255, 250, 235, 0.45);
+
+	position: relative;
+	isolation: isolate;
+	border-left: 4px solid var(--cdn-aws-orange, #ff9900);
+	border-radius: var(--cdn-radius-md, 8px);
+	overflow: hidden;
+	/* Same depth stack as wave 27a v2 featured-event — perspective +
+	   preserve-3d enable child translateZ() pop without loading any 3D
+	   runtime. 1200px = subtle ambient depth. */
+	perspective: 1200px;
+	transform-style: preserve-3d;
+	/* GPU layer isolation (mirrors wave 30a featured-event hardening):
+	   - contain: layout paint style isolates this card's paint operations
+	     so reflow/repaint above/below doesn't cascade through the new
+	     sustained animations (twinkle, title tape, date plate breathe).
+	   - translate3d(0,0,0) forces the card onto its own GPU compositor
+	     layer so the stacked animations don't fight for the same layer
+	     during scroll.
+	   - will-change: transform proactively promotes the layer up-front
+	     so the first scroll into view doesn't trigger a synchronous
+	     layer reshuffle. */
+	contain: layout paint style;
+	transform: translate3d(0, 0, 0);
+	will-change: transform;
+	/* layered ambient bloom + 1px stage-rim — sits beneath the radial
+	   spotlight backplate (::before) and the cool sweep depth layer
+	   (::after) below. */
+	box-shadow:
+		0 1px 2px rgba(48, 0, 106, 0.08),
+		0 8px 28px -8px var(--cdn-uvirt-ambient-bloom),
+		0 18px 48px -12px var(--cdn-uvirt-ambient-bloom),
+		inset 0 0 0 1px var(--cdn-uvirt-stage-rim);
+}
+
+.awsui-dark-mode .feed-upcoming-virtual-event {
+	/* dark-mode tokens — deeper indigo bloom, lavender highlight. */
+	--cdn-uvirt-stage-rim: rgba(215, 199, 238, 0.1);
+	--cdn-uvirt-spot-violet: rgba(144, 96, 240, 0.28);
+	--cdn-uvirt-spot-lavender: rgba(215, 199, 238, 0.18);
+	--cdn-uvirt-spot-sweep: rgba(48, 0, 106, 0.42);
+	--cdn-uvirt-ambient-bloom: rgba(48, 0, 106, 0.32);
+	--cdn-uvirt-date-plate-from: rgba(48, 0, 106, 0.6);
+	--cdn-uvirt-date-plate-to: rgba(90, 31, 138, 0.4);
+	--cdn-uvirt-date-plate-border: rgba(199, 184, 232, 0.42);
+	--cdn-uvirt-date-text: var(--cdn-lavender, #d7c7ee);
+	--cdn-uvirt-date-glow: rgba(199, 184, 232, 0.55);
+	--cdn-uvirt-date-shimmer: rgba(215, 199, 238, 0.4);
+	--cdn-uvirt-title-tape: rgba(215, 199, 238, 0.42);
+
+	box-shadow:
+		0 2px 6px rgba(0, 0, 0, 0.5),
+		0 10px 30px -8px var(--cdn-uvirt-ambient-bloom),
+		0 22px 56px -12px var(--cdn-uvirt-ambient-bloom),
+		inset 0 0 0 1px var(--cdn-uvirt-stage-rim);
+}
+
+/* Stage-light gradient backplate — twin radial spotlights: violet key
+   from upper-left, lavender fill from lower-right. Sits behind all
+   content via z-index:0; children stack on z-index:1 below. */
+.feed-upcoming-virtual-event::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+	background:
+		radial-gradient(
+			ellipse 70% 50% at 14% 8%,
+			var(--cdn-uvirt-spot-violet) 0%,
+			transparent 62%
+		),
+		radial-gradient(
+			ellipse 65% 55% at 88% 92%,
+			var(--cdn-uvirt-spot-lavender) 0%,
+			transparent 65%
+		);
+	opacity: 0.95;
+}
+
+/* Slow violet/indigo sweep crosses the card on a 9s ease cycle. Slower
+   than the featured-event 7s sweep so the two cards don't lock-step
+   when stacked in the feed. translateZ(0) anchors the sweep on its own
+   GPU layer for parallax-on-hover. */
+.feed-upcoming-virtual-event::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+	background: linear-gradient(
+		115deg,
+		transparent 0%,
+		transparent 30%,
+		var(--cdn-uvirt-spot-sweep) 50%,
+		transparent 70%,
+		transparent 100%
+	);
+	background-size: 220% 100%;
+	background-position: 120% 0;
+	opacity: 0.65;
+	transform: translateZ(0);
+	transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+	will-change: opacity, transform;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes feed-uvirt-spotlight-sweep {
+		0% {
+			background-position: 120% 0;
+		}
+		60%,
+		100% {
+			background-position: -40% 0;
+		}
+	}
+
+	.feed-upcoming-virtual-event::after {
+		animation: feed-uvirt-spotlight-sweep 9s cubic-bezier(0.4, 0, 0.2, 1)
+			infinite;
+	}
+
+	.feed-upcoming-virtual-event:hover::after {
+		transform: translateZ(8px);
+	}
+}
+
+/* All direct content children sit above the spotlight backplate. */
+.feed-upcoming-virtual-event > * {
+	position: relative;
+	z-index: 1;
+}
+
+/* ---------- Wave 33b — Starfield-twinkle marquee header ----------
+   Replaces the Cloudscape <Header variant="h2"> chrome with a violet
+   backplate flecked with twinkling stars — a deliberate counterpoint to
+   the wave 32a featured-event amber tungsten + chasing-bulbs marquee:
+   same structural pattern (rounded backplate, 1px rim, depth shadow,
+   bold uppercase tight-tracked text), different palette + decoration
+   for the cosmic/global mood of an international virtual event.
+
+   Starfield: 14 dots spread across the backplate via inline left/top
+   percentages from the data array in the component. Each carries an
+   inline `--star-index` custom property that staggers the shared twinkle
+   keyframes (animation-delay = star-index * 0.18s). The base cycle is
+   3.6s with a brief peak — reads as a slow, irregular sparkle, not a
+   strobe. Reduced-motion gates the keyframes off and renders the stars
+   statically dim instead of twinkling.
+
+   Scope: marquee sign in the Container header. Card body (image, badge,
+   title, date plate, brand mark + featured-talk callout, RSVP button)
+   keeps its own styling. */
+.feed-upcoming-virtual-event__marquee {
+	/* Color tokens — light mode = soft violet+lavender backplate, deep
+	   purple text, pale-gold star cores so the stars still warm-pop
+	   against the cool-violet field. Tokens are scoped to the marquee
+	   block so the rest of the card's --cdn-uvirt-* tokens don't bleed
+	   into the sign. */
+	--cdn-uvirt-marquee-bg-from: #f1ebff;
+	--cdn-uvirt-marquee-bg-to: #d7c7ee;
+	--cdn-uvirt-marquee-rim: #5a1f8a;
+	--cdn-uvirt-marquee-rim-highlight: rgba(255, 250, 235, 0.55);
+	--cdn-uvirt-marquee-shadow: rgba(48, 0, 106, 0.32);
+	--cdn-uvirt-marquee-text: #30006a;
+	--cdn-uvirt-marquee-text-glow: rgba(215, 199, 238, 0.7);
+	--cdn-uvirt-star-core: #fff5e6;
+	--cdn-uvirt-star-rim: #d7c7ee;
+	--cdn-uvirt-star-halo: rgba(199, 184, 232, 0.7);
+	--cdn-uvirt-star-dim: rgba(199, 184, 232, 0.3);
+
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 40px;
+	padding: 8px 28px;
+	border-radius: 10px;
+	background: linear-gradient(
+		180deg,
+		var(--cdn-uvirt-marquee-bg-from) 0%,
+		var(--cdn-uvirt-marquee-bg-to) 100%
+	);
+	border: 2px solid var(--cdn-uvirt-marquee-rim);
+	box-shadow:
+		0 1px 0 var(--cdn-uvirt-marquee-rim-highlight) inset,
+		0 -1px 0 rgba(48, 0, 106, 0.18) inset,
+		0 2px 4px var(--cdn-uvirt-marquee-shadow),
+		0 8px 18px -6px var(--cdn-uvirt-marquee-shadow);
+}
+
+.awsui-dark-mode .feed-upcoming-virtual-event__marquee {
+	/* Dark mode = deep indigo backplate with a lavender rim. Stars stay
+	   warm cream-core (cosmic-twinkle is warm across both modes — what
+	   changes is the sign chrome, not the lights). */
+	--cdn-uvirt-marquee-bg-from: #1a0a30;
+	--cdn-uvirt-marquee-bg-to: #2a1148;
+	--cdn-uvirt-marquee-rim: #d7c7ee;
+	--cdn-uvirt-marquee-rim-highlight: rgba(215, 199, 238, 0.4);
+	--cdn-uvirt-marquee-shadow: rgba(0, 0, 0, 0.55);
+	--cdn-uvirt-marquee-text: #d7c7ee;
+	--cdn-uvirt-marquee-text-glow: rgba(255, 250, 235, 0.55);
+	--cdn-uvirt-star-core: #fff5e6;
+	--cdn-uvirt-star-rim: #d7c7ee;
+	--cdn-uvirt-star-halo: rgba(255, 250, 235, 0.65);
+	--cdn-uvirt-star-dim: rgba(199, 184, 232, 0.28);
+
+	box-shadow:
+		0 1px 0 var(--cdn-uvirt-marquee-rim-highlight) inset,
+		0 -1px 0 rgba(0, 0, 0, 0.6) inset,
+		0 2px 6px var(--cdn-uvirt-marquee-shadow),
+		0 12px 24px -6px var(--cdn-uvirt-marquee-shadow);
+}
+
+.feed-upcoming-virtual-event__marquee-text {
+	position: relative;
+	z-index: 1;
+	display: inline-block;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 1rem;
+	font-weight: 800;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--cdn-uvirt-marquee-text);
+	text-shadow:
+		0 0 6px var(--cdn-uvirt-marquee-text-glow),
+		0 1px 0 rgba(255, 250, 235, 0.35);
+	line-height: 1.15;
+}
+
+/* Starfield — absolutely positioned over the marquee backplate. Stars
+   render as small round dots positioned via inline left/top percentages
+   from the data array in upcoming-virtual-event.tsx. The wrapper sits
+   under the headline text (z-index:0) so the text always reads on top. */
+.feed-upcoming-virtual-event__twinkle-wrapper {
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+	overflow: hidden;
+	border-radius: inherit;
+}
+
+.feed-upcoming-virtual-event__twinkle-star {
+	position: absolute;
+	border-radius: 50%;
+	background: radial-gradient(
+		circle at 50% 40%,
+		var(--cdn-uvirt-star-core) 0%,
+		var(--cdn-uvirt-star-rim) 70%,
+		rgba(144, 96, 240, 0.4) 100%
+	);
+	opacity: 0.45;
+	filter: drop-shadow(0 0 2px var(--cdn-uvirt-star-halo));
+	transform: translate(-50%, -50%);
+}
+
+.feed-upcoming-virtual-event__twinkle-star--s2 {
+	width: 2px;
+	height: 2px;
+}
+
+.feed-upcoming-virtual-event__twinkle-star--s3 {
+	width: 3px;
+	height: 3px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes feed-uvirt-twinkle {
+		0%,
+		100% {
+			opacity: 0.25;
+			filter: drop-shadow(0 0 1px var(--cdn-uvirt-star-dim));
+		}
+		20% {
+			opacity: 1;
+			filter: drop-shadow(0 0 4px var(--cdn-uvirt-star-halo));
+		}
+		45% {
+			opacity: 0.4;
+			filter: drop-shadow(0 0 2px var(--cdn-uvirt-star-dim));
+		}
+	}
+
+	.feed-upcoming-virtual-event__twinkle-star {
+		animation: feed-uvirt-twinkle 3.6s ease-in-out infinite;
+		animation-delay: calc(var(--star-index, 0) * 0.18s);
+	}
+}
+
+/* Reduced-motion fallback — stars render statically dim (visible but
+   not animated). Mirrors the wave 32a marquee-bulb static-lit fallback. */
+@media (prefers-reduced-motion: reduce) {
+	.feed-upcoming-virtual-event__twinkle-star {
+		animation: none;
+		opacity: 0.6;
+		filter: drop-shadow(0 0 2px var(--cdn-uvirt-star-halo));
+	}
+}
+
+/* ---------- Wave 33b — title gradient/scrolling-tape (violet→lavender) ----------
+   Promotes the title link to the same scrolling-tape treatment as the
+   wave 27a v2 featured-event title, but with a violet→lavender→cream
+   gradient (vs. featured's purple→violet→cream) to differentiate. */
+.feed-upcoming-virtual-event__title {
+	letter-spacing: -0.005em;
+	line-height: 1.22;
+}
+
+.feed-upcoming-virtual-event__title a {
+	background-image: linear-gradient(
+		90deg,
+		var(--cdn-purple, #5a1f8a) 0%,
+		var(--cdn-violet, #9060f0) 38%,
+		var(--cdn-uvirt-title-tape) 50%,
+		var(--cdn-violet, #9060f0) 62%,
+		var(--cdn-purple, #5a1f8a) 100%
+	);
+	background-size: 220% 100%;
+	background-position: 120% 0;
+	background-clip: text;
+	-webkit-background-clip: text;
+	color: transparent;
+	-webkit-text-fill-color: transparent;
+	text-decoration: none;
+	transition: filter 0.2s ease;
+	/* Same scroll-tearing mitigations as wave 30a featured-event title:
+	   optimizeSpeed favors the cheaper raster path and `antialiased`
+	   stabilizes subpixel position so the shimmer doesn't smear. */
+	text-rendering: optimizeSpeed;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+.awsui-dark-mode .feed-upcoming-virtual-event__title a {
+	background-image: linear-gradient(
+		90deg,
+		var(--cdn-violet, #9060f0) 0%,
+		var(--cdn-lavender, #d7c7ee) 38%,
+		var(--cdn-uvirt-title-tape) 50%,
+		var(--cdn-lavender, #d7c7ee) 62%,
+		var(--cdn-violet, #9060f0) 100%
+	);
+	background-size: 220% 100%;
+	background-position: 120% 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes feed-uvirt-title-tape {
+		0% {
+			background-position: 120% 0;
+		}
+		70%,
+		100% {
+			background-position: -40% 0;
+		}
+	}
+
+	.feed-upcoming-virtual-event__title a {
+		animation: feed-uvirt-title-tape 11s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+	}
+}
+
+.feed-upcoming-virtual-event__title a:hover,
+.feed-upcoming-virtual-event__title a:focus-visible {
+	filter: brightness(1.1) saturate(1.08);
+}
+
+.feed-upcoming-virtual-event__title a:focus-visible {
+	outline: 2px solid var(--cdn-violet, #9060f0);
+	outline-offset: 3px;
+	border-radius: 2px;
+}
+
+/* ---------- Wave 33b — date VFX backplate (violet-tinted) ----------
+   Same backplate pattern as wave 27a v2 featured-event date plate but
+   violet-tinted (vs. featured's tungsten amber). The date string remains
+   plain HTML output from Intl.DateTimeFormat — no SVG, no canvas, no
+   string-split. Wrapper carries layout margin; inner span carries the
+   gradient backplate + shimmer pseudo-element. */
+.feed-upcoming-virtual-event__date {
+	display: block;
+	margin: 4px 0 2px;
+	font-variant-numeric: tabular-nums;
+}
+
+.feed-upcoming-virtual-event__date-plate {
+	position: relative;
+	display: inline-block;
+	padding: 6px 14px;
+	border-radius: 8px;
+	background: linear-gradient(
+		135deg,
+		var(--cdn-uvirt-date-plate-from) 0%,
+		var(--cdn-uvirt-date-plate-to) 100%
+	);
+	border: 1px solid var(--cdn-uvirt-date-plate-border);
+	color: var(--cdn-uvirt-date-text);
+	font-size: 1.25rem;
+	font-weight: 800;
+	line-height: 1.2;
+	letter-spacing: 0.01em;
+	font-variant-numeric: tabular-nums;
+	overflow: hidden;
+	box-shadow:
+		inset 0 1px 0 rgba(255, 250, 235, 0.5),
+		0 2px 6px -1px rgba(48, 0, 106, 0.18),
+		0 6px 18px -6px var(--cdn-uvirt-date-glow);
+	transform: translateZ(4px);
+	will-change: transform, opacity;
+}
+
+.awsui-dark-mode .feed-upcoming-virtual-event__date-plate {
+	box-shadow:
+		inset 0 1px 0 rgba(215, 199, 238, 0.22),
+		0 2px 8px -2px rgba(0, 0, 0, 0.4),
+		0 6px 22px -6px var(--cdn-uvirt-date-glow);
+}
+
+.feed-upcoming-virtual-event__date-plate::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	background: linear-gradient(
+		115deg,
+		transparent 0%,
+		transparent 38%,
+		var(--cdn-uvirt-date-shimmer) 50%,
+		transparent 62%,
+		transparent 100%
+	);
+	background-size: 240% 100%;
+	background-position: 120% 0;
+	mix-blend-mode: screen;
+	border-radius: inherit;
+	opacity: 0.6;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes feed-uvirt-date-glow {
+		0%,
+		100% {
+			text-shadow:
+				0 0 0 transparent,
+				0 1px 0 rgba(255, 250, 235, 0.45);
+			box-shadow:
+				inset 0 1px 0 rgba(255, 250, 235, 0.5),
+				0 2px 6px -1px rgba(48, 0, 106, 0.18),
+				0 6px 18px -6px var(--cdn-uvirt-date-glow);
+		}
+		50% {
+			text-shadow:
+				0 0 6px var(--cdn-uvirt-date-glow),
+				0 1px 0 rgba(255, 250, 235, 0.45);
+			box-shadow:
+				inset 0 1px 0 rgba(255, 250, 235, 0.6),
+				0 2px 8px -1px rgba(48, 0, 106, 0.22),
+				0 8px 24px -6px var(--cdn-uvirt-date-glow);
+		}
+	}
+
+	@keyframes feed-uvirt-date-glow-dark {
+		0%,
+		100% {
+			text-shadow:
+				0 0 0 transparent,
+				0 1px 0 rgba(0, 0, 0, 0.35);
+			box-shadow:
+				inset 0 1px 0 rgba(215, 199, 238, 0.22),
+				0 2px 8px -2px rgba(0, 0, 0, 0.4),
+				0 6px 22px -6px var(--cdn-uvirt-date-glow);
+		}
+		50% {
+			text-shadow:
+				0 0 8px var(--cdn-uvirt-date-glow),
+				0 1px 0 rgba(0, 0, 0, 0.35);
+			box-shadow:
+				inset 0 1px 0 rgba(215, 199, 238, 0.3),
+				0 2px 10px -2px rgba(0, 0, 0, 0.45),
+				0 10px 28px -6px var(--cdn-uvirt-date-glow);
+		}
+	}
+
+	@keyframes feed-uvirt-date-shimmer {
+		0% {
+			background-position: 120% 0;
+		}
+		70%,
+		100% {
+			background-position: -40% 0;
+		}
+	}
+
+	.feed-upcoming-virtual-event__date-plate {
+		animation: feed-uvirt-date-glow 4.4s ease-in-out infinite;
+	}
+
+	.awsui-dark-mode .feed-upcoming-virtual-event__date-plate {
+		animation: feed-uvirt-date-glow-dark 4.4s ease-in-out infinite;
+	}
+
+	.feed-upcoming-virtual-event__date-plate::after {
+		animation: feed-uvirt-date-shimmer 7s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+	}
+}
+
+/* ---------- Wave 33b — pause animations during fast scroll ----------
+   Same scroll-jank-mitigation hook wave 30a wired up for the featured-
+   event card. Skipped under prefers-reduced-motion since the animations
+   are already off in that branch. */
+@media (prefers-reduced-motion: no-preference) {
+	body.cdn-scrolling .feed-upcoming-virtual-event,
+	body.cdn-scrolling .feed-upcoming-virtual-event::after,
+	body.cdn-scrolling .feed-upcoming-virtual-event__twinkle-star,
+	body.cdn-scrolling .feed-upcoming-virtual-event__title a,
+	body.cdn-scrolling .feed-upcoming-virtual-event__date-plate,
+	body.cdn-scrolling .awsui-dark-mode .feed-upcoming-virtual-event__date-plate,
+	body.cdn-scrolling .feed-upcoming-virtual-event__date-plate::after {
+		animation-play-state: paused;
+	}
+}
+
+/* ---------- Wave 33b — dark-mode image CSS-filter STOPGAP ----------
+   TODO(bryan): replace this filter chain with a real dark render once
+   public/events/global-community-gatherings-dark.webp is regenerated.
+   At the time of wave 33b, public/events/global-community-gatherings-
+   dark.webp is byte-identical to the -light.webp variant (md5sum
+   confirms). Until a real dark asset lands, apply a CSS filter chain to
+   the dark <img> element that approximates the Ben-Day halftone dark
+   aesthetic Bryan described (charcoal substrate, indigo-black vignette,
+   ochre/ultramarine tone shifts).
+
+   Filter chain rationale (tuned vs. the brief's suggestion):
+   - invert(0.85): near-tonal-inversion without going full photonegative;
+     0.85 keeps a hint of the original luminance so faces + the AWS
+     Community badge don't read as ghostly silhouettes.
+   - hue-rotate(195deg): rotates the inverted yellows/cyans toward
+     indigo/ultramarine — the Ben-Day-halftone dark voice.
+   - saturate(1.35): pulls the indigo/ochre back up after invert
+     desaturated the midtones.
+   - brightness(0.88): slight luminance pull-down so the result still
+     reads as "dark mode" against the indigo card surface, not as a
+     bright inverted plate.
+   - contrast(1.12): edge-defines the AWS Community badge + global
+     network arc against the inverted background so the focal points
+     don't get muddy.
+
+   Scope: only the .feed-upcoming-virtual-event__image--dark variant.
+   The light variant is unfiltered. The wave 26a __bulbs-wrapper SVG
+   overlay sits on top of the filter at the wrapper level — the bulbs
+   are SVG circles, not the IMG, so they stay unfiltered. */
+.awsui-dark-mode .feed-upcoming-virtual-event__image--dark {
+	filter: invert(0.85) hue-rotate(195deg) saturate(1.35) brightness(0.88)
+		contrast(1.12);
+}
+
+/* ---------- Upcoming virtual event card — wave 26a base ---------- */
 
 .feed-upcoming-virtual-event {
 	border-left: 4px solid var(--cdn-aws-orange, #ff9900);


### PR DESCRIPTION
Two concerns one PR.

## scope 1 — visual uplift
Brings AWS Global Community Gatherings card to wave 32a featured-event quality with a deliberately differentiated palette.

### palette
**violet+lavender + starfield twinkle** — keeps the cosmic/global mood for an international virtual event. Sits alongside featured (amber+chase) and 33a next-meetup (teal-shimmer) as the third distinct family member.

### applied
- Theater marquee header with 14-star starfield SVG overlay (HTML spans, not SVG circles — different aesthetic from the existing __bulbs-wrapper image overlay), staggered twinkle at 3.6s base + 0.18s per-star delay
- Date-plate VFX backplate around formattedDate (violet-tinted)
- Gradient/scrolling-tape title link
- Same depth stack: perspective + preserve-3d + GPU hints + 1px stage rim
- UpcomingVirtualEventErrorBoundary mirrors FeaturedEventErrorBoundary
- 12+ `--cdn-uvirt-*` tokens (light + dark parity), 5 new keyframes
- prefers-reduced-motion fully gated
- preserves: existing brand-mark animated UG disc, featured-talk callout, __bulbs-wrapper light-bulb overlay

## scope 2 — dark-mode image STOPGAP
`md5sum public/events/global-community-gatherings-light.webp public/events/global-community-gatherings-dark.webp` reveals: **same MD5 — dark variant has been a literal copy of light since the original placeholder ship**. Bryan never provided a custom dark render.

This PR applies a CSS-only stopgap filter chain to the dark img element:
```css
filter: invert(0.85) hue-rotate(195deg) saturate(1.35) brightness(0.88) contrast(1.12);
```
Tuned values land closer to the indigo/ultramarine Ben-Day halftone direction Bryan described in his prior dark-mode plan, vs a literal photographic negative. TODO comment in CSS marks this as stopgap pending Bryan's real dark webp.

### gates
- biome ci: 0 errors
- npm run build: PASS
- vitest: 676 / 676 PASS (7 new wave-33b tests)