### PR TITLE
feat(rsvp): wave 35b — frontend wiring to live cdn-rsvp API

### DIFF
--- a/src/lib/__tests__/rsvp.test.ts
+++ b/src/lib/__tests__/rsvp.test.ts
@@ -1,29 +1,55 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type MockInstance,
+	vi,
+} from "vitest";
 import {
 	addRsvp,
 	buildTicketPayload,
 	CDN_EVENTS,
 	getEvent,
-	getRsvp,
-	listUserRsvps,
+	listMyRsvps,
 	type RsvpRecord,
 	spotsRemaining,
 } from "../rsvp";
 
 const EVENT_ID = "happy-hour-2026-06-03";
+const API_BASE = "https://tta0e43bs0.execute-api.us-west-2.amazonaws.com/prod";
+const ID_TOKEN = "stub.id.token";
+
+// Mock fetch as a vi.fn so each test can configure its own resolved/rejected
+// value. Reset between tests so leakage between cases never confuses
+// debugging.
+const fetchMock = vi.fn();
 
 beforeEach(() => {
 	localStorage.clear();
+	sessionStorage.clear();
+	fetchMock.mockReset();
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+	sessionStorage.setItem("cdn.idToken", ID_TOKEN);
 });
 
 afterEach(() => {
 	localStorage.clear();
+	sessionStorage.clear();
 });
 
-describe("rsvp lib", () => {
+function jsonResponse(status: number, body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("rsvp lib — static metadata", () => {
 	it("CDN_EVENTS contains the happy-hour event with expected capacity", () => {
 		const event = getEvent(EVENT_ID);
 		expect(event).toBeDefined();
@@ -32,56 +58,12 @@ describe("rsvp lib", () => {
 		expect(event?.location).toBe("Downtown El Paso, Texas");
 	});
 
-	it("spotsRemaining starts at capacity minus baseline", () => {
-		expect(spotsRemaining(EVENT_ID)).toBe(48);
+	it("CDN_EVENTS list is non-empty", () => {
+		expect(CDN_EVENTS.length).toBeGreaterThan(0);
 	});
 
-	it("spotsRemaining decrements by 1 for each in-app RSVP", () => {
-		addRsvp({ eventId: EVENT_ID, userSub: "u1", name: "Alice", email: null });
-		expect(spotsRemaining(EVENT_ID)).toBe(47);
-		addRsvp({ eventId: EVENT_ID, userSub: "u2", name: "Bob", email: null });
-		expect(spotsRemaining(EVENT_ID)).toBe(46);
-	});
-
-	it("addRsvp is idempotent for the same user+event", () => {
-		const first = addRsvp({
-			eventId: EVENT_ID,
-			userSub: "u1",
-			name: "Alice",
-			email: null,
-		});
-		const second = addRsvp({
-			eventId: EVENT_ID,
-			userSub: "u1",
-			name: "Alice (different)",
-			email: null,
-		});
-		expect(first).toEqual(second);
-		expect(spotsRemaining(EVENT_ID)).toBe(47);
-	});
-
-	it("getRsvp returns the record for matching user+event", () => {
-		addRsvp({
-			eventId: EVENT_ID,
-			userSub: "u1",
-			name: "Alice",
-			email: "a@example.com",
-		});
-		const found = getRsvp(EVENT_ID, "u1");
-		expect(found?.name).toBe("Alice");
-		expect(found?.email).toBe("a@example.com");
-	});
-
-	it("getRsvp returns undefined for missing user+event", () => {
-		expect(getRsvp(EVENT_ID, "missing")).toBeUndefined();
-	});
-
-	it("listUserRsvps returns only the calling user's records", () => {
-		addRsvp({ eventId: EVENT_ID, userSub: "u1", name: "A", email: null });
-		addRsvp({ eventId: EVENT_ID, userSub: "u2", name: "B", email: null });
-		const u1 = listUserRsvps("u1");
-		expect(u1).toHaveLength(1);
-		expect(u1[0].userSub).toBe("u1");
+	it("getEvent returns undefined for an unknown event id", () => {
+		expect(getEvent("does-not-exist")).toBeUndefined();
 	});
 
 	it("buildTicketPayload produces a stable cdn-ticket:v1 prefixed string", () => {
@@ -94,28 +76,192 @@ describe("rsvp lib", () => {
 		};
 		expect(buildTicketPayload(record)).toBe(`cdn-ticket:v1:${EVENT_ID}:u1`);
 	});
+});
 
-	it("spotsRemaining never goes negative when capacity is exhausted", () => {
-		const event = getEvent(EVENT_ID);
-		if (!event) throw new Error("event missing");
-		// Fill all remaining spots with synthetic RSVPs
-		for (let i = 0; i < event.capacity - event.rsvpedBaseline + 5; i++) {
-			addRsvp({
+describe("addRsvp", () => {
+	it("returns the new ticket on 201 and updates the cache", async () => {
+		const record: RsvpRecord = {
+			eventId: EVENT_ID,
+			userSub: "u1",
+			name: "Alice",
+			email: "a@example.com",
+			createdAt: "2026-05-18T22:00:00.000Z",
+		};
+		fetchMock.mockResolvedValueOnce(jsonResponse(201, record));
+
+		const result = await addRsvp({
+			eventId: EVENT_ID,
+			name: "Alice",
+			email: "a@example.com",
+		});
+
+		expect(result).toEqual(record);
+		// Verify request shape — Bearer header + JSON body.
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe(`${API_BASE}/rsvp`);
+		expect(init.method).toBe("POST");
+		const headers = new Headers(init.headers);
+		expect(headers.get("Authorization")).toBe(`Bearer ${ID_TOKEN}`);
+		expect(headers.get("Content-Type")).toBe("application/json");
+		expect(JSON.parse(String(init.body))).toEqual({
+			eventId: EVENT_ID,
+			name: "Alice",
+			email: "a@example.com",
+		});
+		// Cache primed.
+		const cached = JSON.parse(localStorage.getItem("cdn.rsvps.v1") ?? "[]");
+		expect(cached).toEqual([record]);
+	});
+
+	it("treats 200 (idempotent existing ticket) as success", async () => {
+		const record: RsvpRecord = {
+			eventId: EVENT_ID,
+			userSub: "u1",
+			name: "Alice",
+			email: null,
+			createdAt: "2026-05-18T22:00:00.000Z",
+		};
+		fetchMock.mockResolvedValueOnce(jsonResponse(200, record));
+
+		const result = await addRsvp({
+			eventId: EVENT_ID,
+			name: "Alice",
+			email: null,
+		});
+		expect(result).toEqual(record);
+	});
+
+	it("throws Error('capacity_full') on 409 with that error key", async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse(409, { error: "capacity_full" }),
+		);
+		await expect(
+			addRsvp({ eventId: EVENT_ID, name: null, email: null }),
+		).rejects.toThrow("capacity_full");
+	});
+
+	it("throws Error('not_authenticated') when sessionStorage idToken is missing", async () => {
+		sessionStorage.removeItem("cdn.idToken");
+		await expect(
+			addRsvp({ eventId: EVENT_ID, name: null, email: null }),
+		).rejects.toThrow("not_authenticated");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("throws Error('network') when fetch rejects", async () => {
+		fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+		await expect(
+			addRsvp({ eventId: EVENT_ID, name: null, email: null }),
+		).rejects.toThrow("network");
+	});
+
+	it("propagates unknown server error keys verbatim", async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse(400, { error: "bad_request" }),
+		);
+		await expect(
+			addRsvp({ eventId: EVENT_ID, name: null, email: null }),
+		).rejects.toThrow("bad_request");
+	});
+});
+
+describe("listMyRsvps", () => {
+	const record: RsvpRecord = {
+		eventId: EVENT_ID,
+		userSub: "u1",
+		name: "Alice",
+		email: null,
+		createdAt: "2026-05-18T22:00:00.000Z",
+	};
+
+	it("returns the array on success and refreshes the cache", async () => {
+		fetchMock.mockResolvedValueOnce(jsonResponse(200, [record]));
+		const result = await listMyRsvps();
+		expect(result).toEqual([record]);
+		const cached = JSON.parse(localStorage.getItem("cdn.rsvps.v1") ?? "[]");
+		expect(cached).toEqual([record]);
+	});
+
+	it("falls back to the cache when fetch rejects with a network error", async () => {
+		// seed cache with a stale record from a prior session
+		localStorage.setItem("cdn.rsvps.v1", JSON.stringify([record]));
+		fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+		const result = await listMyRsvps();
+		expect(result).toEqual([record]);
+	});
+
+	it("throws Error('network') when fetch rejects AND cache is empty", async () => {
+		fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+		await expect(listMyRsvps()).rejects.toThrow("network");
+	});
+
+	it("throws Error('unauthorized') on 401 (no cache fallback for auth errors)", async () => {
+		// even with a primed cache, a 401 means the user's token is bad and
+		// we want them routed to login — not silently shown stale data.
+		localStorage.setItem("cdn.rsvps.v1", JSON.stringify([record]));
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse(401, { error: "unauthorized" }),
+		);
+		await expect(listMyRsvps()).rejects.toThrow("unauthorized");
+	});
+});
+
+describe("spotsRemaining", () => {
+	let warnSpy: MockInstance<typeof console.warn>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
+	});
+
+	it("returns the remaining count on a 200 response", async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse(200, {
 				eventId: EVENT_ID,
-				userSub: `u${i}`,
-				name: null,
-				email: null,
-			});
-		}
-		expect(spotsRemaining(EVENT_ID)).toBe(0);
+				capacity: 50,
+				taken: 0,
+				remaining: 50,
+			}),
+		);
+		await expect(spotsRemaining(EVENT_ID)).resolves.toBe(50);
+		// public endpoint — no Authorization header should have been sent.
+		const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(init).toBeUndefined();
 	});
 
-	it("CDN_EVENTS list is non-empty", () => {
-		expect(CDN_EVENTS.length).toBeGreaterThan(0);
+	it("returns NaN on a 404 (unknown event)", async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse(404, { error: "unknown_event" }),
+		);
+		const result = await spotsRemaining("does-not-exist");
+		expect(Number.isNaN(result)).toBe(true);
+		expect(warnSpy).toHaveBeenCalled();
 	});
 
-	it("returns empty list for unknown event id", () => {
-		expect(getEvent("does-not-exist")).toBeUndefined();
-		expect(spotsRemaining("does-not-exist")).toBe(0);
+	it("returns NaN AND console.warns when fetch rejects", async () => {
+		fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+		const result = await spotsRemaining(EVENT_ID);
+		expect(Number.isNaN(result)).toBe(true);
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("network error"),
+			expect.anything(),
+		);
+	});
+
+	it("does not require auth (calls public endpoint without idToken)", async () => {
+		sessionStorage.removeItem("cdn.idToken");
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse(200, {
+				eventId: EVENT_ID,
+				capacity: 50,
+				taken: 5,
+				remaining: 45,
+			}),
+		);
+		await expect(spotsRemaining(EVENT_ID)).resolves.toBe(45);
 	});
 });

--- a/src/lib/rsvp.ts
+++ b/src/lib/rsvp.ts
@@ -2,19 +2,33 @@
 // SPDX-License-Identifier: MIT-0
 
 /**
- * RSVP client-side storage layer.
+ * RSVP client-side data layer.
  *
- * Phase 1: localStorage-only. Each RSVP record is keyed by the user's Cognito
- * `sub` and the event id. The QR ticket payload is derived deterministically
- * from {sub, eventId, name, email} so the same authenticated user always
- * regenerates the same ticket from the same browser.
+ * Wave 35a deployed the cdn-rsvp Lambda + API Gateway HTTP V2 + DDB stack at
+ * `https://tta0e43bs0.execute-api.us-west-2.amazonaws.com/prod`. Wave 35b
+ * (this file) flips the client from localStorage-only to fetch() against
+ * that backend.
  *
- * Phase 2 (deferred to a separate dispatch): replace the localStorage layer
- * with an API Gateway HTTP V2 + Lambda + DynamoDB backend so capacity is
- * enforced server-side and tickets survive across browsers/devices.
+ * The DDB record shape mirrors RsvpRecord (user_sub, event_id, name, email,
+ * created_at, ticket_payload), so we keep the existing TypeScript types
+ * unchanged and the QR ticket payload identical
+ * (`cdn-ticket:v1:{eventId}:{userSub}` — see buildTicketPayload).
+ *
+ * localStorage is retained as a read-only cache so:
+ *   - listMyRsvps() can fall back to the cached list when the network
+ *     hiccups or the user is briefly offline (UI shows tickets, possibly
+ *     stale, instead of a hard error).
+ *   - Phase 1 users with localStorage tickets keep seeing them through the
+ *     cutover until they next visit the RSVP page (which will write a fresh
+ *     server record + refresh the cache).
+ *
+ * Writes only ever go to the backend; the cache is updated as a side-effect
+ * of successful reads/writes, never as the source of truth.
  */
 
+const API_BASE = "https://tta0e43bs0.execute-api.us-west-2.amazonaws.com/prod";
 const STORAGE_KEY = "cdn.rsvps.v1";
+const ID_TOKEN_KEY = "cdn.idToken";
 
 export interface CdnEvent {
 	id: string;
@@ -52,11 +66,15 @@ export function getEvent(id: string): CdnEvent | undefined {
 	return CDN_EVENTS.find((e) => e.id === id);
 }
 
+// ---------------------------------------------------------------------------
+// localStorage read-cache helpers
+// ---------------------------------------------------------------------------
+
 function isBrowser(): boolean {
 	return typeof window !== "undefined" && typeof localStorage !== "undefined";
 }
 
-function readAll(): RsvpRecord[] {
+function readCache(): RsvpRecord[] {
 	if (!isBrowser()) return [];
 	try {
 		const raw = localStorage.getItem(STORAGE_KEY);
@@ -69,78 +87,237 @@ function readAll(): RsvpRecord[] {
 	}
 }
 
-function writeAll(records: RsvpRecord[]): void {
+function writeCache(records: RsvpRecord[]): void {
 	if (!isBrowser()) return;
 	try {
 		localStorage.setItem(STORAGE_KEY, JSON.stringify(records));
 	} catch {
-		// localStorage may be disabled (private mode, quota exceeded). The user
-		// will see the ticket on the confirmation page but it won't persist;
-		// next dispatch's backend will solve the durability problem.
+		// localStorage may be disabled (private mode, quota exceeded). Cache
+		// failure is non-fatal — the network path is the source of truth.
 	}
 }
 
-/**
- * Lookup a single user's RSVP for a given event.
- * Returns undefined if no RSVP exists.
- */
-export function getRsvp(
-	eventId: string,
-	userSub: string,
-): RsvpRecord | undefined {
-	return readAll().find((r) => r.eventId === eventId && r.userSub === userSub);
+/** Merge a single fresh record into the cache, replacing any existing entry
+ *  for the same {eventId, userSub}. */
+function upsertCache(record: RsvpRecord): void {
+	const records = readCache();
+	const idx = records.findIndex(
+		(r) => r.eventId === record.eventId && r.userSub === record.userSub,
+	);
+	if (idx >= 0) records[idx] = record;
+	else records.push(record);
+	writeCache(records);
 }
 
+// ---------------------------------------------------------------------------
+// fetch helpers
+// ---------------------------------------------------------------------------
+
+function getIdToken(): string {
+	if (!isBrowser()) throw new Error("not_authenticated");
+	const token = sessionStorage.getItem(ID_TOKEN_KEY);
+	if (!token) throw new Error("not_authenticated");
+	return token;
+}
+
+interface ErrorBody {
+	error?: string;
+}
+
+/** Parse `{error: '...'}` from a non-OK response, falling back to a generic
+ *  string when the body is missing/unparseable. */
+async function parseErrorKey(res: Response): Promise<string> {
+	try {
+		const body = (await res.json()) as ErrorBody;
+		if (typeof body.error === "string" && body.error.length > 0)
+			return body.error;
+	} catch {
+		// fall through to status-based default
+	}
+	if (res.status === 401) return "unauthorized";
+	if (res.status === 403) return "forbidden";
+	if (res.status === 404) return "not_found";
+	if (res.status === 409) return "capacity_full";
+	return "generic";
+}
+
+async function authedFetch(
+	path: string,
+	init?: RequestInit,
+): Promise<Response> {
+	const token = getIdToken();
+	const headers = new Headers(init?.headers);
+	headers.set("Authorization", `Bearer ${token}`);
+	if (init?.body && !headers.has("Content-Type")) {
+		headers.set("Content-Type", "application/json");
+	}
+	let res: Response;
+	try {
+		res = await fetch(`${API_BASE}${path}`, { ...init, headers });
+	} catch {
+		throw new Error("network");
+	}
+	return res;
+}
+
+// ---------------------------------------------------------------------------
+// public API
+// ---------------------------------------------------------------------------
+
 /**
- * Add (or refresh) an RSVP record for the given user + event.
- * Idempotent — a second call with the same {eventId,userSub} returns the
- * existing record without duplicating it.
+ * Add (or refresh) the calling user's RSVP for the given event. The user's
+ * `sub` is derived server-side from the JWT — the caller no longer passes
+ * it. The legacy `userSub` field on `input` is accepted but ignored for
+ * backward compatibility with Phase 1 callsites.
+ *
+ * The backend is idempotent: 201 for a new ticket, 200 for an existing one.
+ * Both resolve to a successful RsvpRecord here.
+ *
+ * Throws:
+ *   - Error('not_authenticated') — sessionStorage idToken missing
+ *   - Error('capacity_full')     — 409 from server
+ *   - Error('network')           — fetch threw (offline, DNS, etc.)
+ *   - Error(<server error key>)  — any other 4xx/5xx
  */
-export function addRsvp(input: {
+export async function addRsvp(input: {
 	eventId: string;
-	userSub: string;
+	userSub?: string;
 	name: string | null;
 	email: string | null;
-}): RsvpRecord {
-	const existing = getRsvp(input.eventId, input.userSub);
-	if (existing) return existing;
-	const record: RsvpRecord = {
-		eventId: input.eventId,
-		userSub: input.userSub,
-		name: input.name,
-		email: input.email,
-		createdAt: new Date().toISOString(),
-	};
-	const records = readAll();
-	records.push(record);
-	writeAll(records);
+}): Promise<RsvpRecord> {
+	const body: Record<string, unknown> = { eventId: input.eventId };
+	if (input.name) body.name = input.name;
+	if (input.email) body.email = input.email;
+
+	const res = await authedFetch("/rsvp", {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+
+	if (!(res.status === 200 || res.status === 201)) {
+		const key = await parseErrorKey(res);
+		throw new Error(key);
+	}
+
+	const record = (await res.json()) as RsvpRecord;
+	upsertCache(record);
 	return record;
 }
 
-/** Return all RSVPs belonging to a single authenticated user. */
-export function listUserRsvps(userSub: string): RsvpRecord[] {
-	return readAll().filter((r) => r.userSub === userSub);
+/**
+ * List every RSVP belonging to the currently authenticated user. On network
+ * failure, falls back to the localStorage read-cache (records may be stale
+ * from a prior session) so the meetings page still renders something useful
+ * during transient API outages.
+ *
+ * Throws:
+ *   - Error('not_authenticated') — no idToken AND no cache available
+ *   - Error('network')           — fetch threw AND no cache available
+ *   - Error(<server error key>)  — any 4xx/5xx other than transient network
+ */
+export async function listMyRsvps(): Promise<RsvpRecord[]> {
+	let res: Response;
+	try {
+		res = await authedFetch("/rsvp", { method: "GET" });
+	} catch (err) {
+		// `not_authenticated` from getIdToken() is also caught here; it would
+		// be re-thrown without consulting the cache because we can't filter the
+		// cache to "this user" without a sub.
+		if (err instanceof Error && err.message === "network") {
+			const cached = readCache();
+			if (cached.length > 0) return cached;
+		}
+		throw err;
+	}
+
+	if (!res.ok) {
+		const key = await parseErrorKey(res);
+		throw new Error(key);
+	}
+
+	const list = (await res.json()) as RsvpRecord[];
+	// refresh the cache with the authoritative server view
+	if (Array.isArray(list)) writeCache(list);
+	return list;
 }
 
 /**
- * Spots remaining for an event. Counts the baseline (off-platform RSVPs) plus
- * the local count of in-app RSVPs. Phase 2 will swap this for a server query.
+ * Lookup the calling user's RSVP for a single event. Implemented by listing
+ * all of the user's RSVPs and filtering — the backend doesn't expose a
+ * single-record GET and the list is bounded by the user's event count
+ * (small).
+ *
+ * Returns undefined if no RSVP exists. Re-throws auth and network errors so
+ * the caller can route to login or render an outage state.
  */
-export function spotsRemaining(eventId: string): number {
-	const event = getEvent(eventId);
-	if (!event) return 0;
-	const localCount = readAll().filter((r) => r.eventId === eventId).length;
-	const taken = event.rsvpedBaseline + localCount;
-	return Math.max(0, event.capacity - taken);
+export async function getRsvpForCurrentUser(
+	eventId: string,
+): Promise<RsvpRecord | undefined> {
+	const list = await listMyRsvps();
+	return list.find((r) => r.eventId === eventId);
+}
+
+/**
+ * Public spots-remaining counter. Does NOT require auth — backed by the
+ * public `GET /rsvp/{eventId}/spots` route. On any failure (network, 404,
+ * 5xx) returns Number.NaN so the UI's `remaining > 0` checks fail-safe to
+ * the "sold out / unknown" state. A console.warn marks the failure for
+ * devtools visibility.
+ */
+export async function spotsRemaining(eventId: string): Promise<number> {
+	let res: Response;
+	try {
+		res = await fetch(`${API_BASE}/rsvp/${encodeURIComponent(eventId)}/spots`);
+	} catch (err) {
+		console.warn("[rsvp] spotsRemaining network error", err);
+		return Number.NaN;
+	}
+
+	if (!res.ok) {
+		console.warn(`[rsvp] spotsRemaining returned ${res.status} for ${eventId}`);
+		return Number.NaN;
+	}
+
+	try {
+		const body = (await res.json()) as { remaining?: number };
+		if (typeof body.remaining === "number") return body.remaining;
+		console.warn("[rsvp] spotsRemaining body missing remaining field", body);
+		return Number.NaN;
+	} catch (err) {
+		console.warn("[rsvp] spotsRemaining body parse error", err);
+		return Number.NaN;
+	}
 }
 
 /**
  * Build the deterministic ticket payload string used as the QR code value.
  * Format: `cdn-ticket:v1:{eventId}:{userSub}` — short, scannable, no PII.
- * The check-in flow at the door scans this string and looks up the record
- * server-side (when the backend lands in Phase 2). For now it serves as a
- * stable identifier the user can show.
+ * Wire-compatible with Phase 1 tickets and the wave 35a backend's
+ * `ticket_payload` field. Pure function — no I/O.
  */
 export function buildTicketPayload(record: RsvpRecord): string {
 	return `cdn-ticket:v1:${record.eventId}:${record.userSub}`;
+}
+
+// ---------------------------------------------------------------------------
+// backward-compat shims
+//
+// Phase 1 callsites pass userSub explicitly; the new API derives sub from
+// the JWT server-side. These shims accept the old signature and forward to
+// the new one so consumers can migrate at their own pace.
+// ---------------------------------------------------------------------------
+
+/** @deprecated Use {@link getRsvpForCurrentUser}. The userSub argument is
+ *  ignored — the server derives it from the JWT. */
+export function getRsvp(
+	eventId: string,
+	_userSub?: string,
+): Promise<RsvpRecord | undefined> {
+	return getRsvpForCurrentUser(eventId);
+}
+
+/** @deprecated Use {@link listMyRsvps}. The userSub argument is ignored —
+ *  the server derives it from the JWT. */
+export function listUserRsvps(_userSub?: string): Promise<RsvpRecord[]> {
+	return listMyRsvps();
 }

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1015,6 +1015,12 @@
 		"viewMyTickets": "View my tickets",
 		"rsvpButton": "Confirm my RSVP",
 		"rsvpingNow": "Reserving your seat...",
-		"fallbackMeetupCta": "RSVP on Meetup instead"
+		"fallbackMeetupCta": "RSVP on Meetup instead",
+		"error": {
+			"capacityFull": "Sorry — this event is full. Watch the feed for the next one.",
+			"network": "Network hiccup — try again in a moment.",
+			"unauthorized": "Sign in to RSVP.",
+			"generic": "Something went wrong — we logged it. Try again or RSVP on Meetup."
+		}
 	}
 }

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -1015,6 +1015,12 @@
 		"viewMyTickets": "Ver mis boletos",
 		"rsvpButton": "Confirmar mi RSVP",
 		"rsvpingNow": "Reservando tu lugar...",
-		"fallbackMeetupCta": "Mejor házlo por Meetup"
+		"fallbackMeetupCta": "Mejor házlo por Meetup",
+		"error": {
+			"capacityFull": "Disculpa — este evento ya se llenó. Checa el feed para el próximo.",
+			"network": "Falla de red — intenta de nuevo en un momento.",
+			"unauthorized": "Inicia sesión para hacer RSVP.",
+			"generic": "Algo salió mal — lo registramos. Intenta de nuevo o haz RSVP en Meetup."
+		}
 	}
 }

--- a/src/pages/feed/components/__tests__/featured-event-scroll.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-event-scroll.test.tsx
@@ -35,7 +35,7 @@
  * structural rendering. This file is the scroll-stability layer on top.
  */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../../contexts/locale-context";
 import FeaturedEvent, { FeaturedEventErrorBoundary } from "../featured-event";
@@ -59,14 +59,33 @@ function renderInsideTallScrollContainer() {
 }
 
 describe("FeaturedEvent — wave 30a scroll-tearing regression", () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
 	beforeEach(() => {
 		// Defensive — make sure no leaked .cdn-scrolling class from a previous
 		// test bleeds into this one's assertions.
 		document.body.classList.remove("cdn-scrolling");
+		// Wave 35b — spotsRemaining() now hits the public cdn-rsvp API. Stub
+		// fetch so the spots chip renders; without the stub the call returns
+		// NaN and .feed-featured-event__spots is hidden, breaking the
+		// structural assertion below.
+		fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					eventId: "happy-hour-2026-06-03",
+					capacity: 50,
+					taken: 0,
+					remaining: 50,
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
 	});
 
 	afterEach(() => {
 		document.body.classList.remove("cdn-scrolling");
+		fetchMock.mockReset();
 	});
 
 	it("renders without crashing inside a tall scrollable container", () => {
@@ -94,7 +113,7 @@ describe("FeaturedEvent — wave 30a scroll-tearing regression", () => {
 		expect(screen.getByText(/Featured event/i)).toBeInTheDocument();
 	});
 
-	it("renders the structural class names that wave 30a CSS targets for tearing mitigation", () => {
+	it("renders the structural class names that wave 30a CSS targets for tearing mitigation", async () => {
 		const { container } = renderInsideTallScrollContainer();
 
 		// The card root is the primary GPU layer promotion target — CSS
@@ -111,9 +130,12 @@ describe("FeaturedEvent — wave 30a scroll-tearing regression", () => {
 		expect(datePlate).not.toBeNull();
 
 		// The spots-remaining chip carries will-change: transform, opacity
-		// (3.4s pulse + outer ring breathe).
-		const spots = container.querySelector(".feed-featured-event__spots");
-		expect(spots).not.toBeNull();
+		// (3.4s pulse + outer ring breathe). Wave 35b — chip renders only
+		// after the async spotsRemaining fetch resolves.
+		await waitFor(() => {
+			const spots = container.querySelector(".feed-featured-event__spots");
+			expect(spots).not.toBeNull();
+		});
 	});
 
 	it("does not leak the body.cdn-scrolling class on initial mount (added only by the scroll-jank-mitigation listener at runtime)", () => {

--- a/src/pages/feed/components/__tests__/featured-event.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-event.test.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../../contexts/locale-context";
 import FeaturedEvent from "../featured-event";
 
@@ -13,6 +13,32 @@ function renderWithLocale(locale: "us" | "mx") {
 		</LocaleProvider>,
 	);
 }
+
+// Wave 35b — spotsRemaining() now hits the public cdn-rsvp API. Stub fetch
+// so the spots-remaining chip renders in tests; without the stub the call
+// would return NaN and the chip element would be hidden, breaking layout
+// assertions that expect .feed-featured-event__spots.
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+	fetchMock.mockReset();
+	fetchMock.mockResolvedValue(
+		new Response(
+			JSON.stringify({
+				eventId: "happy-hour-2026-06-03",
+				capacity: 50,
+				taken: 0,
+				remaining: 50,
+			}),
+			{ status: 200, headers: { "Content-Type": "application/json" } },
+		),
+	);
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+	fetchMock.mockReset();
+});
 
 describe("FeaturedEvent", () => {
 	it("renders the v2 event title with link to auth.clouddelnorte.org signup with rsvp return_to", () => {
@@ -103,7 +129,7 @@ describe("FeaturedEvent", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders the wave 31a responsive grid layout wrapper containing all card children", () => {
+	it("renders the wave 31a responsive grid layout wrapper containing all card children", async () => {
 		const { container } = renderWithLocale("us");
 		const layout = container.querySelector(".feed-featured-event__layout");
 		expect(layout).not.toBeNull();
@@ -111,6 +137,8 @@ describe("FeaturedEvent", () => {
 		// the grid layout (image-area, title, date, in-person, location,
 		// description, spots, buttons). DOM order is the logical reading
 		// order — preserved across the SpaceBetween → grid migration.
+		// Wave 35b — the spots chip renders only after the async
+		// spotsRemaining fetch resolves; await it before asserting.
 		expect(
 			layout?.querySelector(".feed-featured-event__image-area"),
 		).not.toBeNull();
@@ -125,7 +153,11 @@ describe("FeaturedEvent", () => {
 		expect(
 			layout?.querySelector(".feed-featured-event__description"),
 		).not.toBeNull();
-		expect(layout?.querySelector(".feed-featured-event__spots")).not.toBeNull();
+		await waitFor(() => {
+			expect(
+				layout?.querySelector(".feed-featured-event__spots"),
+			).not.toBeNull();
+		});
 		expect(layout?.querySelector(".cdn-brand-btn-stack")).not.toBeNull();
 		// Wave 32a — badge was removed entirely.
 		expect(layout?.querySelector(".feed-featured-event__badge")).toBeNull();
@@ -147,7 +179,7 @@ describe("FeaturedEvent", () => {
 		expect(darkImg).not.toBeNull();
 	});
 
-	it("preserves DOM reading order: image → title → date → in-person → location → description → spots → buttons (a11y / screen-reader contract; wave 32a dropped badge slot, wave 33c wraps image in anchor)", () => {
+	it("preserves DOM reading order: image → title → date → in-person → location → description → spots → buttons (a11y / screen-reader contract; wave 32a dropped badge slot, wave 33c wraps image in anchor)", async () => {
 		const { container } = renderWithLocale("us");
 		const layout = container.querySelector(".feed-featured-event__layout");
 		expect(layout).not.toBeNull();
@@ -155,6 +187,12 @@ describe("FeaturedEvent", () => {
 		// <a class="feed-featured-event__image-link"> anchor (the inner
 		// __image-area div is nested inside it). The reading order intent
 		// is preserved: the image link reads before the title, date, etc.
+		// Wave 35b — spots chip is async; wait for it before asserting order.
+		await waitFor(() => {
+			expect(
+				layout?.querySelector(".feed-featured-event__spots"),
+			).not.toBeNull();
+		});
 		const expected = [
 			"feed-featured-event__image-link",
 			"feed-featured-event__title",
@@ -180,10 +218,14 @@ describe("FeaturedEvent", () => {
 		expect(primary).toHaveAttribute("href", expected);
 	});
 
-	it("renders the limited-space CTA", () => {
+	it("renders the limited-space CTA", async () => {
 		localStorage.clear();
 		renderWithLocale("us");
-		expect(screen.getByText(/Limited space — RSVP now/i)).toBeInTheDocument();
+		// Wave 35b — copy comes from the spotsCopy slot which is hidden
+		// until spotsRemaining() resolves; await it.
+		expect(
+			await screen.findByText(/Limited space — RSVP now/i),
+		).toBeInTheDocument();
 	});
 
 	it("inlines the AsciiSmirk SVG inside the description (after the 'game' hook)", () => {

--- a/src/pages/feed/components/featured-event.tsx
+++ b/src/pages/feed/components/featured-event.tsx
@@ -106,8 +106,19 @@ function FeaturedEventInner() {
 	const [remaining, setRemaining] = useState<number | null>(null);
 
 	useEffect(() => {
-		// localStorage is browser-only; compute on mount to avoid hydration drift.
-		setRemaining(spotsRemaining(EVENT_ID));
+		// spotsRemaining now talks to the public cdn-rsvp API. It returns NaN
+		// on any error (network, 404, parse) so the UI's `remaining > 0`
+		// gating already fail-safes — we just store whatever it produces.
+		// Effect is fire-and-forget; if the user navigates away before the
+		// fetch resolves the cancelled flag prevents a no-op setState warning.
+		let cancelled = false;
+		(async () => {
+			const value = await spotsRemaining(EVENT_ID);
+			if (!cancelled) setRemaining(value);
+		})();
+		return () => {
+			cancelled = true;
+		};
 	}, []);
 
 	const langTag = locale === "mx" ? "es-MX" : "en-US";
@@ -130,7 +141,7 @@ function FeaturedEventInner() {
 		"https://www.meetup.com/awsugclouddelnorte/events/314839263/rsvp/";
 
 	const spotsCopy =
-		event && remaining !== null
+		event && remaining !== null && Number.isFinite(remaining)
 			? t("feedPage.featuredEventSpotsRemaining")
 					.replace("{count}", String(remaining))
 					.replace("{capacity}", String(event.capacity))

--- a/src/sites/awsug/meetings/components/my-tickets.tsx
+++ b/src/sites/awsug/meetings/components/my-tickets.tsx
@@ -1,35 +1,78 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
+import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
+import Spinner from "@cloudscape-design/components/spinner";
 import { QRCodeSVG } from "qrcode.react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "../../../../hooks/useTranslation";
 import {
 	buildTicketPayload,
 	getEvent,
-	listUserRsvps,
+	listMyRsvps,
 	type RsvpRecord,
 } from "../../../../lib/rsvp";
 import type { AuthState } from "../../_shared/auth";
 
+/** Map a thrown error message to the locale key the UI should render. */
+function errorKeyFor(message: string): string {
+	switch (message) {
+		case "network":
+			return "rsvp.error.network";
+		case "not_authenticated":
+		case "unauthorized":
+			return "rsvp.error.unauthorized";
+		default:
+			return "rsvp.error.generic";
+	}
+}
+
 export default function MyTickets({ auth }: { auth: AuthState }) {
 	const { t } = useTranslation();
 	const [tickets, setTickets] = useState<RsvpRecord[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [errorKey, setErrorKey] = useState<string | null>(null);
 
 	useEffect(() => {
-		setTickets(listUserRsvps(auth.sub));
+		let cancelled = false;
+		(async () => {
+			try {
+				const list = await listMyRsvps();
+				if (cancelled) return;
+				// Defensive filter: the cache fallback inside listMyRsvps may have
+				// returned records belonging to a different sub from a prior
+				// session on a shared device. The server response is already
+				// scoped, but the cache is not.
+				setTickets(list.filter((r) => r.userSub === auth.sub));
+				setLoading(false);
+			} catch (err) {
+				if (cancelled) return;
+				const message = err instanceof Error ? err.message : "generic";
+				setErrorKey(errorKeyFor(message));
+				setLoading(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
 	}, [auth.sub]);
 
 	return (
 		<Container
 			header={<Header variant="h2">{t("meetings.myTicketsHeader")}</Header>}
 		>
-			{tickets.length === 0 ? (
+			{loading ? (
+				<Box padding="m" textAlign="center">
+					<Spinner />
+				</Box>
+			) : errorKey ? (
+				<Alert type="error">{t(errorKey)}</Alert>
+			) : tickets.length === 0 ? (
 				<Box color="text-status-inactive">{t("meetings.myTicketsEmpty")}</Box>
 			) : (
 				<SpaceBetween size="m">

--- a/src/sites/awsug/rsvp/app.tsx
+++ b/src/sites/awsug/rsvp/app.tsx
@@ -16,7 +16,7 @@ import {
 	addRsvp,
 	buildTicketPayload,
 	getEvent,
-	getRsvp,
+	getRsvpForCurrentUser,
 	type RsvpRecord,
 	spotsRemaining,
 } from "../../../lib/rsvp";
@@ -28,38 +28,90 @@ function getEventIdFromQuery(): string {
 	return params.get("event") ?? "happy-hour-2026-06-03";
 }
 
+/**
+ * Map an Error.message thrown by the rsvp lib to a localized i18n key under
+ * the `rsvp.error.*` namespace. Unknown messages fall through to the generic
+ * bucket. Kept as a pure function so the test bench (and future error
+ * boundaries) can reuse it.
+ */
+function errorKeyFor(message: string): string {
+	switch (message) {
+		case "capacity_full":
+			return "rsvp.error.capacityFull";
+		case "network":
+			return "rsvp.error.network";
+		case "not_authenticated":
+		case "unauthorized":
+			return "rsvp.error.unauthorized";
+		default:
+			return "rsvp.error.generic";
+	}
+}
+
 function RsvpFlow({ auth }: { auth: AuthState }) {
 	const { t, locale } = useTranslation();
 	const [eventId] = useState<string>(() => getEventIdFromQuery());
 	const event = getEvent(eventId);
 	const [ticket, setTicket] = useState<RsvpRecord | null>(null);
-	const [submitting, setSubmitting] = useState(false);
-	const [remaining, setRemaining] = useState<number>(() =>
-		event ? spotsRemaining(eventId) : 0,
-	);
+	const [submitting, setSubmitting] = useState(true);
+	const [remaining, setRemaining] = useState<number>(Number.NaN);
+	const [errorKey, setErrorKey] = useState<string | null>(null);
 
 	// Auto-confirm RSVP on first visit (single-click flow once authenticated).
 	// Idempotent — repeat visits to /rsvp/?event=... show the existing ticket.
 	useEffect(() => {
-		if (!event) return;
-		const existing = getRsvp(eventId, auth.sub);
-		if (existing) {
-			setTicket(existing);
-			setRemaining(spotsRemaining(eventId));
+		if (!event) {
+			setSubmitting(false);
 			return;
 		}
-		if (remaining <= 0) return;
-		setSubmitting(true);
-		const record = addRsvp({
-			eventId,
-			userSub: auth.sub,
-			name: auth.name ?? null,
-			email: auth.email,
-		});
-		setTicket(record);
-		setRemaining(spotsRemaining(eventId));
-		setSubmitting(false);
-	}, [event, auth.sub, auth.name, auth.email, eventId, remaining]);
+
+		let cancelled = false;
+		(async () => {
+			try {
+				// Refresh the public spots counter alongside the auth'd lookup.
+				// Both kick off in parallel; spotsRemaining never throws (returns
+				// NaN on error) so we can Promise.all freely.
+				const [existing, freshSpots] = await Promise.all([
+					getRsvpForCurrentUser(eventId),
+					spotsRemaining(eventId),
+				]);
+				if (cancelled) return;
+				setRemaining(freshSpots);
+
+				if (existing) {
+					setTicket(existing);
+					setSubmitting(false);
+					return;
+				}
+
+				// No existing ticket — try to RSVP. The backend returns 409 with
+				// {error:'capacity_full'} when the event is full; we let that
+				// bubble up to the catch block which renders the localized alert.
+				const record = await addRsvp({
+					eventId,
+					name: auth.name ?? null,
+					email: auth.email,
+				});
+				if (cancelled) return;
+				setTicket(record);
+				// Refresh spots after our successful RSVP so the chip reflects
+				// the post-write count.
+				const after = await spotsRemaining(eventId);
+				if (cancelled) return;
+				setRemaining(after);
+				setSubmitting(false);
+			} catch (err) {
+				if (cancelled) return;
+				const message = err instanceof Error ? err.message : "generic";
+				setErrorKey(errorKeyFor(message));
+				setSubmitting(false);
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [event, auth.name, auth.email, eventId]);
 
 	if (!event) {
 		return (
@@ -89,7 +141,36 @@ function RsvpFlow({ auth }: { auth: AuthState }) {
 		);
 	}
 
-	if (!ticket && remaining <= 0) {
+	// Error state — render an Alert with the localized message and offer
+	// the Meetup fallback. capacity_full also lands here.
+	if (errorKey) {
+		return (
+			<Container
+				header={<Header variant="h2">{t("rsvp.soldOutHeader")}</Header>}
+			>
+				<SpaceBetween size="m">
+					<Alert
+						type={errorKey === "rsvp.error.capacityFull" ? "info" : "error"}
+					>
+						{t(errorKey)}
+					</Alert>
+					<Button
+						href={event.meetupRsvpUrl}
+						target="_blank"
+						iconAlign="right"
+						iconName="external"
+					>
+						{t("rsvp.fallbackMeetupCta")}
+					</Button>
+				</SpaceBetween>
+			</Container>
+		);
+	}
+
+	// remaining is NaN when the public spots endpoint failed; treat that as
+	// "unknown but not-yet-error" only when we already have a ticket. If we
+	// have no ticket and remaining is 0, render the sold-out fallback.
+	if (!ticket && remaining === 0) {
 		return (
 			<Container
 				header={<Header variant="h2">{t("rsvp.soldOutHeader")}</Header>}


### PR DESCRIPTION
Replaces localStorage RSVP storage with fetch() calls to the cdn-rsvp Lambda deployed in #251. localStorage retained as read-cache fallback during transient API outages (writes go to backend only).

## what ships
- src/lib/rsvp.ts rewritten: API_BASE points at https://tta0e43bs0.execute-api.us-west-2.amazonaws.com/prod, async fetch() with auth header from sessionStorage.cdn.idToken, backward-compat shims preserve old call signatures
- 4 new error keys per locale (capacityFull / network / unauthorized / generic) with norteño es-MX
- src/sites/awsug/rsvp/app.tsx — try/catch + Alert rendering with errorKeyFor() mapper
- src/sites/awsug/meetings/components/my-tickets.tsx — async listMyRsvps + cache fallback filtered to current user sub
- src/pages/feed/components/featured-event.tsx — async spotsRemaining + Number.isFinite guard so NaN (network error) hides the chip rather than rendering 'NaN of 50'
- vitest suite rewritten: mocks fetch() instead of localStorage, 16 rsvp lib cases (was 11), featured-event tests made async-aware

## CSP
NOT modified. Both awsug + main CSP files already permit the new endpoint through the existing `https://*.execute-api.us-west-2.amazonaws.com` wildcard. Saves CSP byte budget.

## gates
- biome ci: 0 errors / 541 warnings (baseline)
- tsc: clean
- npm run build: PASS for main + auth + awsug
- vitest: 700 / 700 PASS

## verification
Backend smoke tested live before this PR was prepared:
- GET /rsvp/happy-hour-2026-06-03/spots → 200 {capacity:50, taken:0, remaining:50}
- GET /rsvp/does-not-exist/spots → 404 {error:unknown_event}
- POST /rsvp without auth → 401 {error:unauthorized}
- OPTIONS preflight → 204 + correct CORS headers