### PR TITLE
fix(rsvp): wave 35c — deploy-cdn-rsvp.sh durable env-var handling via jq + --environment file://

### DIFF
--- a/scripts/deploy-cdn-rsvp.sh
+++ b/scripts/deploy-cdn-rsvp.sh
@@ -5,6 +5,12 @@ set -euo pipefail
 # Production traffic via API Gateway HTTP V2 (configured separately by
 # scripts/deploy-cdn-rsvp-apigw.sh).
 # Profile: jitsi-video-hosting (account 170473530355, us-west-2)
+#
+# NOTE: Environment variables are written to a tmp JSON file via jq and passed
+# as `--environment file:///tmp/cdn-rsvp-env.json` (instead of the AWS CLI
+# `Variables={k=v,...}` shorthand). EVENT_CAPACITIES contains JSON with commas,
+# which breaks the shorthand parser. The file:// pattern sidesteps it entirely.
+# See wave 35c.
 
 LAMBDA_ACCOUNT=170473530355
 LAMBDA_REGION=us-west-2
@@ -87,7 +93,19 @@ cd "$REPO_ROOT"
 
 echo "=== 4. Create/update Lambda function ==="
 ROLE_ARN="arn:aws:iam::${LAMBDA_ACCOUNT}:role/${ROLE_NAME}"
-ENV_VARS="Variables={EVENT_CAPACITIES=${EVENT_CAPACITIES},USER_POOL_ID=${USER_POOL_ID},RSVP_TABLE=${RSVP_TABLE}}"
+
+# Build the Environment payload as a tmp JSON file via jq. Passing complex
+# values inline via the AWS CLI `Variables={k=v,...}` shorthand fails when
+# any value contains a comma (e.g. EVENT_CAPACITIES JSON). jq handles all
+# the quote/escape rules correctly. See wave 35c.
+ENV_JSON_FILE=/tmp/cdn-rsvp-env.json
+jq -n \
+  --arg ec "$EVENT_CAPACITIES" \
+  --arg up "$USER_POOL_ID" \
+  --arg rt "$RSVP_TABLE" \
+  '{Variables: {EVENT_CAPACITIES: $ec, USER_POOL_ID: $up, RSVP_TABLE: $rt}}' \
+  > "$ENV_JSON_FILE"
+trap 'rm -f "$ENV_JSON_FILE" /tmp/cdn-rsvp.zip' EXIT
 
 if aws lambda get-function --function-name "$LAMBDA_NAME" \
     --region "$LAMBDA_REGION" --profile "$PROFILE" 2>/dev/null; then
@@ -100,7 +118,7 @@ if aws lambda get-function --function-name "$LAMBDA_NAME" \
     --region "$LAMBDA_REGION" --profile "$PROFILE"
   aws lambda update-function-configuration --function-name "$LAMBDA_NAME" \
     --role "$ROLE_ARN" \
-    --environment "$ENV_VARS" \
+    --environment "file://$ENV_JSON_FILE" \
     --timeout "$LAMBDA_TIMEOUT" --memory-size "$LAMBDA_MEMORY" \
     --region "$LAMBDA_REGION" --profile "$PROFILE"
 else
@@ -111,7 +129,7 @@ else
     --zip-file fileb:///tmp/cdn-rsvp.zip \
     --timeout "$LAMBDA_TIMEOUT" --memory-size "$LAMBDA_MEMORY" \
     --architectures x86_64 \
-    --environment "$ENV_VARS" \
+    --environment "file://$ENV_JSON_FILE" \
     --region "$LAMBDA_REGION" --profile "$PROFILE"
   aws lambda wait function-active \
     --function-name "$LAMBDA_NAME" \


### PR DESCRIPTION
Surgical script fix. Wave 35a's first deploy hit `ParamValidation: Expected: '=', received: '"'` because the AWS CLI `--environment Variables={k=v,...}` shorthand can't handle commas inside JSON values (EVENT_CAPACITIES is `{"happy-hour-2026-06-03":50}`). The Lambda was created via a manual `--cli-input-json` bypass; this PR makes the script itself durable.

## change
```diff
- ENV_VARS="Variables={EVENT_CAPACITIES=...,USER_POOL_ID=...,RSVP_TABLE=...}"
+ jq -n --arg ec "$EVENT_CAPACITIES" --arg up "$USER_POOL_ID" --arg rt "$RSVP_TABLE" \
+   '{Variables: {EVENT_CAPACITIES: $ec, USER_POOL_ID: $up, RSVP_TABLE: $rt}}' \
+   > /tmp/cdn-rsvp-env.json
+ trap 'rm -f /tmp/cdn-rsvp-env.json /tmp/cdn-rsvp.zip' EXIT
- ... --environment "$ENV_VARS"
+ ... --environment "file:///tmp/cdn-rsvp-env.json"
```

Both create-function and update-function-configuration paths updated.

## verified
- bash -n syntax check: pass
- biome ci: 0 errors / 541 warnings (baseline, .sh files not linted)
- npm run build: PASS
- vitest: 700 / 700 PASS

## notes
Pure deploy-tooling fix. No Lambda runtime change. No env var value change. Live Lambda unchanged from #251.