### PR TITLE
fix: wave 42c — banned blue on Mescalero (Cloudscape SegmentedControl tokens) + theme transition smoothness window

### DIFF
--- a/src/pages/feed/components/youtube-shorts-carousel.css
+++ b/src/pages/feed/components/youtube-shorts-carousel.css
@@ -189,3 +189,50 @@
 .awsui-dark-mode .feed-shorts-carousel__sort {
 	color: rgba(255, 255, 255, 0.92);
 }
+
+/* ==========================================================================
+   Wave 42c — Cloudscape SegmentedControl banned-blue override (Mescalero card)
+   --------------------------------------------------------------------------
+   The Mescalero shorts card uses a Cloudscape <SegmentedControl> for the
+   newest/oldest sort flip. Cloudscape's default selected segment renders
+   on #006ce0 (the AWS console "banned blue") and its hover state pulls
+   #f0fbff / #002b66 sky+navy-blue tokens — both fall outside the Cloud Del
+   Norte palette. Bryan flagged the card as the trigger ("that fucking
+   banned blue I hate ... we only have navy colors in our style guide")
+   and wave 42c overrides the relevant Cloudscape design tokens at the
+   .feed-shorts-carousel__sort scope so the override only fires for the
+   shorts card. Per .kiro/steering/cloudscape-overrides.md the substring
+   attribute selector pattern with !important would work for direct rule
+   targeting; tokens are simpler — set --color-background-segment-active-*
+   on the wrapper and Cloudscape's own var() lookup picks up our value
+   without the need for !important or specificity battles.
+
+   Light mode → navy (#00002a) for the selected segment background — the
+   strong dark anchor Bryan asked for, with white inherited segment text
+   for AAA contrast (15.8:1 on near-black navy). Hover background dropped
+   to a soft amber tint (rgba(139,90,43,0.08)) matching the rest of the
+   feed card's warm-amber hover idiom; hover text uses --cdn-purple so the
+   non-selected hover state still reads in palette. Focus ring border
+   color flipped from Cloudscape's #006ce0 to --cdn-violet so keyboard
+   users see the same brand outline the .feed-shorts-carousel__thumb
+   focus-visible rule already declares.
+
+   Dark mode → --cdn-violet for the selected segment background (navy
+   would disappear on the dark navy page surface; violet is the brand-
+   adjacent dark-mode anchor used elsewhere on the card). Hover token
+   gets a soft violet tint, hover text picks up --cdn-lavender, and the
+   focus-ring border stays --cdn-violet for parity with light mode.
+   ========================================================================== */
+:root:not(.awsui-dark-mode) .feed-shorts-carousel__sort {
+	--color-background-segment-active-1u2ldl: var(--cdn-navy, #00002a);
+	--color-background-segment-hover-800sl4: rgba(139, 90, 43, 0.08);
+	--color-text-segment-hover-65a2x8: var(--cdn-purple, #5a1f8a);
+	--color-border-item-focused-uk47pl: var(--cdn-violet, #9060f0);
+}
+
+.awsui-dark-mode .feed-shorts-carousel__sort {
+	--color-background-segment-active-1u2ldl: var(--cdn-violet, #9060f0);
+	--color-background-segment-hover-800sl4: rgba(144, 96, 240, 0.16);
+	--color-text-segment-hover-65a2x8: var(--cdn-lavender, #d7c7ee);
+	--color-border-item-focused-uk47pl: var(--cdn-violet, #9060f0);
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -896,3 +896,64 @@ body.cdn-stream-playing
 	[class*="awsui_button"][class*="variant-link"]:hover {
 	color: var(--cdn-violet, #9060f0) !important;
 }
+
+/* ==========================================================================
+   Wave 42c — Light/dark mode transition smoothness
+   --------------------------------------------------------------------------
+   Bryan flagged "transition between light & dark mode is still not smooth
+   enough". Wave 25c already made the FOUC guard + initial applyMode sync
+   on first paint, so the surface lands correctly on initial load — the
+   remaining gap is the *toggle* moment: every theme-bearing property
+   (background-color, color, border-color, fill, stroke) snaps instantly
+   when the user clicks the picker, and Cloudscape's runtime applyMode()
+   walks its design-token table on a microtask so multiple surfaces flip
+   on slightly different ticks — staggered swap reads as abrupt.
+
+   Approach — a brief "transition window": src/utils/theme.ts adds the
+   .cdn-theme-transitioning class to <body> for ~240ms during the toggle
+   handler, and the rule below eases the theme-bearing properties for
+   every descendant during that window. Outside the window the class is
+   absent and there is no blanket transition cost during scroll, hover,
+   or other ambient interactions — the rule only pays for itself when
+   the user actually flips the theme.
+
+   Properties chosen — only the ones the theme actually animates:
+     - background-color + background    swaps the surface
+     - color                            swaps the prose
+     - border-color                     swaps card/button rims
+     - fill / stroke                    swaps inline SVG (icons, glyphs)
+
+   Duration 200ms ease-in-out — fast enough to feel responsive, slow
+   enough that the eye doesn't register the staggered Cloudscape token-
+   table walk as separate flips. The setTimeout in theme.ts removes the
+   class at 240ms (200ms transition + 40ms slack so the final frame
+   commits before the rule disappears).
+
+   Opt-out hook — descendants that own their own transition timing can
+   carry .no-theme-transition to skip the blanket easing during the
+   toggle window. None today; reserved for future surfaces that paint
+   their own theme animation (the wave 33b twinkle stars, fiona LEDs,
+   etc. would each have to opt out if they ever needed bespoke timing).
+
+   prefers-reduced-motion: reduce — strip the transition entirely; the
+   theme still flips, just instantly. Mirrors the rest of the site's
+   reduced-motion contract.
+   ========================================================================== */
+
+body.cdn-theme-transitioning,
+body.cdn-theme-transitioning *:not(.no-theme-transition) {
+	transition:
+		background-color 200ms ease-in-out,
+		background 200ms ease-in-out,
+		color 200ms ease-in-out,
+		border-color 200ms ease-in-out,
+		fill 200ms ease-in-out,
+		stroke 200ms ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	body.cdn-theme-transitioning,
+	body.cdn-theme-transitioning *:not(.no-theme-transition) {
+		transition: none;
+	}
+}

--- a/src/utils/__tests__/theme-transition.test.ts
+++ b/src/utils/__tests__/theme-transition.test.ts
@@ -1,0 +1,203 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/**
+ * Wave 42c — light/dark mode transition smoothness regression coverage.
+ *
+ * Bryan reported the transition between light and dark mode "is still not
+ * smooth enough" even after the wave 25c FOUC guard + synchronous initial
+ * applyMode landed. The wave 42c fix is a transition window: src/utils/
+ * theme.ts adds body.cdn-theme-transitioning for ~240ms during the toggle
+ * handler, and src/styles/tokens.css declares a rule that eases the theme-
+ * bearing properties (background-color, background, color, border-color,
+ * fill, stroke) for every descendant during that window.
+ *
+ * jsdom does not apply external CSS to the cascade, so we cannot assert
+ * getComputedStyle(document.body).transition. What we CAN assert is the
+ * structural contract on both sides:
+ *
+ *   1. The CSS rule exists in tokens.css with the expected transition
+ *      properties + a prefers-reduced-motion: reduce override that strips
+ *      the transition entirely.
+ *
+ *   2. The applyTheme handler in theme.ts adds the cdn-theme-transitioning
+ *      class to body during a real toggle, and removes it after the
+ *      THEME_TRANSITION_DURATION_MS window elapses (verified with
+ *      vi.useFakeTimers + vi.advanceTimersByTime). The first apply
+ *      (lastAppliedMode === null) does NOT add the class because the
+ *      wave 25c FOUC guard already aligned <html>.awsui-dark-mode on
+ *      parse-time, so the first applyTheme is a no-op for the surface.
+ *
+ * Companion coverage: theme.test.ts asserts the wave 25c FOUC guard +
+ * applyMode timing contract; this file is the wave 42c transition layer
+ * on top.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Wave 42c — cdn-theme-transitioning CSS rule (tokens.css)", () => {
+	// Read tokens.css directly because jsdom does not apply external CSS
+	// to the cascade. Same approach next-meetup.test.tsx + featured-event-
+	// scroll.test.tsx use to verify CSS-only contracts.
+	const tokensPath = join(__dirname, "..", "..", "styles", "tokens.css");
+	const tokensText = readFileSync(tokensPath, "utf8");
+
+	it("declares the body.cdn-theme-transitioning rule with the expected transition properties", () => {
+		// The rule must apply to body.cdn-theme-transitioning AND its
+		// descendants (so every surface eases simultaneously when the
+		// theme flips). Match the selector list permissively (whitespace
+		// and the descendant combinator vary across formatters).
+		expect(tokensText).toMatch(/body\.cdn-theme-transitioning/);
+		expect(tokensText).toMatch(
+			/body\.cdn-theme-transitioning \*:not\(\.no-theme-transition\)/,
+		);
+
+		// The transition must cover the theme-bearing properties — the
+		// brief calls out background-color, color, border-color, fill,
+		// stroke. background (shorthand) is also included so cards with a
+		// gradient `background:` declaration ease too.
+		const transitionBlock = tokensText.match(
+			/body\.cdn-theme-transitioning,[\s\S]*?body\.cdn-theme-transitioning \*:not\(\.no-theme-transition\) \{[\s\S]*?transition:[\s\S]*?\}/,
+		);
+		expect(transitionBlock).not.toBeNull();
+		const block = transitionBlock?.[0] ?? "";
+		expect(block).toMatch(/background-color\s+\d+ms/);
+		expect(block).toMatch(/background\s+\d+ms/);
+		expect(block).toMatch(/color\s+\d+ms/);
+		expect(block).toMatch(/border-color\s+\d+ms/);
+		expect(block).toMatch(/fill\s+\d+ms/);
+		expect(block).toMatch(/stroke\s+\d+ms/);
+		// 180-220ms ease-in-out is the brief's calibrated band; assert the
+		// timing function is ease-in-out (not the default linear/ease) so
+		// the swap reads as deliberate rather than abrupt.
+		expect(block).toMatch(/ease-in-out/);
+	});
+
+	it("strips the transition under prefers-reduced-motion: reduce", () => {
+		// The reduced-motion fallback must wrap the same selector list and
+		// reset transition to none — the theme still flips on click, just
+		// instantly, mirroring the rest of the site's reduced-motion contract.
+		const reducedBlock = tokensText.match(
+			/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?body\.cdn-theme-transitioning[\s\S]*?transition:\s*none[\s\S]*?\}/,
+		);
+		expect(reducedBlock).not.toBeNull();
+	});
+});
+
+describe("Wave 42c — applyTheme transition-class window (theme.ts)", () => {
+	beforeEach(() => {
+		// Defensive cleanup so a leaked class from a previous test doesn't
+		// poison the assertions below.
+		document.body.classList.remove("cdn-theme-transitioning");
+		document.documentElement.classList.remove("awsui-dark-mode");
+		localStorage.clear();
+		vi.resetModules();
+		// vi.useFakeTimers must be enabled per-test to control the
+		// 240ms setTimeout that removes the class. requestIdleCallback /
+		// requestAnimationFrame are stubbed by jsdom but the module's
+		// scheduleApplyMode runs applyMode synchronously on the first
+		// apply (wave 25c) — the deferred path is exercised on subsequent
+		// applies and is not the focus of this test.
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		document.body.classList.remove("cdn-theme-transitioning");
+		document.documentElement.classList.remove("awsui-dark-mode");
+	});
+
+	it("does NOT add cdn-theme-transitioning on the first applyTheme call (wave 25c FOUC guard already aligned <html> at parse-time, so the first apply has nothing to ease)", async () => {
+		const { applyTheme } = await import("../theme");
+
+		// First apply — should land synchronously without queuing a
+		// transition window. The body class must remain absent.
+		applyTheme("dark");
+		expect(document.body.classList.contains("cdn-theme-transitioning")).toBe(
+			false,
+		);
+
+		// Even after advancing timers, no class should appear (the toggle
+		// path was not entered).
+		vi.advanceTimersByTime(500);
+		expect(document.body.classList.contains("cdn-theme-transitioning")).toBe(
+			false,
+		);
+	});
+
+	it("adds cdn-theme-transitioning on a real toggle and removes it after the 240ms window", async () => {
+		const { applyTheme } = await import("../theme");
+
+		// First apply — primes lastAppliedMode but does not add the class
+		// (covered by the test above; here we just need the priming side
+		// effect so the next call enters the toggle path).
+		applyTheme("dark");
+		expect(document.body.classList.contains("cdn-theme-transitioning")).toBe(
+			false,
+		);
+
+		// Real toggle — second apply with a different theme. The class
+		// must now be present synchronously so the CSS rule in tokens.css
+		// engages on the same frame the html class flips.
+		applyTheme("light");
+		expect(document.body.classList.contains("cdn-theme-transitioning")).toBe(
+			true,
+		);
+
+		// Mid-window — class is still present (the swap is still being
+		// eased). 200ms transition + 40ms slack puts removal at 240ms;
+		// at 100ms we should still be inside the window.
+		vi.advanceTimersByTime(100);
+		expect(document.body.classList.contains("cdn-theme-transitioning")).toBe(
+			true,
+		);
+
+		// End-of-window — the setTimeout fires at 240ms and removes the
+		// class. Advance to 240ms total (140ms more on top of the 100ms
+		// already advanced).
+		vi.advanceTimersByTime(140);
+		expect(document.body.classList.contains("cdn-theme-transitioning")).toBe(
+			false,
+		);
+	});
+
+	it("re-arms the transition window on a rapid double-toggle (the second toggle's full window is honored, not truncated by the first toggle's pending removal)", async () => {
+		const { applyTheme } = await import("../theme");
+
+		// Prime + first real toggle — class added at t=0, scheduled to
+		// remove at t=240.
+		applyTheme("dark");
+		applyTheme("light");
+		expect(document.body.classList.contains("cdn-theme-transitioning")).toBe(
+			true,
+		);
+
+		// Second real toggle at t=120 (mid-window). The handler must
+		// cancel the in-flight removal and re-arm a fresh 240ms window
+		// from the new toggle moment — without the cancel, the original
+		// timeout would still fire at t=240 and strip the class while
+		// the second swap is still being eased.
+		vi.advanceTimersByTime(120);
+		applyTheme("dark");
+		expect(document.body.classList.contains("cdn-theme-transitioning")).toBe(
+			true,
+		);
+
+		// At t=240 (the original first-toggle removal moment) the class
+		// must still be present because the re-arm cancelled that
+		// timeout.
+		vi.advanceTimersByTime(120);
+		expect(document.body.classList.contains("cdn-theme-transitioning")).toBe(
+			true,
+		);
+
+		// At t=240 + 240 = 480 the second toggle's fresh window has
+		// elapsed and the class is removed.
+		vi.advanceTimersByTime(120);
+		expect(document.body.classList.contains("cdn-theme-transitioning")).toBe(
+			false,
+		);
+	});
+});

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -12,6 +12,17 @@ const THEME_KEY = "awsaerospace-theme";
 let lastAppliedMode: Mode | null = null;
 let pendingApplyHandle: number | null = null;
 
+// Wave 42c — transition-window timer handle. The toggle handler adds
+// body.cdn-theme-transitioning for ~240ms so the CSS rule in tokens.css
+// can ease theme-bearing properties (background-color, color, border-color,
+// fill, stroke) during the swap. Stored at module scope so repeated rapid
+// toggles cancel the in-flight removal and re-arm a fresh window — without
+// the cancel a quick double-click would remove the class mid-transition on
+// the second flip and the second swap would snap instead of ease.
+let pendingTransitionHandle: number | null = null;
+const THEME_TRANSITION_CLASS = "cdn-theme-transitioning";
+const THEME_TRANSITION_DURATION_MS = 240;
+
 const getSystemPreference = (): Theme => {
 	if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
 		return "dark";
@@ -95,6 +106,36 @@ const scheduleApplyMode = (mode: Mode): void => {
 };
 
 export const applyTheme = (theme: Theme): void => {
+	// Wave 42c — open a transition window so theme-bearing properties
+	// (background-color, color, border-color, fill, stroke) ease to the
+	// new value instead of snapping. Skip on the very first apply: the
+	// wave 25c FOUC guard already aligned the awsui-dark-mode class on
+	// <html> at parse-time, so the class toggle below is a no-op for the
+	// initial mount and there is nothing to animate. Subsequent toggles
+	// (user clicks the picker, system preference change) are real swaps
+	// and benefit from the eased transition. Body availability is checked
+	// because applyTheme can run before body mounts in unusual entry
+	// orderings — the transition is a nice-to-have, not load-bearing.
+	const isFirstApply = lastAppliedMode === null;
+	if (
+		!isFirstApply &&
+		typeof document !== "undefined" &&
+		document.body !== null
+	) {
+		document.body.classList.add(THEME_TRANSITION_CLASS);
+		// Cancel any in-flight removal from a previous rapid toggle so the
+		// fresh window's full duration is honored. Without this, a quick
+		// double-click would strip the class mid-transition on the second
+		// flip and the second swap would snap instead of ease.
+		if (pendingTransitionHandle !== null) {
+			clearTimeout(pendingTransitionHandle);
+		}
+		pendingTransitionHandle = window.setTimeout(() => {
+			pendingTransitionHandle = null;
+			document.body.classList.remove(THEME_TRANSITION_CLASS);
+		}, THEME_TRANSITION_DURATION_MS);
+	}
+
 	// IMMEDIATE: toggle the html class so our CSS palette + the wallpaper
 	// MutationObserver react synchronously. User sees the surface flip
 	// (light ↔ dark) within the same frame they clicked.


### PR DESCRIPTION
## banned blue source
The Mescalero card body CSS was already clean. Banned blue came from Cloudscape SegmentedControl defaults: selected segment #006ce0, hover bg #f0fbff, hover text #002b66, focus ring #006ce0. Scoped Cloudscape token override on .feed-shorts-carousel__sort:
- light: --color-background-segment-active → var(--cdn-navy, #00002a); hover bg → soft amber rgba(139,90,43,0.08); hover text → --cdn-purple; focus border → --cdn-violet
- dark: active → --cdn-violet; hover bg → rgba(144,96,240,0.16); hover text → --cdn-lavender; focus border → --cdn-violet

## broader audit (NOT fixed, documented in commit body)
- feed-card-shell.css `.feed-card-shell--navy` uses #1e40af (Tailwind navy-blue) — palette-name says 'navy' but color reads blue, ambiguous against tokens.css --cdn-navy (#00002a)
- src/styles/cdn-glass-streaks.css decorative violet→cyan dark-mode streak (intentional)
- next-meetup --cdn-nm-spot-cyan / --cdn-nm-spot-cool (deliberate wave 33a cool-palette VFX)
- shell/styles.css --cdn-sky-top: #2d5d8a (steel-blue dune-test wallpaper)

## theme transition smoothness
Wave 25c sync-applied first paint; runtime toggle still felt abrupt. Added a 240ms transition window via `body.cdn-theme-transitioning` class:
- src/utils/theme.ts: applyTheme adds class synchronously, schedules removal at 240ms (200ms transition + 40ms slack), cancels-and-rearms on rapid double-toggle, guarded against first-apply
- src/styles/tokens.css: `body.cdn-theme-transitioning *:not(.no-theme-transition)` eases background-color/color/border-color/fill/stroke at 200ms ease-in-out
- prefers-reduced-motion: reduce strips the transition (theme still flips, instantly)

5 new vitest cases on src/utils/__tests__/theme-transition.test.ts.

biome 0 NEW errors / tsc 0 / build PASS / 741 tests