### PR TITLE
fix(format): run biome check --write on src/

### DIFF
--- a/src/pages/admin/index.html
+++ b/src/pages/admin/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/pages/auth/callback/index.html
+++ b/src/pages/auth/callback/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/pages/costs/index.html
+++ b/src/pages/costs/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/pages/create-meeting/index.html
+++ b/src/pages/create-meeting/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/pages/dune-test/index.html
+++ b/src/pages/dune-test/index.html
@@ -62,7 +62,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/pages/feed/index.html
+++ b/src/pages/feed/index.html
@@ -32,7 +32,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/pages/home/index.html
+++ b/src/pages/home/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/pages/learning/api/index.html
+++ b/src/pages/learning/api/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/pages/maintenance-calendar/index.html
+++ b/src/pages/maintenance-calendar/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/pages/meeting-public/index.html
+++ b/src/pages/meeting-public/index.html
@@ -14,7 +14,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/pages/meetings/index.html
+++ b/src/pages/meetings/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/pages/plans/index.html
+++ b/src/pages/plans/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/pages/roadmap/index.html
+++ b/src/pages/roadmap/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/pages/theme/index.html
+++ b/src/pages/theme/index.html
@@ -15,7 +15,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/sites/auth/forgot-password/index.html
+++ b/src/sites/auth/forgot-password/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/sites/auth/login/index.html
+++ b/src/sites/auth/login/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/sites/auth/passkeys/index.html
+++ b/src/sites/auth/passkeys/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/sites/auth/signup/index.html
+++ b/src/sites/auth/signup/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/sites/auth/verification-setup/index.html
+++ b/src/sites/auth/verification-setup/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/sites/auth/verify/index.html
+++ b/src/sites/auth/verify/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/sites/awsug/admin/index.html
+++ b/src/sites/awsug/admin/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/sites/awsug/auth/callback/index.html
+++ b/src/sites/awsug/auth/callback/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/sites/awsug/auth/redeem/index.html
+++ b/src/sites/awsug/auth/redeem/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/sites/awsug/create-meeting/index.html
+++ b/src/sites/awsug/create-meeting/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/sites/awsug/index.html
+++ b/src/sites/awsug/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/sites/awsug/meetings/index.html
+++ b/src/sites/awsug/meetings/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');

--- a/src/sites/awsug/rsvp/index.html
+++ b/src/sites/awsug/rsvp/index.html
@@ -16,7 +16,7 @@
          same class is a no-op classList toggle. Wrapped in try/catch because
          localStorage throws in private-browsing modes. -->
     <script>
-      (function () {
+      (() => {
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');


### PR DESCRIPTION
## Summary

Sprint 3 CI cleanup. Ran the repo's pinned biome (`@biomejs/biome 2.4.13`) in safe-fix mode against `src/` to clear formatter/linter drift before turning on the format gate in CI.

## Command

```bash
npx biome check --write src/
```

Uses the existing `biome.json` (formatter: tab indent, double quotes; linter: recommended + a11y/style/correctness/suspicious overrides; assist: organizeImports on).

## Result

- `Checked 349 files in 281ms. Fixed 27 files.`
- 27 files changed, 27 insertions(+), 27 deletions(-)
- All 27 modified files are HTML (`src/pages/**/index.html`, `src/sites/**/index.html`)
- The single auto-applied safe fix is `lint/complexity/useArrowFunction` on the inline theme-bootstrap IIFE: `(function () { ... })` → `(() => { ... })`
- No TS/TSX/JS/CSS files needed changes — the existing source already matched biome's formatter

## Out of scope

`biome check --write` reported **514 warnings** with **265 unsafe fixes skipped** (e.g. `noImportantStyles` in `src/components/speaker-proposal-cta/styles.css`, plus the rest of the recommended-warn rule set). Those need human review and a follow-up PR with `--unsafe` or targeted edits — intentionally not included here so this PR stays a mechanical, reviewable formatting pass.

## Verification

- `git diff --shortstat` → `27 files changed, 27 insertions(+), 27 deletions(-)`
- All changes are inside `src/`
- No changes to `biome.json`, lockfile, or build config