### PR TITLE
feat(feed): wave 38b — next-meetup spacing redesign + LivePulseDot personality detail

### DIFF
--- a/src/pages/feed/components/__tests__/live-pulse-dot.test.tsx
+++ b/src/pages/feed/components/__tests__/live-pulse-dot.test.tsx
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/**
+ * Wave 38b — LivePulseDot regression coverage.
+ *
+ * The wave 38b uplift adds a small inline pulsing-dot SVG before the
+ * next-meetup date-plate as a "next live session" microcue (the
+ * idiosyncratic personality detail mirroring featured-event's
+ * AsciiSmirk after "game"). This test asserts the structural contract
+ * the wave 38b CSS targets:
+ *
+ *   - The wrapper span carries .cdn-live-pulse-dot + aria-hidden="true"
+ *     so the description / date string carries meaning, not the glyph.
+ *   - The inner SVG renders with role="img" + aria-label so AT that
+ *     traverse roles can still discover the indicator's purpose.
+ *   - Two circle elements (halo + core) render — the halo is the
+ *     animated outer ring, the core is the static solid dot.
+ *
+ * jsdom does not apply external CSS to the cascade, so we don't assert
+ * computed-style values for the pulse animation. The animation contract
+ * lives in live-pulse-dot.css and is verified via the prefers-reduced-
+ * motion gate covered in next-meetup.test.tsx (CSS text scan).
+ */
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import LivePulseDot from "../live-pulse-dot";
+
+describe("LivePulseDot — wave 38b inline microcue", () => {
+	it("renders the wrapper span as aria-hidden so the date-plate text carries meaning", () => {
+		const { container } = render(<LivePulseDot />);
+		const span = container.querySelector("span.cdn-live-pulse-dot");
+		expect(span).not.toBeNull();
+		expect(span?.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	it("renders an inline SVG with role=img and aria-label='live indicator'", () => {
+		const { container } = render(<LivePulseDot />);
+		const svg = container.querySelector("svg");
+		expect(svg).not.toBeNull();
+		expect(svg?.getAttribute("role")).toBe("img");
+		expect(svg?.getAttribute("aria-label")).toBe("live indicator");
+	});
+
+	it("contains a halo ring + a solid core (two circle elements)", () => {
+		const { container } = render(<LivePulseDot />);
+		const circles = container.querySelectorAll("circle");
+		expect(circles.length).toBe(2);
+		// halo carries the animated class hook the CSS pulses
+		const halo = container.querySelector("circle.cdn-live-pulse-dot__halo");
+		expect(halo).not.toBeNull();
+		// core is the inner solid dot
+		const core = container.querySelector("circle.cdn-live-pulse-dot__core");
+		expect(core).not.toBeNull();
+	});
+
+	it("includes a title element labelling the SVG 'live indicator' for AT that traverse roles", () => {
+		const { container } = render(<LivePulseDot />);
+		const title = container.querySelector("svg title");
+		expect(title?.textContent).toBe("live indicator");
+	});
+});

--- a/src/pages/feed/components/__tests__/next-meetup.test.tsx
+++ b/src/pages/feed/components/__tests__/next-meetup.test.tsx
@@ -184,3 +184,129 @@ describe("NextMeetup — wave 33a CSS hooks (prefers-reduced-motion + cdn-scroll
 		expect(stylesText).toMatch(/--cdn-nm-marquee-rim: #5eead4/);
 	});
 });
+
+describe("NextMeetup — wave 38b spacing redesign + description personality", () => {
+	// jsdom doesn't apply external CSS to the cascade, so we read the
+	// stylesheet text directly and assert the wave 38b spacing-token
+	// substitutions + the new layout/description rules are wired in.
+	const stylesPath = join(__dirname, "..", "..", "styles.css");
+	const stylesText = readFileSync(stylesPath, "utf8");
+
+	it("replaces the wave 33a raw-px marquee padding with --cdn-space-* tokens at all three breakpoints (mobile 12/16, tablet 12/24, desktop 16/24)", () => {
+		// Mobile — 12 / 16. The mobile rule lives inside the .feed-next-
+		// meetup__marquee block, not inside a media query. Match the
+		// padding line within that block.
+		const mobileBlock = stylesText.match(
+			/\.feed-next-meetup__marquee \{[\s\S]*?padding: var\(--cdn-space-12, 12px\) var\(--cdn-space-md, 16px\);/,
+		);
+		expect(mobileBlock).not.toBeNull();
+
+		// Tablet — 12 / 24
+		const tabletBlock = stylesText.match(
+			/@media \(min-width: 520px\)[\s\S]*?\.feed-next-meetup__marquee \{[\s\S]*?padding: var\(--cdn-space-12, 12px\) var\(--cdn-space-lg, 24px\);/,
+		);
+		expect(tabletBlock).not.toBeNull();
+
+		// Desktop — 16 / 24
+		const desktopBlock = stylesText.match(
+			/@media \(min-width: 860px\)[\s\S]*?\.feed-next-meetup__marquee \{[\s\S]*?padding: var\(--cdn-space-md, 16px\) var\(--cdn-space-lg, 24px\);/,
+		);
+		expect(desktopBlock).not.toBeNull();
+	});
+
+	it("replaces the wave 33a raw-px date-plate padding with --cdn-space-sm / --cdn-space-md tokens", () => {
+		const datePlateBlock = stylesText.match(
+			/\.feed-next-meetup__date-plate \{[\s\S]*?padding: var\(--cdn-space-sm, 8px\) var\(--cdn-space-md, 16px\);/,
+		);
+		expect(datePlateBlock).not.toBeNull();
+	});
+
+	it("removes the wave 33a asymmetric date wrapper margin (4 / 0 / 2) — spacing is now owned by the layout grid hierarchy", () => {
+		expect(stylesText).not.toMatch(
+			/\.feed-next-meetup__date \{[\s\S]*?margin: 4px 0 2px;/,
+		);
+	});
+
+	it("declares the wave 38b __layout flex-column primitive that replaces the loaded-event SpaceBetween wrapper", () => {
+		const layoutBlock = stylesText.match(
+			/\.feed-next-meetup__layout \{[\s\S]*?display: flex;[\s\S]*?flex-direction: column;[\s\S]*?gap: 0;/,
+		);
+		expect(layoutBlock).not.toBeNull();
+	});
+
+	it("encodes the spacing hierarchy ladder via per-element margin-block-end on the wave 38b layout children (title→date 12, date→location 8, location→desc 12)", () => {
+		// title → date : 12px
+		expect(stylesText).toMatch(
+			/\.feed-next-meetup__layout \.feed-next-meetup__title \{[\s\S]*?margin-block-end: var\(--cdn-space-12, 12px\);/,
+		);
+		// date → location : 8px
+		expect(stylesText).toMatch(
+			/\.feed-next-meetup__layout \.feed-next-meetup__date \{[\s\S]*?margin-block-end: var\(--cdn-space-sm, 8px\);/,
+		);
+		// location → description : 12px
+		expect(stylesText).toMatch(
+			/\.feed-next-meetup__location \{[\s\S]*?margin-block-end: var\(--cdn-space-12, 12px\);/,
+		);
+	});
+
+	it("declares the wave 38b description personality rule (line-height 1.65, --cdn-text-base, var(--cdn-color-text), 64ch max-width)", () => {
+		const descriptionBlock = stylesText.match(
+			/\.feed-next-meetup__description \{[\s\S]*?font-size: var\(--cdn-text-base, 0\.875rem\);[\s\S]*?line-height: 1\.65;[\s\S]*?max-width: 64ch;[\s\S]*?color: var\(--cdn-color-text\);/,
+		);
+		expect(descriptionBlock).not.toBeNull();
+	});
+});
+
+describe("NextMeetup — wave 38b LivePulseDot inline microcue integration", () => {
+	// Stub the static-data fetch so the loaded-event branch renders
+	// (and the LivePulseDot gets mounted). Without this, the component
+	// stays in the "loading" state and the layout / dot don't render.
+	function mockSuccessfulFetch() {
+		const futureIso = new Date(
+			Date.now() + 7 * 24 * 60 * 60 * 1000,
+		).toISOString();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					summary: "AWS UG Cloud Del Norte — Test Meetup",
+					dtstart: futureIso,
+					url: "https://www.meetup.com/awsugclouddelnorte/events/test/",
+					location: "Downtown El Paso",
+					description: "Test description for wave 38b layout.",
+				}),
+				text: async () => "",
+			}),
+		);
+	}
+
+	it("renders the LivePulseDot SVG inside the date wrapper as aria-hidden once the loaded-event branch mounts", async () => {
+		mockSuccessfulFetch();
+		const { container, findByRole } = render(
+			<LocaleProvider locale="us">
+				<NextMeetup />
+			</LocaleProvider>,
+		);
+		// Wait for the date-plate to render (signals the loaded branch is up).
+		// findByRole on the heading lets vitest poll until the iCal stub resolves.
+		await findByRole("heading", { level: 2 });
+		// Poll for the date wrapper since the static-fetch effect is async.
+		// The LivePulseDot renders inside .feed-next-meetup__date.
+		const start = Date.now();
+		let dot: Element | null = null;
+		while (Date.now() - start < 1500) {
+			dot = container.querySelector(
+				".feed-next-meetup__date .cdn-live-pulse-dot",
+			);
+			if (dot) break;
+			await new Promise((r) => setTimeout(r, 25));
+		}
+		expect(dot).not.toBeNull();
+		expect(dot?.getAttribute("aria-hidden")).toBe("true");
+		// Two circles inside the dot's SVG (halo + core).
+		const circles = dot?.querySelectorAll("circle");
+		expect(circles?.length).toBe(2);
+		vi.unstubAllGlobals();
+	});
+});

--- a/src/pages/feed/components/live-pulse-dot.css
+++ b/src/pages/feed/components/live-pulse-dot.css
@@ -1,0 +1,82 @@
+/* --------------------------------------------------------------------------
+   LivePulseDot — inline pulsing dot SVG.
+
+   Wave 38b — inline microcue rendered before the next-meetup date-plate.
+   Steel-blue/teal palette (light: #2c5282; dark: #5eead4) layered into
+   currentColor by the parent .feed-next-meetup__live-dot rule so this
+   file stays palette-neutral and the card scope owns the hue.
+
+   Sits inline like an emoji: vertical-align:middle so the 16x16 box hugs
+   the date-plate baseline. The wrapper span carries the inline-flex
+   alignment + a small right margin so the glyph + date string read as a
+   single horizontal cluster.
+
+   Animations:
+     - default loop (2s): outer halo ring pulses opacity 0.4 → 0.85 →
+       0.4 + scales 1 → 1.25 → 1, then settles. Reads as a "live now"
+       indicator beat — slower than a heart-rate pulse so the eye
+       registers it without strobing. The inner core stays solid.
+     - prefers-reduced-motion: animation off; static halo still reads
+       as a soft ring + solid core (no information lost).
+
+   Padding/margin token policy: --cdn-space-xs (4px) for the right margin
+   so the glyph sits on the 8pt grid alongside the date-plate's --cdn-
+   space-sm/--cdn-space-md padding. No backplate (unlike AsciiSmirk's
+   cream-rect background) — the dot is meant to read as a free-floating
+   indicator, not a chiclet.
+   -------------------------------------------------------------------------- */
+
+.cdn-live-pulse-dot {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	vertical-align: middle;
+	margin-inline-end: var(--cdn-space-xs, 4px);
+	line-height: 1;
+}
+
+.cdn-live-pulse-dot__svg {
+	display: block;
+	overflow: visible;
+}
+
+.cdn-live-pulse-dot__halo {
+	transform-origin: 8px 8px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes cdn-live-pulse-dot-halo {
+		0%,
+		100% {
+			opacity: 0.4;
+			transform: scale(1);
+		}
+		50% {
+			opacity: 0.85;
+			transform: scale(1.25);
+		}
+	}
+
+	.cdn-live-pulse-dot__halo {
+		animation: cdn-live-pulse-dot-halo 2s ease-in-out infinite;
+	}
+}
+
+/* Reduced-motion fallback — strip animation, keep the static halo +
+   core so the indicator still reads as a soft "live" ring. */
+@media (prefers-reduced-motion: reduce) {
+	.cdn-live-pulse-dot__halo {
+		animation: none;
+		opacity: 0.55;
+		transform: none;
+	}
+}
+
+/* Pause during fast scroll — same scroll-jank-mitigation hook the rest
+   of the next-meetup card uses. Skipped under reduced-motion since the
+   animation isn't running there to begin with. */
+@media (prefers-reduced-motion: no-preference) {
+	body.cdn-scrolling .cdn-live-pulse-dot__halo {
+		animation-play-state: paused;
+	}
+}

--- a/src/pages/feed/components/live-pulse-dot.tsx
+++ b/src/pages/feed/components/live-pulse-dot.tsx
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import "./live-pulse-dot.css";
+
+/**
+ * LivePulseDot — inline animated pulsing dot SVG.
+ *
+ * Wave 38b — sits inline before the meetup date-plate as a "next live
+ * session" microcue. The dot itself is a solid steel-blue/teal disc
+ * (currentColor), wrapped in a soft outer ring that breathes on a 2s loop
+ * — the small idiosyncratic detail that gives the next-meetup card a bit
+ * of character without competing with the marquee shimmer or the date-
+ * plate diagonal-sweep VFX. Adjacent in spirit to featured-event's inline
+ * AsciiSmirk after "game" — a tiny, quiet glyph that lives inside the
+ * card body and rewards close inspection.
+ *
+ * Adopts the cooler steel-blue / teal palette via the parent type token
+ * (color: var(--cdn-nm-live-dot) on light, lighter teal on dark) and a
+ * matching outer-ring halo. Sized ~16px tall so it hugs the baseline
+ * like an emoji and pairs visually with the date-plate text it sits
+ * beside.
+ *
+ * Animations (CSS): the outer ring pulses opacity + scale on a 2s loop
+ * (live-indicator vibe). The inner core stays solid. Reduced-motion
+ * strips the animation; the static halo still reads as a soft ring.
+ *
+ * Accessibility: the wrapping span is aria-hidden — the date string
+ * itself carries the meaning. The inner SVG uses role="img" + a title
+ * element so AT that traverse roles can still discover the glyph as
+ * a "live indicator".
+ */
+export default function LivePulseDot() {
+	return (
+		<span className="cdn-live-pulse-dot" aria-hidden="true">
+			<svg
+				className="cdn-live-pulse-dot__svg"
+				viewBox="0 0 16 16"
+				width="16"
+				height="16"
+				role="img"
+				aria-label="live indicator"
+				focusable="false"
+			>
+				<title>live indicator</title>
+				{/* outer halo ring — opacity + scale pulse on 2s loop */}
+				<circle
+					className="cdn-live-pulse-dot__halo"
+					cx="8"
+					cy="8"
+					r="7"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="1"
+					opacity="0.45"
+				/>
+				{/* inner core — solid disc */}
+				<circle
+					className="cdn-live-pulse-dot__core"
+					cx="8"
+					cy="8"
+					r="3"
+					fill="currentColor"
+				/>
+			</svg>
+		</span>
+	);
+}

--- a/src/pages/feed/components/next-meetup.tsx
+++ b/src/pages/feed/components/next-meetup.tsx
@@ -56,6 +56,7 @@ import {
 } from "react";
 import { SkeletonLine, SkeletonTitle } from "../../../components/skeleton";
 import { useTranslation } from "../../../hooks/useTranslation";
+import LivePulseDot from "./live-pulse-dot";
 
 const MEETUP_GROUP = "awsugclouddelnorte";
 const MEETUP_ICAL = `https://www.meetup.com/${MEETUP_GROUP}/events/ical/`;
@@ -335,10 +336,26 @@ function NextMeetupInner() {
 			);
 		}
 	} else {
+		// Wave 38b — loaded-event branch is rebuilt as a flex column layout
+		// with per-element margin-block-end so the spacing hierarchy mirrors
+		// the wave 37c featured-event treatment:
+		//   past-label → title    : --cdn-space-sm  (8px)  small cluster step
+		//   title     → date     : --cdn-space-12  (12px) hero hierarchy
+		//   date      → location : --cdn-space-sm  (8px)  meta cluster
+		//   location  → desc     : --cdn-space-12  (12px) close prose to context
+		// SpaceBetween size="s" (the wave 33a primitive) gave a uniform 12px
+		// gap which read as flat — the wave 37c hierarchy is what gives the
+		// cluster a deliberate ladder. The loading + en-US fallback + es-MX
+		// past-meetup-spotlight branches keep their SpaceBetween primitives
+		// — those are simpler stacks where uniform 12px reads correctly.
 		content = (
-			<SpaceBetween size="s">
+			<div className="feed-next-meetup__layout">
 				{event.isPast && (
-					<Box color="text-status-inactive" fontSize="body-s">
+					<Box
+						color="text-status-inactive"
+						fontSize="body-s"
+						className="feed-next-meetup__past-label"
+					>
 						{t("feedPage.nextMeetupPastLabel")}
 					</Box>
 				)}
@@ -355,28 +372,49 @@ function NextMeetupInner() {
 						event.summary
 					)}
 				</Box>
-				{/* Wave 33a — date-plate VFX. Date string itself is plain HTML
-				    output from Intl.DateTimeFormat (no SVG, no canvas, no string
-				    splitting). The wrapper div carries the layout margin; the
-				    inner span is the steel-blue / deep-teal backplate with a
-				    soft pulsing text-shadow glow + diagonal sweep shimmer. */}
+				{/* Wave 33a — date-plate VFX + wave 38b — inline LivePulseDot
+				    microcue. Date string itself is plain HTML output from
+				    Intl.DateTimeFormat (no SVG, no canvas, no string
+				    splitting). The wrapper div carries the layout margin;
+				    the LivePulseDot sits inline before the plate as a
+				    "next live session" indicator; the plate span is the
+				    steel-blue / deep-teal backplate with the breathe + sweep
+				    VFX defined in styles.css. */}
 				<div className="feed-next-meetup__date">
+					<LivePulseDot />
 					<span className="feed-next-meetup__date-plate">
 						{formatDate(event.dtstart)}
 					</span>
 				</div>
 				{event.location && (
-					<Box color="text-body-secondary" fontSize="body-s">
+					<Box
+						color="text-body-secondary"
+						fontSize="body-s"
+						className="feed-next-meetup__location"
+					>
 						{event.location}
 					</Box>
 				)}
+				{/* Wave 38b — description copy gets the wave 37c personality
+				    uplift: color="inherit" (was "text-body-secondary" muted
+				    gray) so the .feed-next-meetup__description CSS rule —
+				    which sets color: var(--cdn-color-text) — actually
+				    paints. fontSize="body-m" (was body-s) bumps the inherited
+				    text size onto the --cdn-text-base tier; the same CSS
+				    rule layers an explicit var(--cdn-text-base) font-size +
+				    line-height: 1.65 + 64ch max-width on top so the prose
+				    reads as deliberate voice rather than fine-print metadata. */}
 				{event.description && (
-					<Box color="text-body-secondary" fontSize="body-s">
+					<Box
+						color="inherit"
+						fontSize="body-m"
+						className="feed-next-meetup__description"
+					>
 						{event.description}
 						{event.description.length >= MAX_DESCRIPTION_CHARS ? "…" : ""}
 					</Box>
 				)}
-			</SpaceBetween>
+			</div>
 		);
 	}
 

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -3313,7 +3313,12 @@
 	align-items: center;
 	justify-content: center;
 	min-height: 40px;
-	padding: 8px 28px;
+	/* wave 38b — tokenize raw 8px / 28px padding onto the 8pt grid.
+	   Mobile: --cdn-space-12 (12px) vertical, --cdn-space-md (16px)
+	   horizontal. Mirrors the wave 37c featured-event marquee. The
+	   original 8/28 was off-grid (28px is not a multiple of 8) and
+	   the 8px vertical was tight against the 40px min-height. */
+	padding: var(--cdn-space-12, 12px) var(--cdn-space-md, 16px);
 	border-radius: 10px;
 	overflow: hidden;
 	background: linear-gradient(
@@ -3507,16 +3512,27 @@
    div carries the layout margin; the inner span is the backplate.
    prefers-reduced-motion: no-preference gates the breathe + shimmer. */
 .feed-next-meetup__date {
-	display: block;
-	margin: 4px 0 2px;
+	display: flex;
+	align-items: center;
+	/* wave 38b — drop the legacy asymmetric 4px / 0 / 2px margin (off-grid
+	   2px). Inter-element spacing is now owned by the
+	   .feed-next-meetup__layout flex-column per-element margin-block-end
+	   tokens (date → location = --cdn-space-sm = 8px). Switching to
+	   display:flex aligns the wave 38b inline LivePulseDot microcue with
+	   the date-plate baseline as a single horizontal cluster. */
+	margin: 0;
 	font-variant-numeric: tabular-nums;
 }
 
 .feed-next-meetup__date-plate {
 	position: relative;
 	display: inline-block;
-	padding: 6px 14px;
-	border-radius: 8px;
+	/* wave 38b — round padding from raw 6px / 14px to the 8pt grid:
+	   --cdn-space-sm (8px) vertical, --cdn-space-md (16px) horizontal.
+	   Mirrors the wave 37c featured-event date-plate. Border-radius
+	   pinned to --cdn-radius-md (8px) token. */
+	padding: var(--cdn-space-sm, 8px) var(--cdn-space-md, 16px);
+	border-radius: var(--cdn-radius-md, 8px);
 	background: linear-gradient(
 		135deg,
 		var(--cdn-nm-date-plate-from) 0%,
@@ -3709,7 +3725,11 @@
 @media (min-width: 520px) {
 	.feed-next-meetup__marquee {
 		min-height: 44px;
-		padding: 10px 36px;
+		/* wave 38b — tokenize raw 10px / 36px → 12px / 24px (--cdn-space-12 /
+		   --cdn-space-lg). Mirrors the wave 37c featured-event tablet
+		   marquee padding. 36px was off-grid; 24px falls on the canonical
+		   8pt scale and matches Cloudscape SpaceBetween size="l". */
+		padding: var(--cdn-space-12, 12px) var(--cdn-space-lg, 24px);
 	}
 
 	.feed-next-meetup__marquee-text {
@@ -3721,13 +3741,154 @@
 @media (min-width: 860px) {
 	.feed-next-meetup__marquee {
 		min-height: 48px;
-		padding: 12px 44px;
+		/* wave 38b — tokenize raw 12px / 44px → 16px / 24px (--cdn-space-md /
+		   --cdn-space-lg). Mirrors the wave 37c featured-event desktop
+		   marquee padding. 44px was off-grid; the new 16/24 pair gives
+		   the sign desktop-class breathing room while keeping the box
+		   rhythm on the 8pt scale. */
+		padding: var(--cdn-space-md, 16px) var(--cdn-space-lg, 24px);
 	}
 
 	.feed-next-meetup__marquee-text {
 		font-size: 1.125rem;
 		letter-spacing: 0.08em;
 	}
+}
+
+/* ==========================================================================
+   Wave 38b — Next meetup layout grid + spacing hierarchy + description
+   personality + LivePulseDot inline microcue
+   ==========================================================================
+
+   Brings the wave 33a next meetup card up to the wave 37c spacing baseline
+   the featured-event card got. Bryan's framing: "all the upcoming meetup
+   cards are pretty amateur looking & lacking our signature styling — keep
+   critiquing & improving them".
+
+   AUDIT (what was hackey on this card before this wave):
+     - Marquee padding mobile / tablet / desktop = 8/28, 10/36, 12/44 →
+       all off the 8pt grid (28, 36, 44 are not multiples of 8; the
+       vertical 8/10/12 mixed half-grid + on-grid).
+     - Date plate padding 6px 14px → both values off-grid (6 + 14 are
+       not multiples of 4; featured-event uses 8/16 token-tier).
+     - Date wrapper margin: 4 / 0 / 2 → asymmetric, the 2px lower
+       margin was off the 4-unit grid entirely.
+     - The loaded-event branch wrapped its content in
+       <SpaceBetween size="s"> which forced a uniform 12px gap between
+       every pair of children — no spacing hierarchy, the title and
+       date string read at the same beat as the location and
+       description. Wave 37c on featured-event had moved past flat
+       gap onto a per-element margin-block-end ladder so the cluster
+       reads as "headline → time → fine-print metadata → prose".
+
+   TOKEN-BASED HIERARCHY (mirrors wave 37c featured-event):
+     past-label → title    : --cdn-space-sm  (8px)  small cluster step
+     title     → date     : --cdn-space-12  (12px) hero hierarchy
+     date      → location : --cdn-space-sm  (8px)  meta cluster
+     location  → desc     : --cdn-space-12  (12px) close prose to context
+     description (last)   : 0 (no margin-block-end on the final item)
+
+   Smaller gaps cluster related metadata; the larger 12px steps mark
+   semantic boundaries (headline beat, prose beat). The next-meetup card
+   does not have an in-card CTA in the loaded-event branch (the title
+   itself is the click target via the external Meetup link), so the
+   wave 37c "spots → buttons = 24px primary-action breathing room" step
+   does not apply here. The en-US fallback branch keeps its
+   <SpaceBetween size="s"> primitive — it's a simple 2-element stack
+   (CTA copy + button) where uniform 12px reads correctly. Same for the
+   es-MX past-meetup spotlight: SpaceBetween size="s" gives a flat 12px
+   that reads as evenly-pitched paragraphs.
+
+   DESCRIPTION PERSONALITY:
+     The optional event.description Box (wave 33a rendered it as a
+     muted text-body-secondary body-s line) is promoted to color="inherit"
+     + fontSize="body-m" in the JSX, paired with the .feed-next-meetup__
+     description CSS rule below — explicit --cdn-text-base font-size +
+     line-height: 1.65 + 64ch max-width + var(--cdn-color-text). Mirrors
+     the wave 37c featured-event description treatment so the meetup
+     copy reads as deliberate voice rather than fine-print metadata.
+
+   LIVEPULSEDOT MICROCUE:
+     A small inline pulsing-dot SVG component (~16px, aria-hidden,
+     prefers-reduced-motion gated) sits before the date-plate as a "next
+     live session" indicator. Owns its own component file
+     (live-pulse-dot.tsx + live-pulse-dot.css) and inherits the steel-
+     blue / teal palette via the .feed-next-meetup__date currentColor
+     rule below. Adjacent in spirit to featured-event's inline AsciiSmirk
+     after "game" — a tiny idiosyncratic glyph that gives the card a
+     quiet bit of character. */
+
+/* Layout primitive — flex column with per-element margin-block-end.
+   Replaces the wave 33a SpaceBetween size="s" wrapper on the loaded-
+   event branch. min-width: 0 lets the column shrink inside its
+   Cloudscape Container parent without long event titles forcing the
+   track wider than the card (mirrors the .feed-featured-event__layout
+   pattern). */
+.feed-next-meetup__layout {
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+	min-width: 0;
+}
+
+.feed-next-meetup__past-label {
+	/* past-label → title : 8px (small cluster step). Keeps the past-
+	   event indicator visually attached to the title it modifies. */
+	margin-block-end: var(--cdn-space-sm, 8px);
+}
+
+/* wave 38b — title → date : 12px (hero hierarchy step). The wave 33a
+   .feed-next-meetup__title rule above carries the steel-blue / cyan
+   gradient + scrolling-tape animation; this rule only adds the
+   margin-block-end so the spacing hierarchy is explicit at the call
+   site. Compound selector (.feed-next-meetup__layout descendant) so
+   the rule does not affect the title in the fallback / past-meetup
+   branches that still use SpaceBetween. */
+.feed-next-meetup__layout .feed-next-meetup__title {
+	margin-block-end: var(--cdn-space-12, 12px);
+}
+
+/* wave 38b — date → location : 8px (meta cluster step). Same scope-
+   to-layout pattern as the title rule. */
+.feed-next-meetup__layout .feed-next-meetup__date {
+	margin-block-end: var(--cdn-space-sm, 8px);
+	/* Steel-blue currentColor for the inline LivePulseDot; the dot
+	   inherits this hue so its halo + core paint in-palette without
+	   the component file owning brand tokens. Dark-mode override
+	   below shifts to the lighter teal --cdn-nm-title-mid. */
+	color: var(--cdn-nm-title-mid, #2c5282);
+}
+
+.awsui-dark-mode .feed-next-meetup__layout .feed-next-meetup__date {
+	color: var(--cdn-nm-title-mid, #99f6e4);
+}
+
+.feed-next-meetup__location {
+	/* location → description : 12px (semantic boundary step). */
+	margin-block-end: var(--cdn-space-12, 12px);
+}
+
+/* Wave 38b — description personality uplift. Mirrors the wave 37c
+   .feed-featured-event__description treatment so both event cards read
+   with the same prose voice.
+     line-height 1.65         — open vertical rhythm for body prose
+     font-size --cdn-text-base — explicit token (14px); replaces the
+                                 inherited body-s metadata-tier value
+     color    var(--cdn-color-text) — high-contrast text token; pairs
+                                 with the JSX color="inherit" prop so
+                                 Cloudscape's secondary-color override
+                                 doesn't paint over the deliberate token
+     letter-spacing 0.005em   — subtle, matches featured-event
+     max-width 64ch            — comfortable reading measure for prose
+   The description Box is the last item in the layout, so no margin-
+   block-end is needed (the card body's own bottom padding handles the
+   tail spacing). */
+.feed-next-meetup__description {
+	font-size: var(--cdn-text-base, 0.875rem);
+	line-height: 1.65;
+	max-width: 64ch;
+	letter-spacing: 0.005em;
+	color: var(--cdn-color-text);
 }
 
 /* ==========================================================================


### PR DESCRIPTION
Applies wave 37c's 8pt token spacing + body-m description treatment to the next-meetup card. Bryan: 'all the upcoming meetup cards are pretty amateur looking & lacking our signature styling'.

## audit findings
- Marquee padding off-grid (8/28, 10/36, 12/44 — not multiples of 8)
- Date plate 6/14, date wrapper margin 4/0/2 — asymmetric, off-grid
- Description rendered as text-body-secondary + body-s — muted fine-print, not deliberate prose

## redesign
- Tokenized every raw px (marquee 12/16, 12/24, 16/24; date plate 8/16; date wrapper margin 0)
- Replaced uniform SpaceBetween size=s with .feed-next-meetup__layout flex-column + per-element margin-block-end ladder: past-label→title 8, title→date 12, date→location 8, location→desc 12
- Description: color=inherit + body-m + var(--cdn-color-text) + line-height 1.65 + 64ch max-width

## signature personality detail — LivePulseDot
Inline ~16px pulsing-dot SVG before the date-plate as a 'next live session' microcue. Mirrors featured-event's AsciiSmirk pattern (sibling component + CSS, aria-hidden, role=img + title, prefers-reduced-motion gated, body.cdn-scrolling fast-scroll pause). Steel-blue currentColor inherits parent palette.

## gates
- biome 0 errors / tsc 0 NEW errors / build PASS / 730 tests pass