### PR TITLE
fix(ci): remove invalid step-level docker props from screenshot.yml

### DIFF
--- a/.woodpecker/screenshot.yml
+++ b/.woodpecker/screenshot.yml
@@ -13,9 +13,6 @@ when:
 steps:
   - name: capture-dev
     image: mcr.microsoft.com/playwright:v1.60.0-noble
-    mem_limit: 4294967296
-    memswap_limit: 4294967296
-    init: true
     failure: ignore
     when:
       - event: [push, manual]
@@ -55,8 +52,6 @@ steps:
 
   - name: capture-prod
     image: mcr.microsoft.com/playwright:v1.49.0-jammy
-    mem_limit: 4294967296
-    memswap_limit: 4294967296
     failure: ignore
     when:
       - event: [push, manual]


### PR DESCRIPTION
Strips step-level mem_limit / memswap_limit / init from .woodpecker/screenshot.yml. These are not in the Woodpecker v3.13 step schema (linter warnings on every push to this repo for weeks). Same pattern as chasko-labs/chrome-extension-moodle-uploader#1225 applied to screenshot.yml.