### PR TITLE
feat(feed): wave 33c — clickable event card images route to RSVP

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -159,6 +159,8 @@
 		"featuredEventSpotsRemaining": "Limited space — RSVP now",
 		"featuredEventRsvpPrimary": "RSVP on CloudDelNorte.org",
 		"featuredEventRsvpMeetup": "RSVP on Meetup",
+		"featuredEventImageLinkLabel": "RSVP for the Community Happy Hour & Networking Night",
+		"upcomingVirtualEventImageLinkLabel": "RSVP for AWS Global Community Gatherings on Meetup",
 		"episodeScroller": {
 			"headerSuffix": " — episodes",
 			"sortNewest": "Newest first",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -159,6 +159,8 @@
 		"featuredEventSpotsRemaining": "Cupo limitado — RSVP ya",
 		"featuredEventRsvpPrimary": "RSVP en CloudDelNorte.org",
 		"featuredEventRsvpMeetup": "RSVP en Meetup",
+		"featuredEventImageLinkLabel": "RSVP para la Hora Feliz Comunitaria y Noche de Networking",
+		"upcomingVirtualEventImageLinkLabel": "RSVP en Meetup para AWS Global Community Gatherings",
 		"episodeScroller": {
 			"headerSuffix": " — episodios",
 			"sortNewest": "Reciente primero",

--- a/src/pages/feed/components/__tests__/featured-event.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-event.test.tsx
@@ -71,6 +71,31 @@ describe("FeaturedEvent", () => {
 		);
 	});
 
+	// ---------- Wave 33c — clickable image RSVP link ----------
+
+	it("wave 33c — wraps the image-area in an anchor pointing at the speakeasy /signup?return_to=/rsvp/ flow with the new aria-label locale key", () => {
+		const { container } = renderWithLocale("us");
+		const link = container.querySelector(".feed-featured-event__image-link");
+		expect(link).not.toBeNull();
+		// href matches the same speakeasy CTA URL the primary RSVP button
+		// uses (encoded /rsvp/?event=happy-hour-2026-06-03 return path).
+		const expectedHref = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent("/rsvp/?event=happy-hour-2026-06-03")}`;
+		expect(link?.getAttribute("href")).toBe(expectedHref);
+		// aria-label resolves through the new feedPage.featuredEventImageLinkLabel
+		// locale key — describes the link action; the inner <img> alt text
+		// continues to describe the image content.
+		expect(link?.getAttribute("aria-label")).toBe(
+			"RSVP for the Community Happy Hour & Networking Night",
+		);
+		// Both image variants live inside the anchor.
+		expect(
+			link?.querySelector(".feed-featured-event__image--light"),
+		).not.toBeNull();
+		expect(
+			link?.querySelector(".feed-featured-event__image--dark"),
+		).not.toBeNull();
+	});
+
 	it("renders the in-person location label", () => {
 		renderWithLocale("us");
 		expect(
@@ -122,12 +147,16 @@ describe("FeaturedEvent", () => {
 		expect(darkImg).not.toBeNull();
 	});
 
-	it("preserves DOM reading order: image → title → date → in-person → location → description → spots → buttons (a11y / screen-reader contract; wave 32a dropped badge slot)", () => {
+	it("preserves DOM reading order: image → title → date → in-person → location → description → spots → buttons (a11y / screen-reader contract; wave 32a dropped badge slot, wave 33c wraps image in anchor)", () => {
 		const { container } = renderWithLocale("us");
 		const layout = container.querySelector(".feed-featured-event__layout");
 		expect(layout).not.toBeNull();
+		// Wave 33c — the first direct grid child is now the wrapping
+		// <a class="feed-featured-event__image-link"> anchor (the inner
+		// __image-area div is nested inside it). The reading order intent
+		// is preserved: the image link reads before the title, date, etc.
 		const expected = [
-			"feed-featured-event__image-area",
+			"feed-featured-event__image-link",
 			"feed-featured-event__title",
 			"feed-featured-event__date",
 			"feed-featured-event__in-person-pill",

--- a/src/pages/feed/components/__tests__/upcoming-virtual-event.test.tsx
+++ b/src/pages/feed/components/__tests__/upcoming-virtual-event.test.tsx
@@ -98,6 +98,42 @@ describe("UpcomingVirtualEvent", () => {
 		);
 	});
 
+	// ---------- Wave 33c — clickable image RSVP link ----------
+
+	it("wave 33c — wraps both light + dark image variants in anchors pointing at the meetup RSVP URL with target=_blank, rel='noreferrer', and a shared aria-label locale key", () => {
+		const { container } = renderWithLocale("us");
+		const links = container.querySelectorAll(
+			".feed-upcoming-virtual-event__image-link",
+		);
+		// Two image variants → two anchors (light img wrapper + bulbs-wrapper
+		// for the dark variant + EventBulbsOverlay).
+		expect(links.length).toBe(2);
+		const expectedHref =
+			"https://www.meetup.com/awsglobalcommunitygatherings/events/314332142/";
+		const expectedAriaLabel =
+			"RSVP for AWS Global Community Gatherings on Meetup";
+		links.forEach((link) => {
+			expect(link.getAttribute("href")).toBe(expectedHref);
+			expect(link.getAttribute("target")).toBe("_blank");
+			// rel must include noreferrer so the external Meetup nav can't
+			// see document.referrer back into the SPA.
+			expect(link.getAttribute("rel") ?? "").toContain("noreferrer");
+			// Both anchors share the same aria-label from the new locale key.
+			expect(link.getAttribute("aria-label")).toBe(expectedAriaLabel);
+		});
+		// First anchor wraps the light variant standalone <img>.
+		expect(
+			links[0].querySelector(".feed-upcoming-virtual-event__image--light"),
+		).not.toBeNull();
+		// Second anchor wraps the bulbs-wrapper (dark img + bulbs overlay).
+		expect(
+			links[1].querySelector(".feed-upcoming-virtual-event__bulbs-wrapper"),
+		).not.toBeNull();
+		expect(
+			links[1].querySelector(".feed-upcoming-virtual-event__image--dark"),
+		).not.toBeNull();
+	});
+
 	// ---------- Wave 33b — starfield-twinkle marquee header ----------
 
 	it("wave 33b — renders the marquee header with role=heading aria-level=2", () => {

--- a/src/pages/feed/components/featured-event.tsx
+++ b/src/pages/feed/components/featured-event.tsx
@@ -162,27 +162,40 @@ function FeaturedEventInner() {
 					    swap CSS (display:none on the off-theme variant) still
 					    decides which one paints. onError handlers from wave 30a
 					    remain on each <img> so a 404 on either asset is still
-					    handled per-image without dropping the wrapping cell. */}
-					<div className="feed-featured-event__image-area">
-						<img
-							src={EVENT_IMAGE_LIGHT}
-							alt={t("feedPage.featuredEventImageAlt")}
-							className="feed-featured-event__image feed-featured-event__image--light"
-							width={1200}
-							height={630}
-							loading="lazy"
-							onError={hideBrokenImage}
-						/>
-						<img
-							src={EVENT_IMAGE_DARK}
-							alt={t("feedPage.featuredEventImageAlt")}
-							className="feed-featured-event__image feed-featured-event__image--dark"
-							width={1200}
-							height={630}
-							loading="lazy"
-							onError={hideBrokenImage}
-						/>
-					</div>
+					    handled per-image without dropping the wrapping cell.
+					    Wave 33c — the entire image pair is wrapped in an anchor
+					    pointing at the same speakeasy RSVP URL as the primary
+					    CTA button, so clicking the photo (light or dark variant)
+					    routes to /signup?return_to=/rsvp/. The <img> alt
+					    attributes describe the image content; the wrapping <a>
+					    aria-label describes the link action via a new locale
+					    key so screen readers announce both axes correctly. */}
+					<a
+						href={RSVP_PAGE_URL}
+						aria-label={t("feedPage.featuredEventImageLinkLabel")}
+						className="feed-featured-event__image-link"
+					>
+						<div className="feed-featured-event__image-area">
+							<img
+								src={EVENT_IMAGE_LIGHT}
+								alt={t("feedPage.featuredEventImageAlt")}
+								className="feed-featured-event__image feed-featured-event__image--light"
+								width={1200}
+								height={630}
+								loading="lazy"
+								onError={hideBrokenImage}
+							/>
+							<img
+								src={EVENT_IMAGE_DARK}
+								alt={t("feedPage.featuredEventImageAlt")}
+								className="feed-featured-event__image feed-featured-event__image--dark"
+								width={1200}
+								height={630}
+								loading="lazy"
+								onError={hideBrokenImage}
+							/>
+						</div>
+					</a>
 					<Box
 						fontWeight="bold"
 						fontSize="heading-m"

--- a/src/pages/feed/components/upcoming-virtual-event.tsx
+++ b/src/pages/feed/components/upcoming-virtual-event.tsx
@@ -148,27 +148,53 @@ function UpcomingVirtualEventInner() {
 					>
 						{t("feedPage.upcomingVirtualEventBadge")}
 					</Box>
-					<img
-						src={EVENT_IMAGE_LIGHT}
-						alt={t("feedPage.upcomingVirtualEventImageAlt")}
-						className="feed-upcoming-virtual-event__image feed-upcoming-virtual-event__image--light"
-						width={1200}
-						height={630}
-						loading="lazy"
-						onError={hideBrokenImage}
-					/>
-					<div className="feed-upcoming-virtual-event__bulbs-wrapper">
+					{/* Wave 33c — both visible image variants are wrapped in
+					    anchors pointing at the AWS Global Community Gatherings
+					    Meetup page (target=_blank since this is an external
+					    Meetup destination, mirroring the RSVP button below).
+					    The image alt text describes the image content; the
+					    wrapping anchor's aria-label describes the link action
+					    via a new locale key so AT users hear both. The bulbs-
+					    wrapper anchor sits ABOVE the dark img + EventBulbsOverlay
+					    so the entire wrapper (including the bulb overlay area)
+					    is one click target. */}
+					<a
+						href={RSVP_URL}
+						aria-label={t("feedPage.upcomingVirtualEventImageLinkLabel")}
+						target="_blank"
+						rel="noreferrer"
+						className="feed-upcoming-virtual-event__image-link"
+					>
 						<img
-							src={EVENT_IMAGE_DARK}
+							src={EVENT_IMAGE_LIGHT}
 							alt={t("feedPage.upcomingVirtualEventImageAlt")}
-							className="feed-upcoming-virtual-event__image feed-upcoming-virtual-event__image--dark"
+							className="feed-upcoming-virtual-event__image feed-upcoming-virtual-event__image--light"
 							width={1200}
 							height={630}
 							loading="lazy"
 							onError={hideBrokenImage}
 						/>
-						<EventBulbsOverlay />
-					</div>
+					</a>
+					<a
+						href={RSVP_URL}
+						aria-label={t("feedPage.upcomingVirtualEventImageLinkLabel")}
+						target="_blank"
+						rel="noreferrer"
+						className="feed-upcoming-virtual-event__image-link"
+					>
+						<div className="feed-upcoming-virtual-event__bulbs-wrapper">
+							<img
+								src={EVENT_IMAGE_DARK}
+								alt={t("feedPage.upcomingVirtualEventImageAlt")}
+								className="feed-upcoming-virtual-event__image feed-upcoming-virtual-event__image--dark"
+								width={1200}
+								height={630}
+								loading="lazy"
+								onError={hideBrokenImage}
+							/>
+							<EventBulbsOverlay />
+						</div>
+					</a>
 					<Box
 						fontWeight="bold"
 						fontSize="heading-m"

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -3648,3 +3648,55 @@
 		letter-spacing: 0.08em;
 	}
 }
+
+/* ==========================================================================
+   Wave 33c — Clickable event card image links
+   ==========================================================================
+
+   Wraps the event-card images in anchors so clicking the photo routes to
+   the same RSVP destination as the primary CTA button:
+     - .feed-featured-event__image-link → speakeasy /signup?return_to=/rsvp/
+     - .feed-upcoming-virtual-event__image-link → external Meetup page
+
+   The featured-event link is the new direct grid-item child of
+   .feed-featured-event__layout (the inner __image-area div is no longer
+   the grid item itself), so the link MUST carry `grid-area: image` to
+   land in the same cell the wrapper div used to occupy. min-width:0
+   mirrors the legacy .feed-featured-event__image-area rule so the cell
+   can shrink inside its column track without the image's intrinsic
+   1200px width forcing the track wider than the card.
+
+   Both link classes share base block-level + reset styling. The
+   focus-visible ring uses the AWS amber token at a 3px outline + 3px
+   offset so keyboard users get the same conspicuous focus signal the
+   primary CTA button carries elsewhere on the card. */
+
+.feed-featured-event__image-link,
+.feed-upcoming-virtual-event__image-link {
+	display: block;
+	text-decoration: none;
+	border-radius: var(--cdn-radius-md, 8px);
+	cursor: pointer;
+	/* preserve the perspective/3d transform stack from the parent — the
+	   wave 27a v2 hover micro-tilt still fires on the inner image since
+	   :hover propagates through the wrapping anchor's children. */
+}
+
+/* Featured-event link is the grid-item child of .feed-featured-event__layout
+   now that the .feed-featured-event__image-area div is wrapped. Place it in
+   the `image` named grid area so the existing wave 31a / 32a layout pours
+   into the same cell. */
+.feed-featured-event__image-link {
+	grid-area: image;
+	min-width: 0;
+}
+
+.feed-featured-event__image-link:focus-visible,
+.feed-upcoming-virtual-event__image-link:focus-visible {
+	outline: 3px solid var(--cdn-aws-orange, #ff9900);
+	outline-offset: 3px;
+}
+
+/* When the wrapping anchor is hovered, the existing image hover transforms
+   still fire on the inner image since :hover propagates through anchor
+   children — nothing to override here. */


### PR DESCRIPTION
Clicking either event card image now routes to the same RSVP destination as the primary CTA button.

## what changes
- featured-event card: image-area wrapped in <a href={RSVP_PAGE_URL}> (auth.clouddelnorte.org/signup → /rsvp/)
- upcoming-virtual-event card: BOTH the standalone light <img> AND the bulbs-wrapper (containing dark img + bulb overlay) wrapped in anchors → opens the AWS Global Community Gatherings Meetup page in a new tab with rel=noreferrer

## a11y
- Image alt attributes unchanged (alt = image content semantics)
- Anchor aria-label carries the link action via 2 new locale keys:
  - feedPage.featuredEventImageLinkLabel (en + es-MX norteño)
  - feedPage.upcomingVirtualEventImageLinkLabel (en + es-MX norteño)
- Focus-visible amber 3px ring at 3px offset on the wrapping anchor preserves keyboard nav
- DOM reading order updated: anchor → image-area → 2 imgs

## gates
- biome ci: 0 errors / 542 warnings (baseline)
- tsc: clean
- npm run build: PASS
- vitest: 693 / 693 PASS (+2 new wave-33c cases)