### PR TITLE
fix(chrome): wave 46 — left menu close-button glass + 44x44 touch + theme-transition flicker guard + wave 45a test hotfix

### DIFF
--- a/src/layouts/shell/styles.css
+++ b/src/layouts/shell/styles.css
@@ -1997,6 +1997,7 @@ nav[class*="awsui_navigation_"]:not(
    Visible circle: 32×32. Transparent padding extends tap zone to 44×44.
    display:flex centers the SVG icon within the visible circle. */
 button[class*="awsui_navigation-toggle"],
+button[class*="awsui_navigation-close"],
 [class*="awsui_tools-toggle_"] button,
 button[class*="awsui_tools-toggle"] {
 	width: 32px !important;

--- a/src/pages/feed/components/__tests__/wave-45-rizz.test.tsx
+++ b/src/pages/feed/components/__tests__/wave-45-rizz.test.tsx
@@ -9,7 +9,7 @@
 //   5. RSC two-sentence excerpt split logic
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../../contexts/locale-context";
 import { FeedAndmore, FeedAwsml, type FeedPost } from "../feed-section";
 
@@ -39,9 +39,7 @@ const SAMPLE_POSTS: FeedPost[] = [
 // ---------------------------------------------------------------------------
 
 function capExcerpt(excerpt: string): string {
-	return excerpt.length > 140
-		? `${excerpt.slice(0, 140).trimEnd()}…`
-		: excerpt;
+	return excerpt.length > 140 ? `${excerpt.slice(0, 140).trimEnd()}…` : excerpt;
 }
 
 describe("PostCarousel excerpt cap logic (task 1.4)", () => {
@@ -78,8 +76,7 @@ describe("PostCarousel excerpt cap logic (task 1.4)", () => {
 function twoSentences(excerpt: string): string {
 	if (!excerpt) return "";
 	const chunks = excerpt.split(/\.\s+/);
-	const joined =
-		chunks.length >= 2 ? `${chunks[0]}. ${chunks[1]}.` : chunks[0];
+	const joined = chunks.length >= 2 ? `${chunks[0]}. ${chunks[1]}.` : chunks[0];
 	return joined.length > 140 ? `${joined.slice(0, 140).trimEnd()}…` : joined;
 }
 
@@ -240,9 +237,7 @@ describe("SpeakerProposalCta bounce @keyframes (task 5)", () => {
 	it("cdn-cta-bounce keyframe + motion safety guards are in the stylesheet", async () => {
 		const { readFileSync } = await import("node:fs");
 		const { resolve } = await import("node:path");
-		const cssPath = resolve(
-			"src/components/speaker-proposal-cta/styles.css",
-		);
+		const cssPath = resolve("src/components/speaker-proposal-cta/styles.css");
 		const css = readFileSync(cssPath, "utf-8");
 
 		expect(css).toContain("@keyframes cdn-cta-bounce");

--- a/src/styles/cdn-glass-streaks.css
+++ b/src/styles/cdn-glass-streaks.css
@@ -1380,6 +1380,34 @@ body.cdn-tools-open [class*="awsui_header-wrapper_"]
 	}
 }
 
+/* Wave 46 — close/collapse nav button. Match the hamburger glass treatment
+   so the open-state dismiss control reads as in-family chrome (Bryan's
+   left-menu-icon bug). Cloudscape ships nav-toggle + nav-close as separate
+   classes; the wave 9 / wave 13 glass rule only matched the toggle, leaving
+   the close button bare-gray + undersized. */
+:root:not(.awsui-dark-mode)
+	[class*="awsui_navigation-close"]:not(#\9):not(#\10) {
+	background: var(--cdn-glass-bg-strong, rgba(237, 229, 212, 0.7));
+	backdrop-filter: blur(8px) saturate(1.1);
+	-webkit-backdrop-filter: blur(8px) saturate(1.1);
+	border: 1.5px solid rgba(139, 90, 43, 0.3);
+	color: rgba(90, 58, 20, 0.85);
+	box-shadow:
+		0 1px 6px rgba(44, 18, 6, 0.12),
+		inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.awsui-dark-mode [class*="awsui_navigation-close"]:not(#\9):not(#\10) {
+	background: var(--cdn-glass-bg, rgba(28, 34, 48, 0.55));
+	backdrop-filter: blur(8px) saturate(1.1);
+	-webkit-backdrop-filter: blur(8px) saturate(1.1);
+	border: 1.5px solid rgba(144, 96, 240, 0.3);
+	color: rgba(215, 199, 238, 0.9);
+	box-shadow:
+		0 1px 6px rgba(0, 0, 0, 0.25),
+		inset 0 1px 0 rgba(144, 96, 240, 0.15);
+}
+
 /* ==========================================================================
    Audio-reactive trigger rings — volunteer + tools-toggle + navigation-toggle
    adopt station-primary coloring AND a band-driven expansion ring while a

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -957,3 +957,15 @@ body.cdn-theme-transitioning *:not(.no-theme-transition) {
 		transition: none;
 	}
 }
+
+/* Wave 46 — chrome icons stay stable during theme-transition window.
+   The blanket *:not(.no-theme-transition) rule above animates stroke +
+   fill on every descendant; nav-toggle / nav-close / tools-toggle SVG
+   <path>s briefly flash through interpolated colors during the 200ms
+   transition. Force them to instant-swap. */
+body.cdn-theme-transitioning button[class*="awsui_navigation-toggle"] *,
+body.cdn-theme-transitioning button[class*="awsui_navigation-close"] *,
+body.cdn-theme-transitioning [class*="awsui_tools-toggle_"] button *,
+body.cdn-theme-transitioning button[class*="awsui_tools-toggle"] * {
+	transition: none !important;
+}


### PR DESCRIPTION
## Bryan's blocker
Left side panel close/collapse button (× on mobile, < on desktop) had no glass treatment, no border, no shadow, undersized at 28x32 (vs the 44x44 enforced on hamburger + tools-toggle). Liora's headless audit found Cloudscape ships nav-toggle + nav-close as separate classes — the wave 9/13 glass rule only matched the toggle.

## fixes
- glass treatment block for awsui_navigation-close (light + dark)
- 44x44 outer + 32x32 inner at <=690px touch-target rule extended to navigation-close
- theme-transition window's blanket animate-everything rule excluded chrome-icon SVG paths (no flicker during 200ms toggle)

## task 2 — wave 45a deploy hotfix
Wave 45 merged with wave-45-rizz.test.tsx using beforeEach/afterEach without importing them. tsc fail blocked scripts/deploy-manual.sh. Production stuck on wave 44; this restores deploy.

## gates
- biome 0 errors / 531 warnings
- tsc 0 NEW
- build PASS
- vitest 765 PASS