### PR TITLE
feat(feed): wave 38c — upcoming-virtual-event spacing redesign + GlobalGlobe personality detail

### DIFF
--- a/src/pages/feed/components/__tests__/upcoming-virtual-event.test.tsx
+++ b/src/pages/feed/components/__tests__/upcoming-virtual-event.test.tsx
@@ -194,6 +194,62 @@ describe("UpcomingVirtualEvent", () => {
 			"https://www.meetup.com/awsglobalcommunitygatherings/events/314332142/",
 		);
 	});
+
+	// ---------- Wave 38c — signature personality detail (GlobalGlobe) ----------
+
+	it("wave 38c — renders the inline GlobalGlobe SVG inside the description, anchored after the word 'global', as an aria-hidden decorative glyph", () => {
+		const { container } = renderWithLocale("us");
+		const description = container.querySelector(
+			".feed-upcoming-virtual-event__description",
+		);
+		expect(description).not.toBeNull();
+		// The wave 38c renderDescription helper splits on "global" and
+		// inserts the GlobalGlobe inside a __description-inner span so
+		// the parent Cloudscape Box receives a single child.
+		const inner = description?.querySelector(
+			".feed-upcoming-virtual-event__description-inner",
+		);
+		expect(inner).not.toBeNull();
+		const globe = inner?.querySelector(".cdn-global-globe");
+		expect(globe).not.toBeNull();
+		// Decorative — aria-hidden so screen readers skip it; the inline
+		// SVG carries an aria-label="globe" via its <title> for ATs that
+		// surface SVG titles even on aria-hidden ancestors (defense in
+		// depth, mirrors the wave 27a featured-event AsciiSmirk pattern).
+		expect(globe?.getAttribute("aria-hidden")).toBe("true");
+		const svg = globe?.querySelector("svg");
+		expect(svg).not.toBeNull();
+		expect(svg?.getAttribute("aria-label")).toBe("globe");
+		// Description prose still reads coherently when the glyph is
+		// stripped — the head text ends with the anchor "global" and the
+		// tail picks up the rest of the en-US sentence. The SVG <title>
+		// element ("globe") serializes into textContent as a contiguous
+		// "globalglobe" splice, so the test asserts on the leading "A
+		// global" + the trailing " virtual gathering" segments rather
+		// than a strict regex over the raw textContent.
+		const text = inner?.textContent ?? "";
+		expect(text).toMatch(/^A global/);
+		expect(text).toMatch(/virtual gathering hosted by the AWS community/);
+	});
+
+	it("wave 38c — GlobalGlobe also renders in es-MX since the anchor word 'global' appears in both locales", () => {
+		const { container } = renderWithLocale("mx");
+		const description = container.querySelector(
+			".feed-upcoming-virtual-event__description",
+		);
+		expect(description).not.toBeNull();
+		const inner = description?.querySelector(
+			".feed-upcoming-virtual-event__description-inner",
+		);
+		// es-MX description: "Una reunión virtual global organizada por la
+		// comunidad AWS..." — the anchor "global" is the 4th word, so the
+		// helper still splices the GlobalGlobe in for Spanish-language
+		// readers (the icon is locale-neutral; the anchor word happens to
+		// transliterate identically).
+		expect(inner).not.toBeNull();
+		const globe = inner?.querySelector(".cdn-global-globe");
+		expect(globe).not.toBeNull();
+	});
 });
 
 // ---------- Wave 33b — error boundary fallback ----------

--- a/src/pages/feed/components/global-globe.css
+++ b/src/pages/feed/components/global-globe.css
@@ -1,0 +1,130 @@
+/* --------------------------------------------------------------------------
+   Wave 38c — GlobalGlobe — inline pulsing globe SVG.
+
+   Sits inline next to the word "global" in the upcoming-virtual-event
+   description. ~16px tall, vertical-align: middle so it hugs the text
+   baseline like an emoji. Stroke + fill use currentColor so the parent
+   type token carries the brand-correct hue (deep cdn-purple on light,
+   lavender on dark — scoped under .feed-upcoming-virtual-event*). A
+   small backplate (cream on light / indigo on dark) sits behind the
+   glyph for legibility, mirroring the AsciiSmirk treatment.
+
+   Animations:
+     - outer halo (5.2s loop): subtle opacity + scale breathe — evokes a
+       slow planetary glow that times with the card's other 4–9s loops
+       without lock-stepping any of them
+     - meridian (24s loop): full 360° rotation around the planet center —
+       slow enough that the eye reads it as ambient rotation rather than
+       motion focus, but fast enough that it's discoverable on dwell
+     - prefers-reduced-motion: ALL animations off; static glyph still
+       reads as a globe (planet body + latitudes + meridian + halo all
+       paint at full opacity)
+   -------------------------------------------------------------------------- */
+
+.cdn-global-globe {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	vertical-align: middle;
+	margin: 0 var(--cdn-space-xs, 4px);
+	padding: 0 var(--cdn-space-xs, 4px);
+	border-radius: 6px;
+	background: rgba(255, 250, 235, 0.55);
+	box-shadow:
+		inset 0 0 0 1px rgba(90, 31, 138, 0.18),
+		0 1px 2px rgba(48, 0, 106, 0.08);
+	color: var(--cdn-purple, #5a1f8a);
+	line-height: 1;
+}
+
+.awsui-dark-mode .cdn-global-globe {
+	background: rgba(48, 0, 106, 0.55);
+	box-shadow:
+		inset 0 0 0 1px rgba(199, 184, 232, 0.22),
+		0 1px 2px rgba(0, 0, 0, 0.4);
+	color: var(--cdn-lavender, #d7c7ee);
+}
+
+.cdn-global-globe__svg {
+	display: block;
+	overflow: visible;
+}
+
+/* transform-origins so the breathe + spin animate around their geometric
+   center. The meridian rotates around the planet center (12, 12). */
+.cdn-global-globe__halo {
+	transform-origin: 12px 12px;
+}
+
+.cdn-global-globe__meridian {
+	transform-origin: 12px 12px;
+}
+
+/* ---------- Animations — only when motion is permitted ---------- */
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes cdn-global-globe-halo-breathe {
+		0%,
+		100% {
+			opacity: 0.35;
+			transform: scale(1);
+		}
+		50% {
+			opacity: 0.7;
+			transform: scale(1.08);
+		}
+	}
+
+	@keyframes cdn-global-globe-meridian-spin {
+		from {
+			transform: rotateY(0deg);
+		}
+		to {
+			transform: rotateY(360deg);
+		}
+	}
+
+	.cdn-global-globe__halo {
+		animation: cdn-global-globe-halo-breathe 5.2s ease-in-out infinite;
+	}
+
+	/* Meridian spin uses scaleX as a 2D fake-3D — animating the rx via
+	   transform: scaleX makes the ellipse appear to flatten and re-widen,
+	   reading as a globe meridian rotating around its vertical axis. The
+	   24s loop is slow enough to be ambient (not motion focus) but fast
+	   enough that a curious user catches the rotation on dwell. */
+	@keyframes cdn-global-globe-meridian-rotate {
+		0%,
+		100% {
+			transform: scaleX(1);
+		}
+		25% {
+			transform: scaleX(0);
+		}
+		50% {
+			transform: scaleX(1);
+		}
+		75% {
+			transform: scaleX(0);
+		}
+	}
+
+	.cdn-global-globe__meridian {
+		animation: cdn-global-globe-meridian-rotate 12s ease-in-out infinite;
+	}
+}
+
+/* ---------- Reduced-motion fallback — strip animation, keep static glyph ---------- */
+@media (prefers-reduced-motion: reduce) {
+	.cdn-global-globe__halo,
+	.cdn-global-globe__meridian {
+		animation: none;
+	}
+}
+
+/* ---------- Pause animations during fast scroll ---------- */
+@media (prefers-reduced-motion: no-preference) {
+	body.cdn-scrolling .cdn-global-globe__halo,
+	body.cdn-scrolling .cdn-global-globe__meridian {
+		animation-play-state: paused;
+	}
+}

--- a/src/pages/feed/components/global-globe.tsx
+++ b/src/pages/feed/components/global-globe.tsx
@@ -1,0 +1,110 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import "./global-globe.css";
+
+/**
+ * Wave 38c — GlobalGlobe — inline pulsing globe SVG.
+ *
+ * The upcoming-virtual-event card's signature personality detail (in-family
+ * with featured-event's AsciiSmirk). Sits inline next to the word "global"
+ * in the card description as a visual punctuation that ties the word to the
+ * AWS Global Community Gatherings international/virtual mood — a small
+ * cosmic globe with a soft violet/lavender breathing pulse and a slow rim
+ * rotation that evokes a planet still spinning while builders dial in from
+ * every time zone.
+ *
+ * Visual: ~16px tall (vertical-align: middle so it hugs the text baseline
+ * like emoji); a circular planet body with two latitude curves + one
+ * meridian curve drawn as light strokes; a soft outer halo ring that
+ * breathes; the meridian rotates slowly under prefers-reduced-motion: no-
+ * preference. currentColor is used for stroke + fill so the parent type
+ * token carries the brand-correct hue (deep cdn-purple on light, lavender
+ * on dark — scoped under .feed-upcoming-virtual-event*).
+ *
+ * Accessibility: aria-hidden + aria-label="globe" — decorative, the
+ * description text carries meaning. All animations are gated behind
+ * prefers-reduced-motion: no-preference; under reduce the static glyph
+ * still reads as a globe.
+ */
+export default function GlobalGlobe() {
+	return (
+		<span className="cdn-global-globe" aria-hidden="true">
+			<svg
+				className="cdn-global-globe__svg"
+				viewBox="0 0 24 24"
+				width="16"
+				height="16"
+				role="img"
+				aria-label="globe"
+				focusable="false"
+			>
+				<title>globe</title>
+				{/* outer halo ring — breathes opacity + scale (CSS keyframes) */}
+				<circle
+					className="cdn-global-globe__halo"
+					cx="12"
+					cy="12"
+					r="11"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="0.6"
+					opacity="0.45"
+				/>
+				{/* planet body — solid disc filled with currentColor at low opacity
+				    so the latitude/meridian strokes still read on top */}
+				<circle
+					className="cdn-global-globe__body"
+					cx="12"
+					cy="12"
+					r="8"
+					fill="currentColor"
+					fillOpacity="0.16"
+					stroke="currentColor"
+					strokeWidth="1"
+				/>
+				{/* equator — straight horizontal line through the disc center */}
+				<line
+					className="cdn-global-globe__equator"
+					x1="4"
+					y1="12"
+					x2="20"
+					y2="12"
+					stroke="currentColor"
+					strokeWidth="0.8"
+					opacity="0.7"
+				/>
+				{/* upper latitude — shallow arc above the equator */}
+				<path
+					className="cdn-global-globe__lat-upper"
+					d="M 5 9 Q 12 7 19 9"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="0.7"
+					opacity="0.55"
+				/>
+				{/* lower latitude — mirror arc below the equator */}
+				<path
+					className="cdn-global-globe__lat-lower"
+					d="M 5 15 Q 12 17 19 15"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="0.7"
+					opacity="0.55"
+				/>
+				{/* meridian — vertical ellipse-arc that rotates around the planet */}
+				<ellipse
+					className="cdn-global-globe__meridian"
+					cx="12"
+					cy="12"
+					rx="3"
+					ry="8"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="0.8"
+					opacity="0.7"
+				/>
+			</svg>
+		</span>
+	);
+}

--- a/src/pages/feed/components/upcoming-virtual-event.tsx
+++ b/src/pages/feed/components/upcoming-virtual-event.tsx
@@ -5,7 +5,6 @@ import Box from "@cloudscape-design/components/box";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
-import SpaceBetween from "@cloudscape-design/components/space-between";
 import {
 	Component,
 	type CSSProperties,
@@ -17,12 +16,22 @@ import {
 import MeetupRsvpButton from "../../../components/brand-button/meetup-rsvp";
 import { useTranslation } from "../../../hooks/useTranslation";
 import EventBulbsOverlay from "./event-bulbs-overlay";
+import GlobalGlobe from "./global-globe";
 
 const RSVP_URL =
 	"https://www.meetup.com/awsglobalcommunitygatherings/events/314332142/";
 const EVENT_IMAGE_LIGHT = "/events/global-community-gatherings-light.webp";
 const EVENT_IMAGE_DARK = "/events/global-community-gatherings-dark.webp";
 const EVENT_DATE = "2026-05-22T22:00:00+09:00";
+/**
+ * Wave 38c — anchor inside the description string after which the inline
+ * GlobalGlobe SVG renders. "global" sits in the second word of the en-US
+ * + es-MX strings; placing the glyph immediately after it ties the icon
+ * to the word it qualifies (analogous to wave 27a featured-event smirk
+ * after "game"). If the anchor is absent (defensive fallback for any
+ * future copy revision that drops it), the description renders raw.
+ */
+const GLOBE_ANCHOR = "global";
 
 /**
  * Wave 33b — twinkle-star count rendered behind the marquee headline.
@@ -127,6 +136,28 @@ function MarqueeHeader({ text }: { text: string }) {
 	);
 }
 
+/**
+ * Wave 38c — render the description splicing the GlobalGlobe SVG in
+ * after the GLOBE_ANCHOR ("global") substring. Returns a single span
+ * wrapper so the parent Cloudscape Box receives one child (avoids
+ * React.Children "missing key" array iteration warnings). If the
+ * anchor is absent in the localized string (defensive), the raw text
+ * renders unchanged.
+ */
+function renderDescription(text: string): ReactNode {
+	const idx = text.indexOf(GLOBE_ANCHOR);
+	if (idx < 0) return text;
+	const head = text.slice(0, idx + GLOBE_ANCHOR.length);
+	const tail = text.slice(idx + GLOBE_ANCHOR.length);
+	return (
+		<span className="feed-upcoming-virtual-event__description-inner">
+			{head}
+			<GlobalGlobe />
+			{tail}
+		</span>
+	);
+}
+
 function UpcomingVirtualEventInner() {
 	const { t, locale } = useTranslation();
 	const [brandMarkBroken, setBrandMarkBroken] = useState(false);
@@ -150,7 +181,20 @@ function UpcomingVirtualEventInner() {
 					<MarqueeHeader text={t("feedPage.upcomingVirtualEventHeader")} />
 				}
 			>
-				<SpaceBetween size="s">
+				{/* Wave 38c — replaces the wave 33b <SpaceBetween size="s"> stack
+				    with a custom layout div. SpaceBetween's uniform 12px gap was
+				    too flat for the card's narrative arc — every step read the
+				    same. The new __layout div sets gap:0 and each direct child
+				    carries its own margin-block-end token in styles.css so the
+				    spacing hierarchy reads as deliberate beats: smaller gaps
+				    cluster related metadata (date→location), the largest gaps
+				    set off the secondary primary action (description→featured-
+				    talk callout) and the CTA (callout→buttons). Mirrors the
+				    wave 37c featured-event pattern (which uses CSS Grid named
+				    areas — this card stays in DOM order without grid since the
+				    wave 33b/29a featured-talk callout block is its own visual
+				    anchor that doesn't need re-flow at tablet+ breakpoints). */}
+				<div className="feed-upcoming-virtual-event__layout">
 					<Box
 						fontWeight="bold"
 						fontSize="body-s"
@@ -226,11 +270,33 @@ function UpcomingVirtualEventInner() {
 							{formattedDate}
 						</span>
 					</div>
-					<Box color="text-body-secondary" fontSize="body-s">
+					<Box
+						color="text-body-secondary"
+						fontSize="body-s"
+						className="feed-upcoming-virtual-event__location"
+					>
 						{t("feedPage.upcomingVirtualEventLocation")}
 					</Box>
-					<Box color="text-body-secondary" fontSize="body-s">
-						{t("feedPage.upcomingVirtualEventDescription")}
+					{/* Wave 38c — description copy gets the wave 37c personality
+					    uplift (mirrors featured-event): color="inherit" so the
+					    .feed-upcoming-virtual-event__description CSS rule below
+					    — which sets color: var(--cdn-color-text) — actually
+					    paints (Cloudscape's "text-body-secondary" was muting the
+					    prose to fine-print gray). fontSize="body-m" bumps the
+					    inherited size onto the --cdn-text-base tier; the same
+					    CSS rule layers an explicit font-size + line-height: 1.65
+					    + 64ch max-width on top so the prose reads as the
+					    deliberate voice the card hangs its narrative on rather
+					    than secondary metadata. The inline GlobalGlobe SVG
+					    splices in after the word "global" via renderDescription
+					    (the upcoming-virtual-event signature personality detail
+					    — in-family with the featured-event AsciiSmirk). */}
+					<Box
+						color="inherit"
+						fontSize="body-m"
+						className="feed-upcoming-virtual-event__description"
+					>
+						{renderDescription(t("feedPage.upcomingVirtualEventDescription"))}
 					</Box>
 					<div className="feed-upcoming-virtual-event__featured-talk">
 						<span
@@ -275,7 +341,7 @@ function UpcomingVirtualEventInner() {
 							variant="violet"
 						/>
 					</div>
-				</SpaceBetween>
+				</div>
 			</Container>
 		</div>
 	);

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -2217,7 +2217,15 @@
 	align-items: center;
 	justify-content: center;
 	min-height: 40px;
-	padding: 8px 28px;
+	/* wave 38c — tokenize raw 8px / 28px marquee padding onto the 8pt grid.
+	   Mobile: --cdn-space-12 (12px) vertical, --cdn-space-md (16px)
+	   horizontal. Mirrors the wave 37c featured-event marquee treatment.
+	   The original 28px horizontal pad was off-grid; 12 / 16 sits the
+	   headline comfortably between the rim highlights and falls on the
+	   Cloudscape SpaceBetween size="s" / size="m" rhythm. Tablet +
+	   desktop overrides live in the @media blocks at the bottom of this
+	   marquee section. */
+	padding: var(--cdn-space-12, 12px) var(--cdn-space-md, 16px);
 	border-radius: 10px;
 	background: linear-gradient(
 		180deg,
@@ -2269,6 +2277,40 @@
 		0 0 6px var(--cdn-uvirt-marquee-text-glow),
 		0 1px 0 rgba(255, 250, 235, 0.35);
 	line-height: 1.15;
+}
+
+/* Wave 38c — responsive marquee sizing (mobile baseline above; tablet +
+   desktop here). Plain min-width media queries since the upcoming-virtual-
+   event card is not a CSS container query context (no internal grid layout
+   to query — the card body is the wave 38c __layout block-stack, which
+   stays single-column at every breakpoint since the wave 29a/33b featured-
+   talk callout is its own visual anchor that doesn't reflow). Mirrors the
+   wave 33a next-meetup pattern. If a future wave adds a container-query
+   layout to this card, swap these for @container rules to mirror the
+   featured-event pattern. Padding scale matches the brief: 12/16 mobile
+   (above), 12/24 tablet, 16/24 desktop. */
+@media (min-width: 520px) {
+	.feed-upcoming-virtual-event__marquee {
+		min-height: 44px;
+		padding: var(--cdn-space-12, 12px) var(--cdn-space-lg, 24px);
+	}
+
+	.feed-upcoming-virtual-event__marquee-text {
+		font-size: 1.0625rem;
+		letter-spacing: 0.07em;
+	}
+}
+
+@media (min-width: 860px) {
+	.feed-upcoming-virtual-event__marquee {
+		min-height: 48px;
+		padding: var(--cdn-space-md, 16px) var(--cdn-space-lg, 24px);
+	}
+
+	.feed-upcoming-virtual-event__marquee-text {
+		font-size: 1.125rem;
+		letter-spacing: 0.08em;
+	}
 }
 
 /* Starfield — absolutely positioned over the marquee backplate. Stars
@@ -2423,15 +2465,23 @@
    gradient backplate + shimmer pseudo-element. */
 .feed-upcoming-virtual-event__date {
 	display: block;
-	margin: 4px 0 2px;
+	/* wave 38c — drop the legacy asymmetric 4px / 0 / 2px margin. Inter-
+	   element spacing is now owned by the __layout block-stack's per-
+	   element margin-block-end tokens (title → date = 12px, date →
+	   location = 8px). Mirrors the wave 37c featured-event date wrapper. */
+	margin: 0;
 	font-variant-numeric: tabular-nums;
 }
 
 .feed-upcoming-virtual-event__date-plate {
 	position: relative;
 	display: inline-block;
-	padding: 6px 14px;
-	border-radius: 8px;
+	/* wave 38c — round padding from raw 6px / 14px to the 8pt grid:
+	   --cdn-space-sm (8px) vertical, --cdn-space-md (16px) horizontal.
+	   Border-radius pinned to --cdn-radius-md (8px) token. Mirrors the
+	   wave 37c featured-event date-plate treatment. */
+	padding: var(--cdn-space-sm, 8px) var(--cdn-space-md, 16px);
+	border-radius: var(--cdn-radius-md, 8px);
 	background: linear-gradient(
 		135deg,
 		var(--cdn-uvirt-date-plate-from) 0%,
@@ -2572,7 +2622,11 @@
 
 .feed-upcoming-virtual-event__badge {
 	display: inline-block;
-	padding: 4px 12px;
+	/* wave 38c — tokenize raw 4px / 12px badge padding onto the 8pt grid.
+	   Pill border-radius (999px) is the sentinel value, kept as-is (no
+	   token). justify-self handled by the parent __layout rule below so
+	   the pill sits tight to its natural width inside the block stack. */
+	padding: var(--cdn-space-xs, 4px) var(--cdn-space-12, 12px);
 	border-radius: 999px;
 	background-color: var(--cdn-aws-orange, #ff9900);
 	color: #1a1a1a;
@@ -2592,7 +2646,12 @@
 	object-position: center;
 	background-color: rgba(0, 0, 0, 0.04);
 	border-radius: var(--cdn-radius-md, 8px);
-	margin: 12px 0;
+	/* wave 38c — drop the legacy 12px vertical margin. The __layout
+	   block-stack now owns inter-element spacing via per-element margin-
+	   block-end tokens; the image wrapper's own margin is reset to 0 so
+	   spacing isn't doubled. Mirrors the wave 37c featured-event image
+	   treatment. */
+	margin: 0;
 }
 
 .awsui-dark-mode .feed-upcoming-virtual-event__image {
@@ -2625,7 +2684,10 @@
 	display: block;
 	width: 100%;
 	max-width: 600px;
-	margin: 12px 0;
+	/* wave 38c — drop the legacy 12px vertical margin to match the wave
+	   38c image margin reset above. The __layout block-stack owns inter-
+	   element spacing via per-element margin-block-end tokens. */
+	margin: 0;
 }
 
 /* The wrapped image keeps its own margin/aspect rules — but inside the
@@ -2641,6 +2703,43 @@
    removes the SVG overlay so it never paints over the light image). */
 :not(.awsui-dark-mode) .feed-upcoming-virtual-event__bulbs-wrapper {
 	display: none;
+}
+
+/* Wave 38c — extend the wave 28a/34a theme swap to the wave 33c image-
+   link anchor wrappers. Without this, the off-theme anchor stays visible
+   (its inner img/wrapper is display:none, so the anchor renders empty
+   at height 0) and contributes its wave 38c margin-block-end token to
+   the layout — doubling the image → title spacing. The :has() relational
+   selector targets each anchor by the class of its inner content. */
+.feed-upcoming-virtual-event__image-link:has(
+		.feed-upcoming-virtual-event__bulbs-wrapper
+	) {
+	/* Light-mode default: the second anchor wraps the bulbs-wrapper +
+	   dark img + bulbs overlay — hide it whole so the anchor's margin-
+	   block-end doesn't stack with the visible light anchor's margin-
+	   block-end. */
+	display: none;
+}
+
+.awsui-dark-mode
+	.feed-upcoming-virtual-event__image-link:has(
+		.feed-upcoming-virtual-event__image--light
+	) {
+	/* Dark-mode: the first anchor wraps the standalone light img — its
+	   inner img is already display:none via the wave 28a rule, so the
+	   anchor is empty/zero-height. Hide the anchor itself so its margin-
+	   block-end token doesn't stack with the visible dark anchor's. */
+	display: none;
+}
+
+.awsui-dark-mode
+	.feed-upcoming-virtual-event__image-link:has(
+		.feed-upcoming-virtual-event__bulbs-wrapper
+	) {
+	/* Dark-mode: re-show the anchor wrapping the bulbs-wrapper (the
+	   light-mode default rule above hid it; the dark-mode branch
+	   restores it). */
+	display: block;
 }
 
 /* ---------- Next meetup card — base styling consolidated into wave 33a block ----------
@@ -2732,8 +2831,14 @@
    -------------------------------------------------------------------------- */
 .feed-upcoming-virtual-event__featured-talk {
 	display: flex;
-	gap: 16px;
+	gap: var(--cdn-space-md, 16px);
 	align-items: flex-start;
+	/* wave 38c — featured-talk callout internal padding (wave 29a) stays.
+	   The brand-mark UG disc + featured-talk-body internals are explicitly
+	   off-limits per the wave 38c brief. Outer top-margin removed since
+	   the __layout block-stack now owns inter-element spacing via per-
+	   element margin-block-end tokens (description → featured-talk = 24px,
+	   the secondary primary action's deliberate breathing room). */
 	padding: 14px 16px;
 	border-radius: 12px;
 	background: linear-gradient(
@@ -2742,7 +2847,7 @@
 		rgba(144, 96, 240, 0.06) 100%
 	);
 	border: 1px solid rgba(90, 31, 138, 0.22);
-	margin-top: 4px;
+	margin-top: 0;
 }
 
 .awsui-dark-mode .feed-upcoming-virtual-event__featured-talk {
@@ -2856,6 +2961,93 @@
 
 .awsui-dark-mode .feed-upcoming-virtual-event__featured-talk-title {
 	color: var(--cdn-lavender, #d7c7ee);
+}
+
+/* ---------- Wave 38c — block-stack layout + spacing hierarchy ----------
+   Replaces the wave 33b <SpaceBetween size="s"> uniform 12px stack with
+   a single-column block container whose direct children carry their own
+   margin-block-end token. The block-stack is a CSS Grid with one column
+   so the per-element margins can compose with grid `gap: 0` cleanly
+   (mirrors the wave 37c featured-event __layout pattern; that one uses
+   named-area placement for tablet+ image-left reflow — this card stays
+   single-column at every breakpoint since the wave 29a/33b featured-talk
+   callout is its own visual anchor that doesn't reflow).
+
+   Spacing hierarchy (mirrors the wave 37c featured-event card):
+     marquee   → badge        : 16px (Cloudscape Container body padding)
+     badge     → image        : --cdn-space-12 (12px)
+     image     → title        : --cdn-space-md  (16px)
+     title     → date         : --cdn-space-12 (12px)
+     date      → location     : --cdn-space-sm  (8px)   cluster meta
+     location  → description  : --cdn-space-12 (12px)
+     description → featured-talk : --cdn-space-lg (24px) secondary CTA
+     featured-talk → buttons  : --cdn-space-lg  (24px)  primary CTA
+
+   Smaller gaps (8px, 12px) cluster related metadata; the largest gaps
+   (24px) anchor the secondary primary action (featured-talk callout)
+   and the CTA button stack as deliberate next beats. */
+.feed-upcoming-virtual-event__layout {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 0;
+	min-width: 0;
+}
+
+/* Per-element margin-block-end — encodes the spacing hierarchy on the
+   8pt grid. Each rule sets the distance FROM that element TO the next
+   one in the block stack. Justified on every element so the rhythm is
+   explicit at the call site rather than buried in a single declaration. */
+.feed-upcoming-virtual-event__badge {
+	/* badge → image: 12px */
+	margin-block-end: var(--cdn-space-12, 12px);
+}
+
+.feed-upcoming-virtual-event__image-link {
+	/* image-link → next sibling: 16px (image → title). The first image-
+	   link wraps the light img; the second wraps the dark bulbs-wrapper.
+	   Both render in DOM order; only the active one paints (the other is
+	   display:none via the wave 28a/34a theme swap). The 16px margin is
+	   applied to whichever one is visible. */
+	margin-block-end: var(--cdn-space-md, 16px);
+}
+
+.feed-upcoming-virtual-event__title {
+	/* title → date: 12px */
+	margin-block-end: var(--cdn-space-12, 12px);
+}
+
+.feed-upcoming-virtual-event__date {
+	/* date → location: 8px (cluster meta) */
+	margin-block-end: var(--cdn-space-sm, 8px);
+}
+
+.feed-upcoming-virtual-event__location {
+	/* location → description: 12px */
+	margin-block-end: var(--cdn-space-12, 12px);
+}
+
+.feed-upcoming-virtual-event__description {
+	/* description → featured-talk callout: 24px (secondary primary
+	   action — the featured-talk gets the same big-anchor breathing
+	   room as the wave 37c featured-event spots → buttons step). */
+	margin-block-end: var(--cdn-space-lg, 24px);
+	/* Wave 38c — description personality uplift (mirrors the wave 37c
+	   featured-event description). font-size --cdn-text-base (14px) on
+	   the inherited base tier; line-height 1.65 for an open vertical
+	   rhythm; max-width 64ch keeps the prose at a comfortable measure;
+	   color --cdn-color-text high-contrast so the prose actually reads
+	   (Cloudscape's "text-body-secondary" was muting it to gray). */
+	font-size: var(--cdn-text-base, 0.875rem);
+	line-height: 1.65;
+	max-width: 64ch;
+	letter-spacing: 0.005em;
+	color: var(--cdn-color-text);
+}
+
+.feed-upcoming-virtual-event__layout
+	.feed-upcoming-virtual-event__featured-talk {
+	/* featured-talk callout → cta button stack: 24px (primary action). */
+	margin-block-end: var(--cdn-space-lg, 24px);
 }
 
 /* Featured event location pill + spots counter — see "wave 25a rizz upgrade"


### PR DESCRIPTION
Applies wave 37c's 8pt token spacing + body-m description treatment to the upcoming-virtual-event card. Same intent as 38b for the sibling event card.

## audit findings
- Marquee padding off-grid (8/28, similar to next-meetup), date plate 6/14, badge 4/12, image margin 12/0
- SpaceBetween size=s forced uniform 12px gap — no hierarchy
- Description text-body-secondary + body-s muted gray
- Off-theme wave 33c image-link anchor stayed visible (empty 0-height) doubling image→title spacing

## redesign
- Tokenized all raw px (marquee 12/16, 12/24, 16/24; date plate 8/16; image and bulbs-wrapper margins 0)
- New .feed-upcoming-virtual-event__layout grid + per-element margin-block-end: badge→image 12, image→title 16, title→date 12, date→location 8, location→desc 12, desc→featured-talk 24, featured-talk→buttons 24
- Description: color=inherit + body-m + var(--cdn-color-text) + line-height 1.65 + 64ch max-width
- :has() rules hide off-theme image-link anchor so its margin doesn't double-stack

## signature personality detail — GlobalGlobe
Pulsing globe SVG inline after 'global' in the description. Planet body + 2 latitude curves + equator + meridian ellipse with fake-3D scaleX 12s rotation + outer halo 5.2s breathe. currentColor inherits palette (cdn-purple light, lavender dark). aria-hidden + aria-label='globe' + prefers-reduced-motion gated + scroll-pause hooked.

## gates
- biome 0 errors / tsc 0 / build PASS / 721 tests pass