### PR TITLE
feat(feed): wave 41a — Mescalero shorts host-attribution blurb

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -125,6 +125,7 @@
 		"theZacsShowHeader": "The Zacs' Show",
 		"visitChannel": "visit channel",
 		"shortsHeader": "Mescalero shorts on YouTube",
+		"shortsHostBlurb": "Hosted by Ma-tonth (Rolling Fox), this channel shares real conversations on Oak Flat, Indigenous culture, and the MMIP movement.",
 		"shortsEmpty": "No shorts yet — check back soon",
 		"shortsPlay": "Play short",
 		"shortsModalTitle": "Mescalero short",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -125,6 +125,7 @@
 		"theZacsShowHeader": "El show de los Zacs",
 		"visitChannel": "visitar canal",
 		"shortsHeader": "shorts mescaleros en YouTube",
+		"shortsHostBlurb": "Conducido por Ma-tonth (Rolling Fox), este canal comparte conversaciones reales sobre Oak Flat, cultura indígena y el movimiento MMIP.",
 		"shortsEmpty": "todavía no hay shorts — vuelve pronto, raza",
 		"shortsPlay": "ponle play al short",
 		"shortsModalTitle": "short mescalero",

--- a/src/pages/feed/components/__tests__/youtube-shorts-carousel.test.tsx
+++ b/src/pages/feed/components/__tests__/youtube-shorts-carousel.test.tsx
@@ -85,6 +85,13 @@ describe("YouTubeShortsCarousel", () => {
 		expect(screen.queryAllByTestId("shorts-thumb")).toHaveLength(0);
 	});
 
+	it("renders the host-attribution blurb above the carousel", () => {
+		renderWith(SAMPLE_SHORTS);
+		expect(
+			screen.getByText(/Hosted by Ma-tonth \(Rolling Fox\)/i),
+		).toBeInTheDocument();
+	});
+
 	it("opens the modal embed when a thumbnail is clicked", () => {
 		renderWith(SAMPLE_SHORTS);
 		const thumbs = screen.getAllByTestId("shorts-thumb");

--- a/src/pages/feed/components/youtube-shorts-carousel.tsx
+++ b/src/pages/feed/components/youtube-shorts-carousel.tsx
@@ -163,6 +163,14 @@ export default function YouTubeShortsCarousel({
 		<Container
 			header={<Header variant="h2">{t("feedPage.shortsHeader")}</Header>}
 		>
+			<Box
+				variant="p"
+				color="text-body-secondary"
+				fontSize="body-s"
+				margin={{ bottom: "s" }}
+			>
+				{t("feedPage.shortsHostBlurb")}
+			</Box>
 			{orderedShorts.length === 0 ? (
 				<Box
 					color="text-status-inactive"


### PR DESCRIPTION
Added 'Hosted by Ma-tonth (Rolling Fox), this channel shares real conversations on Oak Flat, Indigenous culture, and the MMIP movement.' below the shorts-carousel header.

New locale key feedPage.shortsHostBlurb (en-US + es-MX with 'movimiento MMIP' translation). Box variant=p, color=text-body-secondary, fontSize=body-s, margin-bottom=s.

biome 0 errors / tsc 0 / build PASS / 736 tests pass