### PR TITLE
feat(auth): wave 40b — login form 'Need an account?' link to top, mirrors wave 39b signup pattern

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -834,7 +834,8 @@
 			"signInButton": "Sign in",
 			"passkeyButton": "Sign in with passkey",
 			"forgotPassword": "Forgot password?",
-			"noAccount": "New here? Apply to join",
+			"noAccount": "New here?",
+			"signUpLink": "Apply to join",
 			"invalidCredentials": "Email or password is incorrect",
 			"genericError": "Something went wrong. Try again.",
 			"mfaSetup": {

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -834,7 +834,8 @@
 			"signInButton": "Entrar",
 			"passkeyButton": "Iniciar sesión con clave de acceso",
 			"forgotPassword": "¿Olvidaste tu contraseña?",
-			"noAccount": "¿Primera vez? Solicita unirte",
+			"noAccount": "¿Primera vez?",
+			"signUpLink": "Solicita unirte",
 			"invalidCredentials": "Correo o contraseña incorrectos",
 			"genericError": "Algo salió mal. Intenta de nuevo.",
 			"mfaSetup": {

--- a/src/sites/auth/login/app.tsx
+++ b/src/sites/auth/login/app.tsx
@@ -431,6 +431,10 @@ function LoginForm() {
 
 	return (
 		<div className="cdn-auth-form-inner">
+			<Box variant="small" textAlign="right" margin={{ bottom: "s" }}>
+				{t("auth.login.noAccount")}{" "}
+				<Link href="/signup/index.html">{t("auth.login.signUpLink")}</Link>
+			</Box>
 			<form
 				onSubmit={(e) => {
 					void handleCredentialsSubmit(e);
@@ -485,7 +489,6 @@ function LoginForm() {
 					<Link href="/forgot-password/index.html">
 						{t("auth.login.forgotPassword")}
 					</Link>
-					<Link href="/signup/index.html">{t("auth.login.noAccount")}</Link>
 				</SpaceBetween>
 			</Box>
 			{window.PublicKeyCredential && (


### PR DESCRIPTION
Mirrors wave 39b's signup-form treatment on the login form for symmetry. Signup link moved from the bottom centered footer (alongside Forgot-password) to the TOP of the credentials-state return, right-aligned small text with margin-bottom 's'.

Hidden during MFA setup / MFA verify states by virtue of those early returns — same conditional gate semantics as 39b's activeStepIndex === 0.

Locale split into 2 keys mirroring 39b's shape:
- noAccount (prompt) + signUpLink (link text)
- Existing copy tone ('Apply to join' / 'Solicita unirte') preserved per 'don't rename if reasonable' guidance.

Forgot-password link stays in its existing centered footer.

biome 0 errors / tsc 0 / build PASS / 732 tests pass