### PR TITLE
perf(player): wave 40a — KEXP polling pauses when tab hidden via Page Visibility API

### DIFF
--- a/src/components/persistent-player/__tests__/kexp-page-visibility.test.ts
+++ b/src/components/persistent-player/__tests__/kexp-page-visibility.test.ts
@@ -1,0 +1,166 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/**
+ * Wave 40a — KEXP polling pause via Page Visibility API.
+ *
+ * Wave 26c shipped the api.kexp.org now-playing poll on a 30s interval inside
+ * PersistentPlayerBar, gated to fire only when stationKey === "kexp" AND audio
+ * is playing. The poll kept firing when the user backgrounded the tab —
+ * burning quota and battery for a UI nobody could see.
+ *
+ * Wave 40a extends the gating envelope to also pause when
+ * document.visibilityState === "hidden". On return to "visible" the poll
+ * resumes with an immediate fetch + restart of the 30s cadence so the album
+ * art catches up to whatever spun during the hidden window.
+ *
+ * We replicate the polling-effect shape from persistent-player/index.tsx
+ * inside a small test hook so we can drive vi.useFakeTimers + the
+ * visibilitychange event without standing up the full audio + media-session
+ * machinery the real component requires. The auto-advance.test.ts pattern in
+ * this directory takes the same approach.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { useEffect } from "react";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type Mock,
+	vi,
+} from "vitest";
+
+const POLL_MS = 30_000;
+
+/**
+ * Mirrors the Wave 40a KEXP poll effect from persistent-player/index.tsx.
+ * The only deltas vs. the production hook:
+ *   - fetchImpl is injected so the test can count calls without monkey-patching
+ *   - the trackplay-row decode + state transitions are stripped (the
+ *     visibility lifecycle is what we need to exercise)
+ * The interval/visibility/cleanup machinery is byte-identical.
+ */
+function useKexpPollEffect(
+	stationKey: string,
+	playing: boolean,
+	fetchImpl: () => Promise<unknown>,
+) {
+	useEffect(() => {
+		if (stationKey !== "kexp" || !playing) return;
+		let cancelled = false;
+		let intervalId: number | null = null;
+		const poll = async () => {
+			await fetchImpl();
+			if (cancelled) return;
+		};
+		const startPolling = () => {
+			if (intervalId !== null) return;
+			poll();
+			intervalId = window.setInterval(poll, POLL_MS);
+		};
+		const stopPolling = () => {
+			if (intervalId !== null) {
+				window.clearInterval(intervalId);
+				intervalId = null;
+			}
+		};
+		const onVisibilityChange = () => {
+			if (document.visibilityState === "hidden") {
+				stopPolling();
+			} else {
+				startPolling();
+			}
+		};
+		if (document.visibilityState !== "hidden") {
+			startPolling();
+		}
+		document.addEventListener("visibilitychange", onVisibilityChange);
+		return () => {
+			cancelled = true;
+			stopPolling();
+			document.removeEventListener("visibilitychange", onVisibilityChange);
+		};
+	}, [stationKey, playing, fetchImpl]);
+}
+
+function setVisibility(state: "visible" | "hidden") {
+	Object.defineProperty(document, "visibilityState", {
+		value: state,
+		configurable: true,
+	});
+	document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("KEXP poll Page Visibility integration (Wave 40a)", () => {
+	let fetchMock: Mock;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		fetchMock = vi.fn().mockResolvedValue(null);
+		// default to visible at the start of every test so prior tests
+		// leaving the document in `hidden` cannot leak across cases
+		Object.defineProperty(document, "visibilityState", {
+			value: "visible",
+			configurable: true,
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		// reset visibility back to "visible" so unrelated tests start clean
+		Object.defineProperty(document, "visibilityState", {
+			value: "visible",
+			configurable: true,
+		});
+	});
+
+	it("does not fetch or arm the interval when the tab is hidden on mount", () => {
+		Object.defineProperty(document, "visibilityState", {
+			value: "hidden",
+			configurable: true,
+		});
+		renderHook(() => useKexpPollEffect("kexp", true, fetchMock));
+		// Even after a full minute (two 30s ticks), no fetch should fire
+		// because the interval was never armed and no immediate fetch ran.
+		vi.advanceTimersByTime(60_000);
+		expect(fetchMock).toHaveBeenCalledTimes(0);
+	});
+
+	it("pauses the poll when the tab transitions to hidden mid-cycle", async () => {
+		renderHook(() => useKexpPollEffect("kexp", true, fetchMock));
+		// initial fetch is a microtask — flush it
+		await vi.advanceTimersByTimeAsync(0);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		// drive one full 30s tick — second fetch fires
+		await vi.advanceTimersByTimeAsync(POLL_MS);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		// tab is backgrounded — interval is cleared and no further fetches fire
+		setVisibility("hidden");
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("kicks an immediate fetch and restarts the interval when the tab returns to visible", async () => {
+		renderHook(() => useKexpPollEffect("kexp", true, fetchMock));
+		await vi.advanceTimersByTimeAsync(0);
+		expect(fetchMock).toHaveBeenCalledTimes(1); // mount fetch
+
+		// background the tab — poll quiesces
+		setVisibility("hidden");
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		// foreground the tab — resume should fire an immediate fetch ahead
+		// of the next interval tick
+		setVisibility("visible");
+		await vi.advanceTimersByTimeAsync(0);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+
+		// 30s after resume the interval ticks again
+		await vi.advanceTimersByTimeAsync(POLL_MS);
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+});

--- a/src/components/persistent-player/index.tsx
+++ b/src/components/persistent-player/index.tsx
@@ -720,6 +720,16 @@ function PersistentPlayerBar({
 	// Stale-data guard: if the API returns the same song/artist signature on
 	// the next poll, we skip the setState call so React does not re-render
 	// the <img> (which would otherwise re-trigger the lazy-load decode).
+	//
+	// Wave 40a — Page Visibility integration. The poll is suspended while
+	// document.visibilityState === "hidden" (backgrounded tab) so we don't
+	// burn api.kexp.org quota or battery while the UI cannot be seen. On
+	// return to "visible" we kick an immediate fetch and restart the 30s
+	// cadence so the album-art surface reflects whatever spun while the tab
+	// was backgrounded. Cadence is unchanged — only the gating envelope
+	// expands. If the tab is already hidden when the effect mounts (rare:
+	// user pre-paused tab before navigating), we just attach the listener
+	// and wait for the next visible transition.
 	useEffect(() => {
 		if (state.stationKey !== "kexp" || !playing) {
 			// any non-KEXP station OR paused state immediately drops the album
@@ -730,6 +740,7 @@ function PersistentPlayerBar({
 			return;
 		}
 		let cancelled = false;
+		let intervalId: number | null = null;
 		const poll = async () => {
 			const result = await fetchKexpNowPlaying();
 			if (cancelled) return;
@@ -748,11 +759,37 @@ function PersistentPlayerBar({
 			kexpTrackSigRef.current = sig;
 			setKexpArt(result);
 		};
-		poll();
-		const id = window.setInterval(poll, POLL_MS);
+		const startPolling = () => {
+			if (intervalId !== null) return; // already running — guard against double-start
+			poll();
+			intervalId = window.setInterval(poll, POLL_MS);
+		};
+		const stopPolling = () => {
+			if (intervalId !== null) {
+				window.clearInterval(intervalId);
+				intervalId = null;
+			}
+		};
+		const onVisibilityChange = () => {
+			if (document.visibilityState === "hidden") {
+				stopPolling();
+			} else {
+				// visible — resume with an immediate fetch so the album art
+				// surface catches up before the next 30s tick
+				startPolling();
+			}
+		};
+		// Initial mount: only kick polling if the tab is currently visible.
+		// If it's already hidden, the visibilitychange listener below will
+		// pick up the next visible transition.
+		if (document.visibilityState !== "hidden") {
+			startPolling();
+		}
+		document.addEventListener("visibilitychange", onVisibilityChange);
 		return () => {
 			cancelled = true;
-			window.clearInterval(id);
+			stopPolling();
+			document.removeEventListener("visibilitychange", onVisibilityChange);
 		};
 	}, [state.stationKey, playing]);
 


### PR DESCRIPTION
Wave 26c shipped 30s api.kexp.org polling but kept firing when tab was backgrounded. This PR adds a visibilitychange listener that clears the interval when document.visibilityState === 'hidden' and resumes with an immediate fetch + interval restart on visible. Hidden-on-mount short-circuits the initial fetch.

30s cadence preserved when active. Cleanup removes both interval + listener.

3 new vitest cases (hidden-on-mount / hidden-mid-cycle / resume-on-visible). Suite 735/735.

biome 0 errors / tsc 0 / build PASS