### PR TITLE
chore: remove accidentally tracked node_modules symlink at repo root

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/bryanchasko/code/websites/cloud-del-norte-website/node_modules


### PR DESCRIPTION
A prior wave's `git add` captured a self-referential `ln -s` that ended up in HEAD. Every fresh clone since shows `D node_modules` against the user's freshly-installed directory. Removes the tracked index entry only — `.gitignore` already excludes `node_modules` so it won't reappear. Working-tree symlink in CI/dev worktrees is unaffected.