### PR TITLE
fix(feed): wave 38d — brand-mark disc switched to AWS-orange so the purple+white star reads

### DIFF
--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -2869,13 +2869,13 @@
 	justify-content: center;
 	background: linear-gradient(
 		135deg,
-		var(--cdn-purple, #5a1f8a) 0%,
-		var(--cdn-violet, #9060f0) 100%
+		var(--cdn-aws-orange, #ff9900) 0%,
+		#ffb84d 100%
 	);
 	color: #faf7f0;
 	box-shadow:
-		0 0 0 2px rgba(255, 153, 0, 0.55),
-		0 4px 14px rgba(90, 31, 138, 0.35);
+		0 0 0 2px rgba(90, 31, 138, 0.55),
+		0 4px 14px rgba(255, 153, 0, 0.35);
 	animation: cdn-brand-mark-pulse 2.6s ease-in-out infinite;
 	user-select: none;
 	overflow: hidden;
@@ -2885,15 +2885,15 @@
 	width: 40px;
 	height: 40px;
 	display: block;
-	/* Drop-shadow lifts the violet star arms off the violet gradient bg
-	   so the brand mark still reads at this 56px disc scale. */
-	filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.45));
+	/* Soft drop-shadow adds depth without competing with the orange disc;
+	   white star arms and purple bulb tips read on their own at 56px. */
+	filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.25));
 }
 
 .awsui-dark-mode .feed-upcoming-virtual-event__brand-mark {
 	box-shadow:
-		0 0 0 2px rgba(255, 153, 0, 0.7),
-		0 4px 16px rgba(144, 96, 240, 0.5);
+		0 0 0 2px rgba(144, 96, 240, 0.7),
+		0 4px 16px rgba(255, 153, 0, 0.5);
 }
 
 @keyframes cdn-brand-mark-pulse {
@@ -2901,15 +2901,15 @@
 	100% {
 		transform: scale(1);
 		box-shadow:
-			0 0 0 2px rgba(255, 153, 0, 0.55),
-			0 4px 14px rgba(90, 31, 138, 0.35),
+			0 0 0 2px rgba(90, 31, 138, 0.55),
+			0 4px 14px rgba(255, 153, 0, 0.35),
 			0 0 0 0 rgba(144, 96, 240, 0.45);
 	}
 	50% {
 		transform: scale(1.05);
 		box-shadow:
-			0 0 0 2px rgba(255, 153, 0, 0.85),
-			0 4px 18px rgba(90, 31, 138, 0.5),
+			0 0 0 2px rgba(90, 31, 138, 0.85),
+			0 4px 18px rgba(255, 153, 0, 0.5),
 			0 0 0 8px rgba(144, 96, 240, 0);
 	}
 }


### PR DESCRIPTION
Bryan: 'the featured talk star logo is a purple & white logo on a purple background so it gets lost - choose a complimentary color'.

## diagnosis
- Brand logo star arms = near-white (#FAFAFA fills)
- Brand logo tip bulbs = purple glow via SVG keyframes (#c8a0ff/#d8b4ff)
- Disc bg = purple→violet gradient (var(--cdn-purple) → var(--cdn-violet))
- White arms read OK on purple, but the purple bulbs blended into the purple disc and got lost

## fix
Disc gradient → `linear-gradient(135deg, var(--cdn-aws-orange, #ff9900) 0%, #ffb84d 100%)`

AWS orange is the complementary hue to purple and was already present in the box-shadow ring. The 2px ring is inverted to purple so the brand-purple still has a contact surface, and the @keyframes pulse + dark-mode override are updated to match. Img drop-shadow softened from 0.45 alpha to 0.25 alpha since the contrast does the work now.

## gates
- biome 0 NEW errors / tsc 0 / build PASS / 732 tests pass