### PR TITLE
chore(biome): wave 38a — pick up 2 safe biome fixes from draft #262, reject the rest

### DIFF
--- a/src/components/speaker-proposal-form/index.tsx
+++ b/src/components/speaker-proposal-form/index.tsx
@@ -1,4 +1,3 @@
-import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import DatePicker from "@cloudscape-design/components/date-picker";

--- a/src/pages/feed/components/__tests__/upcoming-virtual-event.test.tsx
+++ b/src/pages/feed/components/__tests__/upcoming-virtual-event.test.tsx
@@ -152,9 +152,7 @@ describe("UpcomingVirtualEvent", () => {
 			".feed-upcoming-virtual-event__marquee-text",
 		);
 		expect(marqueeText).not.toBeNull();
-		expect(marqueeText?.textContent).toMatch(
-			/Virtual AWS Community Events/i,
-		);
+		expect(marqueeText?.textContent).toMatch(/Virtual AWS Community Events/i);
 	});
 
 	it("wave 33b — marquee renders 14 twinkle stars inside an aria-hidden container, each with a --star-index custom property", () => {


### PR DESCRIPTION
## TL;DR
Picks up 2 of 39 changes from draft PR #262. Rejects the other 37 (153 `!important` removals + a broken non-null-assertion rewrite + 18 .html whitespace tweaks).

## what's IN
- `src/components/speaker-proposal-form/index.tsx` — remove unused Alert import
- `src/pages/feed/components/__tests__/upcoming-virtual-event.test.tsx` — collapse multi-line .toMatch onto single line (this resolves the pre-existing biome format error flagged in wave 37b)

## what's OUT and why

### 153 `!important` removals from CSS files (the bulk of #262)
`.kiro/steering/cloudscape-overrides.md` explicitly mandates `!important` on every Cloudscape override:
> 'cloudscape overrides require !important on every property plus hashed-class substring selectors'

The brand-button, speaker-proposal-cta, and shell layout styles all rely on this pattern to win the cascade against Cloudscape's hashed-class rules. Removing them would silently break visual rendering post-deploy — vitest doesn't catch CSS specificity bugs.

### `result!` → `result?` in projection.test.ts (1 file, 2 lines)
PR #262's --unsafe rewrite produced `result?.projectedDate!` — biome's own `noNonNullAssertedOptionalChain` rule forbids that pattern (`?.` followed by `!` is contradictory). The rewrite would introduce a NEW biome error. Skipping until a proper fix is authored.

### 18 .html files with formatting changes
Skipped for clarity — likely whitespace-only and could land in a follow-up.

## gates
- biome 0 errors / tsc 0 NEW errors / build PASS / vitest passes

## next step
Closing PR #262 with a comment linking to this PR + the cloudscape-overrides.md rationale.