### PR TITLE
feat(feed): wave 36b — FeedCardShell primitive unifies non-event card chrome (palettes, depth stack, error boundary, scroll-pause)

### DIFF
--- a/src/pages/feed/components/__tests__/featured-video-card.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-video-card.test.tsx
@@ -3,7 +3,17 @@
 
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../../../../contexts/locale-context";
 import FeaturedVideoCard from "../featured-video-card";
+
+// Wave 36b — FeaturedVideoCard now wraps its content in FeedCardShell, which
+// consumes useTranslation() to resolve the rsvp.error.generic fallback for
+// its internal error boundary. All renders below therefore need a locale
+// provider in scope; without it useTranslation throws "must be used within
+// a LocaleProvider" before the component reaches the assertions.
+function renderCard(ui: React.ReactElement) {
+	return render(<LocaleProvider locale="us">{ui}</LocaleProvider>);
+}
 
 // ── IntersectionObserver mock ─────────────────────────────────────────────────
 type IOCallback = (entries: IntersectionObserverEntry[]) => void;
@@ -38,25 +48,25 @@ const PROPS = {
 
 describe("FeaturedVideoCard", () => {
 	it("renders thumbnail with correct src", () => {
-		render(<FeaturedVideoCard {...PROPS} />);
+		renderCard(<FeaturedVideoCard {...PROPS} />);
 		const img = screen.getByTestId("featured-video-thumbnail");
 		expect(img).toHaveAttribute("src", PROPS.thumbnailUrl);
 	});
 
 	it("renders title and author", () => {
-		render(<FeaturedVideoCard {...PROPS} />);
+		renderCard(<FeaturedVideoCard {...PROPS} />);
 		expect(screen.getByText(PROPS.title)).toBeInTheDocument();
 		expect(screen.getByText(PROPS.author)).toBeInTheDocument();
 	});
 
 	it("does not render iframe before IntersectionObserver fires", () => {
-		render(<FeaturedVideoCard {...PROPS} />);
+		renderCard(<FeaturedVideoCard {...PROPS} />);
 		expect(screen.queryByTitle(PROPS.title)).toBeNull();
 	});
 
 	it("renders iframe with correct src after IntersectionObserver fires", async () => {
 		const { act } = await import("react");
-		render(<FeaturedVideoCard {...PROPS} />);
+		renderCard(<FeaturedVideoCard {...PROPS} />);
 		await act(async () => {
 			lastCallback?.([{ isIntersecting: true } as IntersectionObserverEntry]);
 		});

--- a/src/pages/feed/components/__tests__/feed-card-shell.test.tsx
+++ b/src/pages/feed/components/__tests__/feed-card-shell.test.tsx
@@ -1,0 +1,194 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/**
+ * Wave 36b — FeedCardShell primitive tests.
+ *
+ * Locks the contract the rest of the wave 36b refactors depend on:
+ *   1. The shell exposes the same h2 heading semantics that the original
+ *      Cloudscape <Header variant="h2"> provided, via role="heading" +
+ *      aria-level=2 on the marquee div.
+ *   2. Children render inside the shell (the wrapping Cloudscape Container
+ *      doesn't swallow content).
+ *   3. The palette modifier class is applied to the wrapper so per-card
+ *      hue differentiation actually paints.
+ *   4. The local error boundary catches a throwing child and renders a
+ *      fallback inside the same shell chrome (so a broken card doesn't
+ *      blank the rest of the feed page).
+ *   5. The CSS hooks the prefers-reduced-motion + scroll-pause stylesheets
+ *      target are present in the rendered DOM.
+ *
+ * jsdom doesn't apply external CSS to the cascade, so #5 is asserted as a
+ * structural contract: the .feed-card-shell + .feed-card-shell__marquee
+ * class names exist on the rendered elements. If those drift the
+ * stylesheets silently regress; the test fails first.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../../../../contexts/locale-context";
+import FeedCardShell, { FeedCardShellErrorBoundary } from "../feed-card-shell";
+
+function renderShell(
+	ui: React.ReactElement,
+	{ locale = "us" as "us" | "mx" } = {},
+) {
+	return render(<LocaleProvider locale={locale}>{ui}</LocaleProvider>);
+}
+
+describe("FeedCardShell", () => {
+	it("renders headerText inside an element with role=heading and aria-level=2", () => {
+		renderShell(
+			<FeedCardShell headerText="Sample Header" palette="sage">
+				<p>body</p>
+			</FeedCardShell>,
+		);
+
+		const heading = screen.getByRole("heading", { level: 2 });
+		expect(heading).toBeInTheDocument();
+		expect(heading).toHaveTextContent("Sample Header");
+	});
+
+	it("renders children inside the shell", () => {
+		renderShell(
+			<FeedCardShell headerText="With Body" palette="amber">
+				<p data-testid="shell-body">body content here</p>
+			</FeedCardShell>,
+		);
+
+		expect(screen.getByTestId("shell-body")).toBeInTheDocument();
+		expect(screen.getByTestId("shell-body")).toHaveTextContent(
+			"body content here",
+		);
+	});
+
+	it("applies the palette modifier class to the wrapper", () => {
+		const { container } = renderShell(
+			<FeedCardShell headerText="Sage Card" palette="sage">
+				<p>body</p>
+			</FeedCardShell>,
+		);
+
+		const wrapper = container.querySelector(".feed-card-shell");
+		expect(wrapper).not.toBeNull();
+		expect(wrapper?.classList.contains("feed-card-shell--sage")).toBe(true);
+		expect(wrapper?.getAttribute("data-feed-card-palette")).toBe("sage");
+	});
+
+	it("error boundary catches a throwing child and renders the locale fallback inside the same shell chrome", () => {
+		const Boom = (): React.JSX.Element => {
+			throw new Error("simulated wave 36b shell render failure");
+		};
+
+		// Suppress the boundary's diagnostic console.error + React's caught-
+		// error log so the test stdout stays clean. The boundary's user-
+		// facing fallback is what the assertions below validate.
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+			// intentionally empty
+		});
+
+		try {
+			const { container } = renderShell(
+				<FeedCardShell headerText="Boom Card" palette="rose">
+					<Boom />
+				</FeedCardShell>,
+			);
+
+			// Same shell chrome (palette modifier still applied) so the empty
+			// state anchors visually in the same slot.
+			const wrapper = container.querySelector(".feed-card-shell");
+			expect(wrapper).not.toBeNull();
+			expect(wrapper?.classList.contains("feed-card-shell--rose")).toBe(true);
+
+			// The marquee header still announces itself as h2.
+			expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+				"Boom Card",
+			);
+
+			// Fallback message resolves through the rsvp.error.generic locale
+			// key. en-US copy: "Something went wrong — we logged it. Try
+			// again or RSVP on Meetup." — assert on the stable opening
+			// phrase to insulate from minor copy edits.
+			expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+
+	it("renders the structural class hooks that the scroll-pause + prefers-reduced-motion CSS targets", () => {
+		const { container } = renderShell(
+			<FeedCardShell headerText="Hooks Card" palette="violet">
+				<p>body</p>
+			</FeedCardShell>,
+		);
+
+		// .feed-card-shell is the perspective + preserve-3d + will-change
+		// + contain target. The stylesheet's reduced-motion fallback also
+		// targets this class to flatten perspective. If the class drifts,
+		// the depth stack silently disables.
+		const wrapper = container.querySelector(".feed-card-shell");
+		expect(wrapper).not.toBeNull();
+
+		// .feed-card-shell__marquee is the scroll-pause target inside the
+		// body.cdn-scrolling rule + the marquee chrome itself. Same drift
+		// concern as above.
+		const marquee = container.querySelector(".feed-card-shell__marquee");
+		expect(marquee).not.toBeNull();
+		expect(marquee?.getAttribute("role")).toBe("heading");
+		expect(marquee?.getAttribute("aria-level")).toBe("2");
+
+		// The marquee text + actions slot classes — match what the shell
+		// styles (and any future per-palette tweaks) target.
+		expect(
+			container.querySelector(".feed-card-shell__marquee-text"),
+		).not.toBeNull();
+	});
+
+	it("renders the optional headerActions slot when provided", () => {
+		const { container } = renderShell(
+			<FeedCardShell
+				headerText="With Actions"
+				palette="gold"
+				headerActions={<a href="https://example.test">All →</a>}
+			>
+				<p>body</p>
+			</FeedCardShell>,
+		);
+
+		const actions = container.querySelector(
+			".feed-card-shell__marquee-actions",
+		);
+		expect(actions).not.toBeNull();
+		expect(actions?.textContent).toContain("All →");
+	});
+
+	it("FeedCardShellErrorBoundary fallback works when used directly with a throwing child", () => {
+		const Boom = (): React.JSX.Element => {
+			throw new Error("direct boundary test");
+		};
+
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+			// intentionally empty — see comment in earlier suppression
+		});
+
+		try {
+			const { container } = render(
+				<FeedCardShellErrorBoundary
+					headerText="Direct"
+					palette="lavender"
+					fallbackMessage="Direct fallback message"
+				>
+					<Boom />
+				</FeedCardShellErrorBoundary>,
+			);
+
+			expect(container.querySelector(".feed-card-shell")).not.toBeNull();
+			expect(
+				container.querySelector(".feed-card-shell--lavender"),
+			).not.toBeNull();
+			expect(screen.getByText(/direct fallback message/i)).toBeInTheDocument();
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+});

--- a/src/pages/feed/components/andres-medium.tsx
+++ b/src/pages/feed/components/andres-medium.tsx
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: MIT-0
 
 import Box from "@cloudscape-design/components/box";
-import Container from "@cloudscape-design/components/container";
-import Header from "@cloudscape-design/components/header";
 import Icon from "@cloudscape-design/components/icon";
 import Link from "@cloudscape-design/components/link";
 import { useEffect, useState } from "react";
 import posts from "../../../data/andres-medium.json";
 import { useTranslation } from "../../../hooks/useTranslation";
+import FeedCardShell from "./feed-card-shell";
 
 interface Post {
 	title: string;
@@ -32,24 +31,20 @@ export default function AndresMedium() {
 
 	const post = items[index];
 
+	// Wave 36b — actions slot mirrors Cloudscape Header's `actions` prop. The
+	// shell's marquee renders this in its right-aligned slot so the "All
+	// posts →" link still reads as a peer of the heading.
+	const headerActions = (
+		<Link href="https://andmoredev.medium.com/" external fontSize="body-s">
+			{t("feedPage.andresMediumAllPosts")} <Icon name="external" />
+		</Link>
+	);
+
 	return (
-		<Container
-			header={
-				<Header
-					variant="h2"
-					actions={
-						<Link
-							href="https://andmoredev.medium.com/"
-							external
-							fontSize="body-s"
-						>
-							{t("feedPage.andresMediumAllPosts")} <Icon name="external" />
-						</Link>
-					}
-				>
-					{t("feedPage.andresMediumHeader")}
-				</Header>
-			}
+		<FeedCardShell
+			headerText={t("feedPage.andresMediumHeader")}
+			headerActions={headerActions}
+			palette="navy"
 		>
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: hover/focus pause is a progressive enhancement; keyboard users reach the link directly */}
 			<div
@@ -82,6 +77,6 @@ export default function AndresMedium() {
 					{index + 1} / {items.length}
 				</span>
 			</div>
-		</Container>
+		</FeedCardShell>
 	);
 }

--- a/src/pages/feed/components/andres-youtube-live.tsx
+++ b/src/pages/feed/components/andres-youtube-live.tsx
@@ -1,12 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import Container from "@cloudscape-design/components/container";
-import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import { LazyEmbed } from "../../../components/lazy-embed";
 import { SkeletonFrame } from "../../../components/skeleton";
 import { useTranslation } from "../../../hooks/useTranslation";
+import FeedCardShell from "./feed-card-shell";
 
 export default function AndresYoutubeLive({
 	videoId,
@@ -14,26 +13,30 @@ export default function AndresYoutubeLive({
 	videoId: string | null;
 }) {
 	const { t } = useTranslation();
-	const header = (
-		<Header
-			variant="h2"
-			actions={
-				<Link
-					href="https://www.youtube.com/@andmoredev"
-					external
-					fontSize="body-s"
-				>
-					{t("feedPage.andresYoutubeChannel")}
-				</Link>
-			}
-		>
+
+	// Wave 36b — header copy carries an inline live-dot indicator (same
+	// pattern as the previous Cloudscape Header). headerText accepts
+	// ReactNode so the leading red-dot span renders inside the marquee
+	// before the headline string.
+	const headerText = (
+		<>
 			<span className="feed-twitch__live-dot" aria-hidden="true" />
 			{` ${t("feedPage.andresYoutubeLiveHeader")}`}
-		</Header>
+		</>
+	);
+
+	const headerActions = (
+		<Link href="https://www.youtube.com/@andmoredev" external fontSize="body-s">
+			{t("feedPage.andresYoutubeChannel")}
+		</Link>
 	);
 
 	return (
-		<Container header={header}>
+		<FeedCardShell
+			headerText={headerText}
+			headerActions={headerActions}
+			palette="rose"
+		>
 			{videoId ? (
 				<div className="feed-carousel">
 					<div className="feed-carousel__viewport">
@@ -49,6 +52,6 @@ export default function AndresYoutubeLive({
 			) : (
 				<SkeletonFrame />
 			)}
-		</Container>
+		</FeedCardShell>
 	);
 }

--- a/src/pages/feed/components/arrowhead-news.tsx
+++ b/src/pages/feed/components/arrowhead-news.tsx
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: MIT-0
 
 import Box from "@cloudscape-design/components/box";
-import Container from "@cloudscape-design/components/container";
-import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import type React from "react";
 import { useEffect, useId, useRef, useState } from "react";
 import articles from "../../../data/arrowhead-news.json";
 import { useTranslation } from "../../../hooks/useTranslation";
+import FeedCardShell from "./feed-card-shell";
 
 export default function ArrowheadNews() {
 	const { t } = useTranslation();
@@ -53,17 +52,22 @@ export default function ArrowheadNews() {
 		}
 	}
 
+	// Wave 36b — header shifts from a Cloudscape <Header variant="h2"> with
+	// an inline secondary span ("at NMSU") to the FeedCardShell marquee. The
+	// shell's headerText prop accepts ReactNode so we pass the same JSX
+	// structure (label + sub-label span) through; the role="heading" /
+	// aria-level=2 contract is asserted by the shell on the marquee wrapper.
+	const headerText = (
+		<>
+			Arrowhead Research Park
+			<span className="feed-card-header-sub">
+				{t("feedPage.arrowheadAtNmsu")}
+			</span>
+		</>
+	);
+
 	return (
-		<Container
-			header={
-				<Header variant="h2">
-					Arrowhead Research Park
-					<span className="feed-card-header-sub">
-						{t("feedPage.arrowheadAtNmsu")}
-					</span>
-				</Header>
-			}
-		>
+		<FeedCardShell headerText={headerText} palette="sage">
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: hover/focus pause is a progressive enhancement; keyboard users reach article links directly */}
 			<div
 				className="feed-article-carousel"
@@ -134,6 +138,6 @@ export default function ArrowheadNews() {
 					))}
 				</div>
 			</div>
-		</Container>
+		</FeedCardShell>
 	);
 }

--- a/src/pages/feed/components/builder-center-card.tsx
+++ b/src/pages/feed/components/builder-center-card.tsx
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import Container from "@cloudscape-design/components/container";
-import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "../../../hooks/useTranslation";
@@ -12,6 +10,7 @@ import {
 	type BuilderCenterCard as Card,
 	deckForLocale,
 } from "./builder-center-data";
+import FeedCardShell from "./feed-card-shell";
 
 const MAX_TITLE = 90; // 2-line clamp handles wrap; this caps absurd outliers
 const truncate = (s: string) =>
@@ -139,20 +138,17 @@ export default function BuilderCenterCard() {
 		step(dir);
 	};
 
+	const headerActions = (
+		<Link href="https://builder.aws.com/" external fontSize="body-s">
+			{t("feedPage.builderCenterOpen")}
+		</Link>
+	);
+
 	return (
-		<Container
-			header={
-				<Header
-					variant="h2"
-					actions={
-						<Link href="https://builder.aws.com/" external fontSize="body-s">
-							{t("feedPage.builderCenterOpen")}
-						</Link>
-					}
-				>
-					{t("feedPage.builderCenterHeader")}
-				</Header>
-			}
+		<FeedCardShell
+			headerText={t("feedPage.builderCenterHeader")}
+			headerActions={headerActions}
+			palette="gold"
 		>
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: pointer handlers only pause auto-advance — keyboard / SR users use the chevron buttons below */}
 			<div
@@ -201,6 +197,6 @@ export default function BuilderCenterCard() {
 					</div>
 				)}
 			</div>
-		</Container>
+		</FeedCardShell>
 	);
 }

--- a/src/pages/feed/components/featured-video-card.tsx
+++ b/src/pages/feed/components/featured-video-card.tsx
@@ -1,10 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import Container from "@cloudscape-design/components/container";
-import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import { LazyEmbed } from "../../../components/lazy-embed";
+import FeedCardShell from "./feed-card-shell";
 
 interface FeaturedVideoCardProps {
 	videoId: string;
@@ -21,26 +20,23 @@ export default function FeaturedVideoCard({
 	authorUrl,
 	thumbnailUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
 }: FeaturedVideoCardProps) {
+	const headerActions = (
+		<Link
+			href={authorUrl}
+			external
+			fontSize="body-s"
+			rel="noopener noreferrer"
+			target="_blank"
+		>
+			{author}
+		</Link>
+	);
+
 	return (
-		<Container
-			header={
-				<Header
-					variant="h2"
-					actions={
-						<Link
-							href={authorUrl}
-							external
-							fontSize="body-s"
-							rel="noopener noreferrer"
-							target="_blank"
-						>
-							{author}
-						</Link>
-					}
-				>
-					{title}
-				</Header>
-			}
+		<FeedCardShell
+			headerText={title}
+			headerActions={headerActions}
+			palette="lavender"
 		>
 			<div className="feed-carousel">
 				<div className="feed-carousel__viewport">
@@ -67,6 +63,6 @@ export default function FeaturedVideoCard({
 					</Link>
 				</div>
 			</div>
-		</Container>
+		</FeedCardShell>
 	);
 }

--- a/src/pages/feed/components/feed-card-shell.css
+++ b/src/pages/feed/components/feed-card-shell.css
@@ -1,0 +1,434 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT-0
+
+   ============================================================================
+   Wave 36b — FeedCardShell shared chrome
+   ============================================================================
+
+   Lifts the depth-stack + marquee-header treatment proven in waves 32a / 33a /
+   33b on the three event cards into one primitive that the simpler non-event
+   feed cards can adopt. The cards in scope (arrowhead-news, andres-medium,
+   andres-youtube-live, builder-center, twitch panes, featured-video,
+   andmore/awsml/readysetcloud feed-section variants) previously rendered as
+   plain Cloudscape Containers with the default h2 header — visually flat
+   compared to the rizzed-up event cards above them. This file gives them all
+   the same dimensional vocabulary while keeping each card visually distinct
+   via a per-palette modifier class.
+
+   The .feed-card-shell wrapper sits *outside* the Cloudscape Container and
+   carries:
+     - perspective(1200px) + transform-style: preserve-3d so any child that
+       wants a translateZ pop can have one without loading a runtime 3D engine
+       (matches featured-event / next-meetup / upcoming-virtual-event)
+     - will-change: transform + contain: layout paint style + a translate3d
+       compositor hint so the card lives on its own GPU layer (same idiom
+       wave 30a deployed on the featured-event card to mitigate scroll
+       tearing — apply it everywhere so the rest of the feed scrolls with the
+       same stability)
+     - a 1px stage-rim inset on the box-shadow plus a layered ambient bloom
+       that picks up the palette accent at low opacity
+
+   The .feed-card-shell__marquee element replaces the Cloudscape <Header
+   variant="h2"> chrome. It carries a 2px palette-tinted rim, an inset
+   highlight on top + a darker shadow on the bottom (the "lit-from-above
+   sign" idiom), an emissive uppercase-tracked headline, and an optional
+   right-aligned actions slot. The wrapper announces itself as h2 to AT via
+   role="heading" + aria-level=2 — Cloudscape only renders an actual <h2>
+   through its Header component, so swapping in custom chrome means we
+   re-assert the role on the replacement.
+
+   Per-palette `.feed-card-shell--<name>` modifiers swap the eight CSS
+   custom properties. Both light and dark mode are covered for every palette.
+
+   ── Wave 36b TODO (deferred from this PR) ────────────────────────────────
+   The three YouTube carousels — youtube-carousel.tsx,
+   youtube-channel-carousel.tsx, youtube-shorts-carousel.tsx — were
+   intentionally not migrated to FeedCardShell in wave 36b. Their internal
+   layout (carousel viewport, frame ratio, custom chevrons) deserves a
+   separate consideration of how the shell's marquee header reads above
+   embedded video chrome before being wrapped. Pick this up in a follow-up
+   wave; shell adoption there is purely cosmetic, so deferring does not
+   block the wave 36b goal of "no plain Cloudscape Containers on the feed
+   page". The TODO is also recorded in src/pages/feed/styles.css per the
+   wave 36b brief. */
+
+.feed-card-shell {
+	/* Default tokens — overridden by the per-palette modifier classes
+	   below. Listed here so a card that forgets the palette modifier
+	   still renders something legible (graceful degradation). */
+	--fcs-bg-from: #f5f5f5;
+	--fcs-bg-to: #e5e5e5;
+	--fcs-rim: #888;
+	--fcs-rim-highlight: rgba(255, 255, 255, 0.6);
+	--fcs-shadow: rgba(0, 0, 0, 0.18);
+	--fcs-text: #1a1a1a;
+	--fcs-text-glow: rgba(255, 255, 255, 0.5);
+	--fcs-stage-rim: rgba(255, 255, 255, 0.08);
+	--fcs-ambient-bloom: rgba(0, 0, 0, 0.1);
+
+	position: relative;
+	isolation: isolate;
+	border-radius: var(--cdn-radius-md, 8px);
+	/* perspective + preserve-3d let descendant elements pop forward in
+	   z without loading a runtime 3D engine. 1200px = subtle ambient
+	   depth, same value waves 30a/33a/33b use on the event cards. */
+	perspective: 1200px;
+	transform-style: preserve-3d;
+	/* Compositor isolation — layered defense against scroll tearing.
+	   contain: layout paint style isolates the card's paint operations,
+	   translate3d forces its own GPU layer, will-change proactively
+	   promotes the layer up-front. Same idiom from wave 30a on the
+	   featured-event card; applying it to every shelled card so the
+	   whole feed page scrolls with the same stability. */
+	contain: layout paint style;
+	transform: translate3d(0, 0, 0);
+	will-change: transform;
+	/* Layered ambient bloom + 1px stage-rim inset — gives the card a
+	   visible "stage edge" line under varied page backgrounds without
+	   requiring the inner Cloudscape Container to opt in. The inset is
+	   palette-tinted via the --fcs-stage-rim variable so dark-mode
+	   variants get a brighter rim against deeper backplates. */
+	box-shadow:
+		0 1px 2px var(--fcs-shadow),
+		0 8px 24px -10px var(--fcs-ambient-bloom),
+		0 18px 44px -16px var(--fcs-ambient-bloom),
+		inset 0 0 0 1px var(--fcs-stage-rim);
+}
+
+/* Marquee header — replaces Cloudscape's <Header variant="h2"> chrome.
+   Layout: flex row, headline centered horizontally with optional
+   actions slot pinned to the right. Uses min-height instead of fixed
+   height so the actions slot can stack onto a second visual row at
+   narrow container widths without clipping. */
+.feed-card-shell__marquee {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 12px;
+	min-height: 40px;
+	padding: 8px 24px;
+	border-radius: 10px;
+	background: linear-gradient(
+		180deg,
+		var(--fcs-bg-from) 0%,
+		var(--fcs-bg-to) 100%
+	);
+	border: 2px solid var(--fcs-rim);
+	box-shadow:
+		0 1px 0 var(--fcs-rim-highlight) inset,
+		0 -1px 0 rgba(0, 0, 0, 0.18) inset,
+		0 2px 4px var(--fcs-shadow),
+		0 8px 18px -6px var(--fcs-shadow);
+}
+
+/* Headline text — bold uppercase, tight tracking, subtle text-shadow
+   so the lettering reads as emissive against the palette backplate.
+   Mirrors the typographic voice of the wave 32a featured-event marquee
+   so the family reads coherent across the page. */
+.feed-card-shell__marquee-text {
+	position: relative;
+	z-index: 1;
+	flex: 1 1 auto;
+	min-width: 0;
+	display: inline-block;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 1rem;
+	font-weight: 800;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--fcs-text);
+	text-shadow:
+		0 0 6px var(--fcs-text-glow),
+		0 1px 0 rgba(255, 255, 255, 0.35);
+	line-height: 1.15;
+	text-align: center;
+}
+
+/* Right-aligned actions slot — hosts the optional "View all" / channel
+   link. Forced flex-shrink: 0 so the headline gives ground first if the
+   marquee runs out of horizontal space at narrow container widths. */
+.feed-card-shell__marquee-actions {
+	position: relative;
+	z-index: 1;
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	font-size: 0.8125rem;
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	text-transform: none;
+}
+
+/* Inner Cloudscape Container — the shell wraps a Container so existing
+   inner content (SpaceBetween, Box, custom carousels) keeps Cloudscape's
+   surface tokens / padding / focus rings. The rules below are the only
+   tweaks: drop the Cloudscape Container's own outer border (the shell
+   carries the dimensional border via box-shadow inset stage-rim) so we
+   don't get a double rim, and let the Container's surface fill the
+   shell's rounded corners. */
+.feed-card-shell .awsui_root_2qdw9_122zh_141,
+.feed-card-shell [class*="awsui_root_"] {
+	/* Cloudscape Container class names are minified per-build so we match
+	   on the awsui_root_ prefix to keep this stable across releases. */
+	border: none;
+}
+
+/* ============================================================================
+   Palette modifiers
+   ============================================================================
+   Each modifier swaps the eight `--fcs-*` custom properties for both the
+   light and dark theme. Light is the default body styling; dark is gated
+   on the .awsui-dark-mode ancestor (Cloudscape's standard dark-mode hook).
+   Editorial mapping documented inline below + on FeedCardShellPalette in
+   feed-card-shell.tsx. */
+
+/* ── amber — warm dev/casual (feed-section andmore) ───────────────────── */
+.feed-card-shell--amber {
+	--fcs-bg-from: #fef3c7;
+	--fcs-bg-to: #fcd34d;
+	--fcs-rim: #d97706;
+	--fcs-rim-highlight: rgba(255, 251, 235, 0.7);
+	--fcs-shadow: rgba(120, 53, 15, 0.22);
+	--fcs-text: #78350f;
+	--fcs-text-glow: rgba(254, 240, 138, 0.55);
+	--fcs-stage-rim: rgba(217, 119, 6, 0.18);
+	--fcs-ambient-bloom: rgba(120, 53, 15, 0.16);
+}
+
+.awsui-dark-mode .feed-card-shell--amber {
+	--fcs-bg-from: #2a1a08;
+	--fcs-bg-to: #1a0f04;
+	--fcs-rim: #f59e0b;
+	--fcs-rim-highlight: rgba(254, 215, 170, 0.32);
+	--fcs-shadow: rgba(0, 0, 0, 0.55);
+	--fcs-text: #fde68a;
+	--fcs-text-glow: rgba(253, 230, 138, 0.55);
+	--fcs-stage-rim: rgba(245, 158, 11, 0.22);
+	--fcs-ambient-bloom: rgba(120, 53, 15, 0.42);
+}
+
+/* ── teal — cool ML/technical (feed-section awsml) ────────────────────── */
+.feed-card-shell--teal {
+	--fcs-bg-from: #ccfbf1;
+	--fcs-bg-to: #5eead4;
+	--fcs-rim: #0e7490;
+	--fcs-rim-highlight: rgba(236, 254, 255, 0.7);
+	--fcs-shadow: rgba(15, 76, 87, 0.22);
+	--fcs-text: #0e3a4a;
+	--fcs-text-glow: rgba(165, 243, 252, 0.55);
+	--fcs-stage-rim: rgba(14, 116, 144, 0.18);
+	--fcs-ambient-bloom: rgba(15, 76, 87, 0.16);
+}
+
+.awsui-dark-mode .feed-card-shell--teal {
+	--fcs-bg-from: #042f2e;
+	--fcs-bg-to: #021a1a;
+	--fcs-rim: #5eead4;
+	--fcs-rim-highlight: rgba(167, 243, 208, 0.32);
+	--fcs-shadow: rgba(0, 0, 0, 0.55);
+	--fcs-text: #ccfbf1;
+	--fcs-text-glow: rgba(94, 234, 212, 0.55);
+	--fcs-stage-rim: rgba(94, 234, 212, 0.22);
+	--fcs-ambient-bloom: rgba(15, 76, 87, 0.42);
+}
+
+/* ── violet — twitch brand purple (twitch-section) ────────────────────── */
+.feed-card-shell--violet {
+	--fcs-bg-from: #ede9fe;
+	--fcs-bg-to: #c4b5fd;
+	--fcs-rim: #7c3aed;
+	--fcs-rim-highlight: rgba(245, 243, 255, 0.7);
+	--fcs-shadow: rgba(76, 29, 149, 0.22);
+	--fcs-text: #312e81;
+	--fcs-text-glow: rgba(221, 214, 254, 0.55);
+	--fcs-stage-rim: rgba(124, 58, 237, 0.18);
+	--fcs-ambient-bloom: rgba(76, 29, 149, 0.16);
+}
+
+.awsui-dark-mode .feed-card-shell--violet {
+	--fcs-bg-from: #1e1b4b;
+	--fcs-bg-to: #0f0a35;
+	--fcs-rim: #a78bfa;
+	--fcs-rim-highlight: rgba(196, 181, 253, 0.32);
+	--fcs-shadow: rgba(0, 0, 0, 0.55);
+	--fcs-text: #ede9fe;
+	--fcs-text-glow: rgba(167, 139, 250, 0.55);
+	--fcs-stage-rim: rgba(167, 139, 250, 0.22);
+	--fcs-ambient-bloom: rgba(76, 29, 149, 0.42);
+}
+
+/* ── sage — research / academic green (arrowhead-news) ────────────────── */
+.feed-card-shell--sage {
+	--fcs-bg-from: #dcfce7;
+	--fcs-bg-to: #86efac;
+	--fcs-rim: #15803d;
+	--fcs-rim-highlight: rgba(240, 253, 244, 0.7);
+	--fcs-shadow: rgba(20, 83, 45, 0.22);
+	--fcs-text: #14532d;
+	--fcs-text-glow: rgba(187, 247, 208, 0.55);
+	--fcs-stage-rim: rgba(21, 128, 61, 0.18);
+	--fcs-ambient-bloom: rgba(20, 83, 45, 0.16);
+}
+
+.awsui-dark-mode .feed-card-shell--sage {
+	--fcs-bg-from: #052e16;
+	--fcs-bg-to: #022c1a;
+	--fcs-rim: #86efac;
+	--fcs-rim-highlight: rgba(187, 247, 208, 0.32);
+	--fcs-shadow: rgba(0, 0, 0, 0.55);
+	--fcs-text: #dcfce7;
+	--fcs-text-glow: rgba(134, 239, 172, 0.55);
+	--fcs-stage-rim: rgba(134, 239, 172, 0.22);
+	--fcs-ambient-bloom: rgba(20, 83, 45, 0.42);
+}
+
+/* ── rose — warm presence (andres-youtube-live) ──────────────────────── */
+.feed-card-shell--rose {
+	--fcs-bg-from: #ffe4e6;
+	--fcs-bg-to: #fda4af;
+	--fcs-rim: #be123c;
+	--fcs-rim-highlight: rgba(255, 241, 242, 0.7);
+	--fcs-shadow: rgba(127, 29, 29, 0.22);
+	--fcs-text: #7f1d1d;
+	--fcs-text-glow: rgba(254, 205, 211, 0.55);
+	--fcs-stage-rim: rgba(190, 18, 60, 0.18);
+	--fcs-ambient-bloom: rgba(127, 29, 29, 0.16);
+}
+
+.awsui-dark-mode .feed-card-shell--rose {
+	--fcs-bg-from: #3f0a17;
+	--fcs-bg-to: #2a0510;
+	--fcs-rim: #fda4af;
+	--fcs-rim-highlight: rgba(254, 205, 211, 0.32);
+	--fcs-shadow: rgba(0, 0, 0, 0.55);
+	--fcs-text: #ffe4e6;
+	--fcs-text-glow: rgba(253, 164, 175, 0.55);
+	--fcs-stage-rim: rgba(253, 164, 175, 0.22);
+	--fcs-ambient-bloom: rgba(127, 29, 29, 0.42);
+}
+
+/* ── navy — long-form / serious publication ──────────────────────────────
+   Used by both andres-medium AND feed-section readysetcloud. Bryan's
+   brief flagged this as an editorial choice — both sources are bylined
+   long-form tech publications (andmoredev's Medium archive, Allen
+   Helton's Ready Set Cloud blog/newsletter). Reusing the palette keeps
+   them visually paired as the "deep-read" cards in the feed without
+   demanding a 9th palette. */
+.feed-card-shell--navy {
+	--fcs-bg-from: #dbeafe;
+	--fcs-bg-to: #93c5fd;
+	--fcs-rim: #1e40af;
+	--fcs-rim-highlight: rgba(239, 246, 255, 0.7);
+	--fcs-shadow: rgba(30, 58, 138, 0.22);
+	--fcs-text: #1e293b;
+	--fcs-text-glow: rgba(219, 234, 254, 0.55);
+	--fcs-stage-rim: rgba(30, 64, 175, 0.18);
+	--fcs-ambient-bloom: rgba(30, 58, 138, 0.16);
+}
+
+.awsui-dark-mode .feed-card-shell--navy {
+	--fcs-bg-from: #0f172a;
+	--fcs-bg-to: #020617;
+	--fcs-rim: #93c5fd;
+	--fcs-rim-highlight: rgba(219, 234, 254, 0.32);
+	--fcs-shadow: rgba(0, 0, 0, 0.55);
+	--fcs-text: #dbeafe;
+	--fcs-text-glow: rgba(147, 197, 253, 0.55);
+	--fcs-stage-rim: rgba(147, 197, 253, 0.22);
+	--fcs-ambient-bloom: rgba(30, 58, 138, 0.42);
+}
+
+/* ── gold — AWS Builder Center ───────────────────────────────────────── */
+.feed-card-shell--gold {
+	--fcs-bg-from: #fef3c7;
+	--fcs-bg-to: #fbbf24;
+	--fcs-rim: #b45309;
+	--fcs-rim-highlight: rgba(255, 251, 235, 0.7);
+	--fcs-shadow: rgba(120, 53, 15, 0.24);
+	--fcs-text: #78350f;
+	--fcs-text-glow: rgba(254, 243, 199, 0.55);
+	--fcs-stage-rim: rgba(180, 83, 9, 0.2);
+	--fcs-ambient-bloom: rgba(120, 53, 15, 0.16);
+}
+
+.awsui-dark-mode .feed-card-shell--gold {
+	--fcs-bg-from: #451a03;
+	--fcs-bg-to: #2c0a02;
+	--fcs-rim: #fbbf24;
+	--fcs-rim-highlight: rgba(254, 215, 170, 0.34);
+	--fcs-shadow: rgba(0, 0, 0, 0.55);
+	--fcs-text: #fef3c7;
+	--fcs-text-glow: rgba(251, 191, 36, 0.55);
+	--fcs-stage-rim: rgba(251, 191, 36, 0.22);
+	--fcs-ambient-bloom: rgba(120, 53, 15, 0.42);
+}
+
+/* ── lavender — women in tech / featured (featured-video-card) ───────── */
+.feed-card-shell--lavender {
+	--fcs-bg-from: #ede9fe;
+	--fcs-bg-to: #ddd6fe;
+	--fcs-rim: #8b5cf6;
+	--fcs-rim-highlight: rgba(245, 243, 255, 0.7);
+	--fcs-shadow: rgba(76, 29, 149, 0.18);
+	--fcs-text: #3730a3;
+	--fcs-text-glow: rgba(221, 214, 254, 0.55);
+	--fcs-stage-rim: rgba(139, 92, 246, 0.18);
+	--fcs-ambient-bloom: rgba(76, 29, 149, 0.14);
+}
+
+.awsui-dark-mode .feed-card-shell--lavender {
+	--fcs-bg-from: #2a1147;
+	--fcs-bg-to: #1a0a30;
+	--fcs-rim: #c4b5fd;
+	--fcs-rim-highlight: rgba(196, 181, 253, 0.32);
+	--fcs-shadow: rgba(0, 0, 0, 0.55);
+	--fcs-text: #ede9fe;
+	--fcs-text-glow: rgba(196, 181, 253, 0.55);
+	--fcs-stage-rim: rgba(196, 181, 253, 0.22);
+	--fcs-ambient-bloom: rgba(76, 29, 149, 0.42);
+}
+
+/* ============================================================================
+   Scroll-pause integration
+   ============================================================================
+   The feed page wires scroll-jank-mitigation.ts → toggles body.cdn-scrolling
+   during a scroll burst and removes it 250ms after the burst settles. Mirror
+   the wave 30a featured-event approach: while body.cdn-scrolling is set,
+   freeze any sustained animation on the shelled card so the compositor can
+   spend its frame budget on the scroll itself.
+
+   The shell itself doesn't carry a sustained animation today, but per-palette
+   future enhancements may add one (a soft rim breathe is planned but out of
+   scope for wave 36b). The pause rule is wired now so the contract is
+   established; future animations only need to declare they animate, not
+   re-declare the scroll-pause integration. Skipped under reduced-motion
+   since animations are off in that branch. */
+@media (prefers-reduced-motion: no-preference) {
+	body.cdn-scrolling .feed-card-shell,
+	body.cdn-scrolling .feed-card-shell::before,
+	body.cdn-scrolling .feed-card-shell::after,
+	body.cdn-scrolling .feed-card-shell__marquee,
+	body.cdn-scrolling .feed-card-shell__marquee::before,
+	body.cdn-scrolling .feed-card-shell__marquee::after {
+		animation-play-state: paused;
+	}
+}
+
+/* ============================================================================
+   Reduced-motion fallback
+   ============================================================================
+   Strip the GPU compositor hints + perspective when the user has signalled
+   reduced motion. The dimensional pop has nothing to motion-pause to begin
+   with at this layer, but flattening the perspective stack means any future
+   per-card translateZ() doesn't kick the wrapper into a 3D space the user
+   has explicitly opted out of. The card stays fully legible — only the
+   subtle depth idiom is suppressed. */
+@media (prefers-reduced-motion: reduce) {
+	.feed-card-shell {
+		perspective: none;
+		transform-style: flat;
+		will-change: auto;
+		transform: none;
+	}
+}

--- a/src/pages/feed/components/feed-card-shell.tsx
+++ b/src/pages/feed/components/feed-card-shell.tsx
@@ -1,0 +1,273 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/**
+ * Wave 36b — FeedCardShell primitive.
+ *
+ * Bryan kept calling out that the feed page felt inconsistent: the three
+ * event cards (featured-event, next-meetup, upcoming-virtual-event) had
+ * been promoted in waves 32a/33a/33b to a depth-stack treatment with a
+ * marquee-style header, scroll-pause integration, prefers-reduced-motion
+ * gates, and a per-card error boundary, but the *other* cards on the feed
+ * (arrowhead-news, andres-medium, andres-youtube-live, builder-center,
+ * twitch panes, featured-video, andmore/awsml/readysetcloud feed-section
+ * variants) were still vanilla Cloudscape Containers with a default h2
+ * header.
+ *
+ * Rather than bespoke-design every non-event card, this primitive lifts
+ * the shared chrome into one component:
+ *   - Renders a Cloudscape Container so existing inner content keeps its
+ *     padding / border / surface-color behaviour.
+ *   - Replaces the Cloudscape <Header variant="h2"> with a custom marquee
+ *     div carrying role="heading" + aria-level=2 (matches the wave 32a /
+ *     33a / 33b ARIA contract — Cloudscape's Header renders a real <h2>;
+ *     trading that for custom chrome means we re-assert the role on the
+ *     replacement element so AT semantics stay intact).
+ *   - Applies perspective(1200px) + transform-style: preserve-3d on the
+ *     wrapper so any child transforms can pop in z without loading a
+ *     runtime 3D engine, plus the will-change / contain / translate3d
+ *     compositor hints from waves 30a/33a so the card lives on its own
+ *     GPU layer (mirrors the tearing-mitigation idiom proven on the
+ *     featured-event card during scroll).
+ *   - Accepts a small palette enum so each card can pick a distinct hue
+ *     and read distinguishably in the feed without introducing per-card
+ *     CSS files. CSS custom properties drive the gradient / rim / text /
+ *     glow — the .feed-card-shell--* class swaps the variable values.
+ *   - Wraps in a local error boundary so a render failure in one card's
+ *     inner content (typically Intl.DateTimeFormat throwing on a malformed
+ *     date or a fetch path resolving to undefined) shows quiet fallback
+ *     chrome instead of blanking the rest of the feed. Mirrors the wave
+ *     30a FeaturedEventErrorBoundary pattern; fallback copy resolves
+ *     through the existing rsvp.error.generic locale key (no new keys
+ *     introduced this wave).
+ *
+ * NOT used for the three event cards. featured-event, next-meetup, and
+ * upcoming-virtual-event keep their bespoke wave 32a/33a/33b chrome
+ * (chasing bulbs, scrolling-tape shimmer, twinkle stars). The shell is
+ * the leveling-up mechanism for the simpler feed cards only.
+ */
+
+import Box from "@cloudscape-design/components/box";
+import Container from "@cloudscape-design/components/container";
+import {
+	Component,
+	type CSSProperties,
+	type ErrorInfo,
+	type ReactNode,
+} from "react";
+import { useTranslation } from "../../../hooks/useTranslation";
+import "./feed-card-shell.css";
+
+/**
+ * Available palette hues. Each maps to a `.feed-card-shell--<palette>`
+ * modifier class defined in feed-card-shell.css that overrides the eight
+ * `--fcs-*` custom properties (gradient endpoints, rim, text, glow, stage
+ * rim, ambient bloom). Light + dark mode parity is provided per palette
+ * inside the CSS file.
+ *
+ * Editorial intent (wave 36b mapping):
+ *   amber   → warm dev/casual  (feed-section andmore)
+ *   teal    → cool ML/technical (feed-section awsml)
+ *   violet  → twitch brand purple (twitch-section)
+ *   sage    → research / academic green (arrowhead-news)
+ *   rose    → warm presence (andres-youtube-live)
+ *   navy    → long-form / publication / serious (andres-medium,
+ *             feed-section readysetcloud — both are bylined long-form
+ *             tech blogs; intentional duplicate to keep the family read
+ *             cohesive across two related sources)
+ *   gold    → AWS Builder Center
+ *   lavender → women in tech / featured (featured-video-card)
+ */
+export type FeedCardShellPalette =
+	| "amber"
+	| "teal"
+	| "violet"
+	| "sage"
+	| "rose"
+	| "navy"
+	| "gold"
+	| "lavender";
+
+interface FeedCardShellProps {
+	/** Header copy. Strings are most common; ReactNode is supported so
+	 *  cards that need inline JSX in the header (e.g. arrowhead-news's
+	 *  "at NMSU" subtitle, andres-youtube-live's leading live-dot) can
+	 *  pass it through without wrapping the whole shell. */
+	headerText: ReactNode;
+	/** Optional right-aligned slot inside the marquee header — preserves
+	 *  Cloudscape Header's `actions` prop semantics for cards that surface
+	 *  a "View all posts" / channel link (andres-medium, builder-center,
+	 *  feed-section variants, featured-video, andres-youtube-live). */
+	headerActions?: ReactNode;
+	/** Palette modifier — see FeedCardShellPalette JSDoc above for the
+	 *  per-card mapping established in wave 36b. */
+	palette: FeedCardShellPalette;
+	/** Optional extra class on the outer .feed-card-shell wrapper for
+	 *  per-card layout adjustments that don't justify a new modifier. */
+	className?: string;
+	/** The inner card body — typically a Cloudscape SpaceBetween / div
+	 *  carrying the existing card content. Rendered inside the wrapped
+	 *  Cloudscape Container so existing padding / surface tokens apply. */
+	children: ReactNode;
+}
+
+/**
+ * Marquee header — replacement for Cloudscape <Header variant="h2">.
+ *
+ * Renders the headline copy on a palette-tinted backplate with a 2px rim,
+ * a subtle inset highlight, and a soft drop shadow so the sign reads as
+ * an emissive marquee against the card surface. role="heading" +
+ * aria-level=2 announces the equivalent semantic role to assistive tech,
+ * matching the wave 32a / 33a / 33b approach.
+ *
+ * Header actions (e.g. "All posts →" link) render in a right-aligned
+ * slot inside the marquee. They sit on the same plane as the headline
+ * so screen readers encounter them after the heading text in the natural
+ * tab order — this matches Cloudscape Header's actions slot ordering.
+ */
+function FeedCardShellMarquee({
+	headerText,
+	headerActions,
+}: {
+	headerText: ReactNode;
+	headerActions?: ReactNode;
+}) {
+	return (
+		<div className="feed-card-shell__marquee" role="heading" aria-level={2}>
+			<span className="feed-card-shell__marquee-text">{headerText}</span>
+			{headerActions && (
+				<span className="feed-card-shell__marquee-actions">
+					{headerActions}
+				</span>
+			)}
+		</div>
+	);
+}
+
+interface FeedCardShellInnerProps extends FeedCardShellProps {}
+
+function FeedCardShellInner({
+	headerText,
+	headerActions,
+	palette,
+	className,
+	children,
+}: FeedCardShellInnerProps) {
+	const wrapperClass = ["feed-card-shell", `feed-card-shell--${palette}`]
+		.concat(className ? [className] : [])
+		.join(" ");
+
+	// translate3d(0,0,0) is applied via CSS, but expose the palette as a
+	// data-attribute too so devtools / tests can introspect the palette
+	// without parsing the className string.
+	const wrapperStyle: CSSProperties = {};
+
+	return (
+		<div
+			className={wrapperClass}
+			data-feed-card-palette={palette}
+			style={wrapperStyle}
+		>
+			<Container
+				header={
+					<FeedCardShellMarquee
+						headerText={headerText}
+						headerActions={headerActions}
+					/>
+				}
+			>
+				{children}
+			</Container>
+		</div>
+	);
+}
+
+/**
+ * Error boundary scoped to a single feed card.
+ *
+ * Mirrors the wave 30a FeaturedEventErrorBoundary pattern: a render-time
+ * failure inside the wrapped card content is contained locally so the
+ * rest of the feed page stays mounted. The fallback UI reuses the same
+ * shell chrome (palette, marquee header) so the empty slot still anchors
+ * visually in the same place — only the body swaps to a quiet, accessible
+ * notice.
+ *
+ * Class component (rather than a hook-based boundary) because React still
+ * doesn't expose a hook equivalent to componentDidCatch /
+ * getDerivedStateFromError. The fallback message is passed in as a string
+ * prop because class components cannot use the useTranslation hook
+ * directly — the parent FeedCardShell function component resolves the
+ * locale key and forwards the string.
+ */
+interface FeedCardShellErrorBoundaryProps {
+	headerText: ReactNode;
+	palette: FeedCardShellPalette;
+	fallbackMessage: string;
+	children: ReactNode;
+}
+
+interface FeedCardShellErrorBoundaryState {
+	hasError: boolean;
+}
+
+export class FeedCardShellErrorBoundary extends Component<
+	FeedCardShellErrorBoundaryProps,
+	FeedCardShellErrorBoundaryState
+> {
+	state: FeedCardShellErrorBoundaryState = { hasError: false };
+
+	static getDerivedStateFromError(): FeedCardShellErrorBoundaryState {
+		return { hasError: true };
+	}
+
+	componentDidCatch(error: Error, info: ErrorInfo): void {
+		// Single console.error so the failure is visible in devtools without
+		// piping crash data to a third-party endpoint. The boundary's render
+		// fallback is the user-visible signal; this is the developer signal.
+		// Mirrors FeaturedEventErrorBoundary in featured-event.tsx.
+		console.error("[FeedCardShell] render failure", error, info);
+	}
+
+	render(): ReactNode {
+		if (this.state.hasError) {
+			const { headerText, palette, fallbackMessage } = this.props;
+			return (
+				<div
+					className={`feed-card-shell feed-card-shell--${palette}`}
+					data-feed-card-palette={palette}
+				>
+					<Container header={<FeedCardShellMarquee headerText={headerText} />}>
+						<Box color="text-body-secondary" fontSize="body-s">
+							{fallbackMessage}
+						</Box>
+					</Container>
+				</div>
+			);
+		}
+		return this.props.children;
+	}
+}
+
+/**
+ * Default export — FeedCardShell with the error boundary always wrapped.
+ *
+ * Consumers pass the headerText / palette / children and get back a card
+ * with the wave-36b shared chrome plus the error containment for free.
+ * The boundary fallback message resolves through the rsvp.error.generic
+ * locale key (already present in en-US + es-MX from earlier waves), so
+ * this PR introduces zero new locale keys.
+ */
+export default function FeedCardShell(props: FeedCardShellProps) {
+	const { t } = useTranslation();
+	const fallbackMessage = t("rsvp.error.generic");
+
+	return (
+		<FeedCardShellErrorBoundary
+			headerText={props.headerText}
+			palette={props.palette}
+			fallbackMessage={fallbackMessage}
+		>
+			<FeedCardShellInner {...props} />
+		</FeedCardShellErrorBoundary>
+	);
+}

--- a/src/pages/feed/components/feed-section.tsx
+++ b/src/pages/feed/components/feed-section.tsx
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: MIT-0
 
 import Box from "@cloudscape-design/components/box";
-import Container from "@cloudscape-design/components/container";
-import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useEffect, useId, useRef, useState } from "react";
 import { SkeletonLine, SkeletonTitle } from "../../../components/skeleton";
 import { useTranslation } from "../../../hooks/useTranslation";
+import FeedCardShell from "./feed-card-shell";
 
 export interface FeedPost {
 	title: string;
@@ -183,56 +182,72 @@ function PostCarousel({ posts, ready }: { posts: FeedPost[]; ready: boolean }) {
 	);
 }
 
+// Wave 36b — feed-section variants each pick a FeedCardShell palette via the
+// section-key-to-palette map below. Detection happens internally per variant
+// (no `palette` prop on the public FeedAndmore/FeedAwsml/FeedReadysetcloud
+// components — keeps app.tsx untouched). Mapping rationale:
+//   andmore       → amber  (warm dev/casual — andmore.dev is a personal /
+//                            project blog with a warm voice)
+//   awsml         → teal   (cool / technical — AWS ML blog reads cooler,
+//                            data-heavy)
+//   readysetcloud → navy   (long-form publication — Allen Helton's serious
+//                            serverless blog + newsletter; reuses the navy
+//                            palette already assigned to andres-medium since
+//                            both are bylined long-form tech publications,
+//                            an intentional family pairing)
+// Documented in feed-card-shell.tsx FeedCardShellPalette JSDoc + commit msg.
+
 export function FeedAndmore() {
 	const { t } = useTranslation();
 	const { posts, ready } = useFeed("andmore");
+
+	const headerText = (
+		<>
+			{t("feedPage.andmoreDevHeader")}
+			<span className="feed-card-header-sub">
+				{t("feedPage.andmoreByAndres")}
+			</span>
+		</>
+	);
+	const headerActions = (
+		<Link href="https://andmore.dev" external fontSize="body-s">
+			{t("feedPage.andresMediumAllPosts")}
+		</Link>
+	);
+
 	return (
-		<Container
-			header={
-				<Header
-					variant="h2"
-					actions={
-						<Link href="https://andmore.dev" external fontSize="body-s">
-							{t("feedPage.andresMediumAllPosts")}
-						</Link>
-					}
-				>
-					{t("feedPage.andmoreDevHeader")}
-					<span className="feed-card-header-sub">
-						{t("feedPage.andmoreByAndres")}
-					</span>
-				</Header>
-			}
+		<FeedCardShell
+			headerText={headerText}
+			headerActions={headerActions}
+			palette="amber"
 		>
 			<PostCarousel posts={posts} ready={ready} />
-		</Container>
+		</FeedCardShell>
 	);
 }
 
 export function FeedAwsml() {
 	const { t } = useTranslation();
 	const { posts, ready } = useFeed("awsml");
+
+	const headerActions = (
+		<Link
+			href="https://aws.amazon.com/blogs/machine-learning/"
+			external
+			fontSize="body-s"
+		>
+			{t("feedPage.awsMlBlogAllPosts")}
+		</Link>
+	);
+
 	return (
-		<Container
-			header={
-				<Header
-					variant="h2"
-					actions={
-						<Link
-							href="https://aws.amazon.com/blogs/machine-learning/"
-							external
-							fontSize="body-s"
-						>
-							{t("feedPage.awsMlBlogAllPosts")}
-						</Link>
-					}
-				>
-					{t("feedPage.awsMlBlog")}
-				</Header>
-			}
+		<FeedCardShell
+			headerText={t("feedPage.awsMlBlog")}
+			headerActions={headerActions}
+			palette="teal"
 		>
 			<PostCarousel posts={posts} ready={ready} />
-		</Container>
+		</FeedCardShell>
 	);
 }
 
@@ -250,8 +265,9 @@ export function FeedReadysetcloud() {
 	};
 
 	return (
-		<Container
-			header={<Header variant="h2">{t("feedPage.readysetcloudHeader")}</Header>}
+		<FeedCardShell
+			headerText={t("feedPage.readysetcloudHeader")}
+			palette="navy"
 		>
 			{!ready ? (
 				<>
@@ -320,7 +336,7 @@ export function FeedReadysetcloud() {
 					</SpaceBetween>
 				</SpaceBetween>
 			)}
-		</Container>
+		</FeedCardShell>
 	);
 }
 

--- a/src/pages/feed/components/twitch-section.tsx
+++ b/src/pages/feed/components/twitch-section.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import { SkeletonFrame } from "../../../components/skeleton";
 import { useTranslation } from "../../../hooks/useTranslation";
 import { probeTwitchLive } from "../../../lib/twitch-channel-cache";
+import FeedCardShell from "./feed-card-shell";
 
 // Twitch Embed SDK types (loaded via script tag at runtime)
 interface TwitchEmbed {
@@ -175,7 +176,12 @@ function TwitchChannelCard({
 	if (probeLive === false) return null;
 
 	if (!hostname) {
-		// SSR / pre-hydration — show skeleton until hostname resolves
+		// SSR / pre-hydration — show skeleton until hostname resolves. The
+		// skeleton is intentionally rendered inside a bare Cloudscape Container
+		// (NOT FeedCardShell) so the loading state doesn't paint a marquee
+		// header for a card that may never reveal itself if the channel turns
+		// out to be offline. Once probeLive resolves we either return null
+		// (offline) or fall through to the FeedCardShell below.
 		return (
 			<Container>
 				<SkeletonFrame />
@@ -183,15 +189,20 @@ function TwitchChannelCard({
 		);
 	}
 
+	// Wave 36b — wrap the live embed in FeedCardShell with the violet palette
+	// (twitch brand purple). The marquee header carries the channel label so
+	// the card has a stable name plate even when the embed itself paints. The
+	// inner LIVE indicator stays inside TwitchChannelEmbed; the marquee just
+	// names the channel.
 	return (
-		<Container>
+		<FeedCardShell headerText={channel.label} palette="violet">
 			<TwitchChannelEmbed
 				channelId={channel.id}
 				hostname={hostname}
 				onLiveChange={onLiveChange}
 				onOfflineChange={onOfflineChange}
 			/>
-		</Container>
+		</FeedCardShell>
 	);
 }
 

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -3,6 +3,22 @@
    Uses CDN token system: var(--cdn-space-*), var(--cdn-text-*), etc.
    ========================================================================== */
 
+/* ── Wave 36b — FeedCardShell adoption follow-up ────────────────────────────
+   Wave 36b introduced src/pages/feed/components/feed-card-shell.tsx + .css
+   as a shared depth-stack/marquee-header primitive for the simpler non-event
+   feed cards (arrowhead-news, andres-medium, andres-youtube-live, builder-
+   center, twitch panes, featured-video, andmore/awsml/readysetcloud). The
+   three carousel cards below were intentionally NOT migrated this wave:
+     - youtube-carousel.tsx
+     - youtube-channel-carousel.tsx
+     - youtube-shorts-carousel.tsx
+   Their internal layouts (carousel viewport, frame ratio, custom chevrons,
+   shorts vertical aspect) need separate consideration of how the marquee
+   header reads above embedded video chrome. Picked up in a follow-up wave;
+   shell adoption there is purely cosmetic so deferring does not block the
+   wave 36b "no plain Cloudscape Containers" goal. Matching note lives in
+   feed-card-shell.css for symmetry. */
+
 .feed-carousel {
 	position: relative;
 	width: 100%;


### PR DESCRIPTION
Brings the 7 non-event feed cards on par with the 3 event cards via a shared depth-stack primitive.

## new primitive
- src/pages/feed/components/feed-card-shell.tsx — wraps a Cloudscape Container with a marquee-style header (role=heading aria-level=2), perspective+preserve-3d, GPU compositing hints, scroll-pause integration, error boundary
- 8 palette variants: amber / teal / violet / sage / rose / navy / gold / lavender — light + dark parity for each

## consumed by 7 cards (palette assignments)
- arrowhead-news → sage (research / academic)
- andres-youtube-live → rose (warm presence)
- andres-medium → navy (long-form publication)
- builder-center-card → gold (AWS Builder)
- twitch-section → violet (Twitch brand)
- featured-video-card → lavender (Women in Tech feature)
- feed-section (andmore/awsml/readysetcloud variants) → palette per source

## NOT touched
- featured-event / next-meetup / upcoming-virtual-event keep their bespoke marquee headers from waves 32a/33a/33b
- youtube-carousel / youtube-channel-carousel / youtube-shorts-carousel deferred (specialized internal layout, separate wave)

## gates
- biome 0 / tsc 0 / build PASS / vitest passes