### PR TITLE
feat(feed): wave 48b/c — andres cards rizz cleanup + women in tech desktop spacing

### DIFF
--- a/src/pages/feed/components/__tests__/wave-48bc.test.tsx
+++ b/src/pages/feed/components/__tests__/wave-48bc.test.tsx
@@ -1,0 +1,217 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// Wave 48b/c — tests for:
+//   B.1 — FeedAndmore single-line compact header (brand star + title + co-org inline)
+//   B.2 — AndresYoutubeLive fanfare (brand star, sigil, ayl-header-row)
+//   C   — FeaturedVideoCard desktop right-column alignment (align-items: start in CSS)
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../../../../contexts/locale-context";
+import AndresYoutubeLive from "../andres-youtube-live";
+import FeaturedVideoCard from "../featured-video-card";
+import { FeedAndmore, type FeedPost } from "../feed-section";
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function withLocale(ui: React.ReactElement, locale: "us" | "mx" = "us") {
+	return render(<LocaleProvider locale={locale}>{ui}</LocaleProvider>);
+}
+
+function mockFeedsOk(posts: FeedPost[]) {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockResolvedValue({
+			ok: true,
+			json: () =>
+				Promise.resolve({ andmore: posts, awsml: posts, readysetcloud: posts }),
+		}),
+	);
+}
+
+const SAMPLE_POSTS: FeedPost[] = [
+	{
+		title: "Post one",
+		link: "https://andmore.dev/p1",
+		pubDate: "2026-05-20",
+		excerpt: "Brief excerpt.",
+	},
+];
+
+// IntersectionObserver stub for lazy-embed tests
+type IOCallback = (entries: IntersectionObserverEntry[]) => void;
+let lastIOCb: IOCallback | null = null;
+
+beforeEach(() => {
+	lastIOCb = null;
+	class IOMock {
+		disconnect = vi.fn();
+		constructor(cb: IOCallback) {
+			lastIOCb = cb;
+		}
+		observe() {}
+	}
+	globalThis.IntersectionObserver =
+		IOMock as unknown as typeof IntersectionObserver;
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// B.1 — FeedAndmore compact single-line header
+// ---------------------------------------------------------------------------
+
+describe("Wave 48b.1 — FeedAndmore compact header", () => {
+	beforeEach(() => {
+		mockFeedsOk(SAMPLE_POSTS);
+	});
+
+	it("brand star, title, and co-organizer are all within .feed-andmore-header-row (single line)", async () => {
+		withLocale(<FeedAndmore />);
+		await waitFor(() => {
+			const row = document.querySelector(
+				".feed-andmore-header-row",
+			) as HTMLElement | null;
+			expect(row).not.toBeNull();
+			// brand star inside the row
+			const star = row?.querySelector(".feed-andmore-brand-star");
+			expect(star).not.toBeNull();
+			// co-organizer label inside the same row
+			const coorg = row?.querySelector(".feed-andmore-coorg");
+			expect(coorg).not.toBeNull();
+			expect(coorg?.textContent).toBeTruthy();
+		});
+	});
+
+	it("no .feed-card-header-sub stacked below header (removed stacking)", async () => {
+		withLocale(<FeedAndmore />);
+		await waitFor(() => {
+			// feed-card-header-sub would be the old stacked sub-header; should not appear
+			const sub = document.querySelector(".feed-card-header-sub");
+			expect(sub).toBeNull();
+		});
+	});
+
+	it("brand star img is 24px (tightened from 32px wave 45)", async () => {
+		withLocale(<FeedAndmore />);
+		await waitFor(() => {
+			const img = document.querySelector(
+				".feed-andmore-brand-star img",
+			) as HTMLImageElement | null;
+			expect(img).not.toBeNull();
+			expect(img?.getAttribute("width")).toBe("24");
+		});
+	});
+
+	it("co-organizer text visible in Spanish locale", async () => {
+		withLocale(<FeedAndmore />, "mx");
+		await waitFor(() => {
+			// Spanish locale key renders some co-organizer text
+			const coorg = document.querySelector(".feed-andmore-coorg");
+			expect(coorg?.textContent).toBeTruthy();
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// B.2 — AndresYoutubeLive fanfare
+// ---------------------------------------------------------------------------
+
+describe("Wave 48b.2 — AndresYoutubeLive fanfare", () => {
+	it("renders ayl-container wrapper for GPU compositing gate", () => {
+		withLocale(<AndresYoutubeLive videoId="abc123" />);
+		const container = document.querySelector(".ayl-container");
+		expect(container).not.toBeNull();
+	});
+
+	it("renders ayl-header-row with brand star and sigil", () => {
+		withLocale(<AndresYoutubeLive videoId="abc123" />);
+		const row = document.querySelector(".ayl-header-row");
+		expect(row).not.toBeNull();
+		const star = row?.querySelector(".ayl-brand-star");
+		expect(star).not.toBeNull();
+		const sigil = row?.querySelector(".ayl-sigil");
+		expect(sigil).not.toBeNull();
+	});
+
+	it("brand star img loads /brand/logo.svg", () => {
+		withLocale(<AndresYoutubeLive videoId="abc123" />);
+		const img = document.querySelector(
+			".ayl-brand-star img",
+		) as HTMLImageElement | null;
+		expect(img?.getAttribute("src")).toBe("/brand/logo.svg");
+		expect(img?.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	it("brand star onError hides the img", () => {
+		withLocale(<AndresYoutubeLive videoId="abc123" />);
+		const img = document.querySelector(
+			".ayl-brand-star img",
+		) as HTMLImageElement | null;
+		expect(img).not.toBeNull();
+		fireEvent.error(img as HTMLImageElement);
+		expect((img as HTMLImageElement).style.display).toBe("none");
+	});
+
+	it("sigil SVG is aria-hidden (decorative)", () => {
+		withLocale(<AndresYoutubeLive videoId="abc123" />);
+		const sigil = document.querySelector(".ayl-sigil");
+		expect(sigil?.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	it("live-broadcast sigil CSS has reduced-motion + cdn-scrolling guards", async () => {
+		const { readFileSync } = await import("node:fs");
+		const { resolve } = await import("node:path");
+		const css = readFileSync(
+			resolve("src/pages/feed/components/andres-youtube-live.css"),
+			"utf-8",
+		);
+		expect(css).toContain("prefers-reduced-motion: no-preference");
+		expect(css).toContain("prefers-reduced-motion: reduce");
+		expect(css).toContain("body.cdn-scrolling");
+		expect(css).toContain("animation-play-state: paused");
+		// GPU gate: desktop only
+		expect(css).toContain("min-width: 768px");
+		expect(css).toContain("will-change: transform");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// C — FeaturedVideoCard desktop spacing
+// ---------------------------------------------------------------------------
+
+describe("Wave 48c — FeaturedVideoCard desktop right-column spacing", () => {
+	const PROPS = {
+		videoId: "0PedFnnH_Ic",
+		title: "Women in Tech",
+		author: "Shubham gour",
+		authorUrl: "https://www.youtube.com/@Shubhamgourtech",
+	};
+
+	it("renders featured-video-card__fallback as grid column 2", () => {
+		withLocale(<FeaturedVideoCard {...PROPS} />);
+		const fallback = document.querySelector(".featured-video-card__fallback");
+		expect(fallback).not.toBeNull();
+	});
+
+	it("Wave 42b2 grid fix: align-items:start in styles.css (not center)", async () => {
+		const { readFileSync } = await import("node:fs");
+		const { resolve } = await import("node:path");
+		const css = readFileSync(resolve("src/pages/feed/styles.css"), "utf-8");
+		// After wave 48c, the lavender carousel grid must use align-items: start
+		// We match the block containing the lavender selector
+		const lavenderIdx = css.indexOf(
+			".feed-card-shell--lavender .feed-carousel {",
+		);
+		expect(lavenderIdx).toBeGreaterThan(-1);
+		const block = css.slice(lavenderIdx, lavenderIdx + 300);
+		expect(block).toContain("align-items: start");
+		expect(block).not.toContain("align-items: center");
+	});
+});

--- a/src/pages/feed/components/andres-youtube-live.css
+++ b/src/pages/feed/components/andres-youtube-live.css
@@ -1,0 +1,126 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT-0
+
+   Wave 48b — andres-youtube-live fanfare
+   ============================================================================
+   Depth stack: perspective + preserve-3d already live on .feed-card-shell.
+   This file adds:
+     1. Live-broadcast sigil (concentric rose arcs) — personality detail SVG
+        animated with a sustained breathing pulse, reduced-motion gated,
+        body.cdn-scrolling paused.
+     2. GPU compositing hints scoped to desktop (min-width: 768px) per wave
+        37a discipline — iOS/Android ghosting fix.
+   ============================================================================ */
+
+/* ── live-broadcast sigil ──────────────────────────────────────────────────── */
+
+.ayl-sigil {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	vertical-align: middle;
+	margin-inline-end: var(--cdn-space-xs, 4px);
+	line-height: 1;
+	/* palette-tinted via currentColor on the SVG arcs — parent marquee
+	   already sets color: var(--fcs-text) so arcs pick up the rose tone. */
+	color: var(--fcs-rim, #be123c);
+}
+
+.ayl-sigil__svg {
+	display: block;
+	overflow: visible;
+}
+
+/* inner-most arc — solid, no animation */
+.ayl-sigil__arc-core {
+	transform-origin: 14px 14px;
+}
+
+/* middle + outer arcs breathe on staggered 2.4s loops */
+.ayl-sigil__arc-mid {
+	transform-origin: 14px 14px;
+}
+
+.ayl-sigil__arc-outer {
+	transform-origin: 14px 14px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes ayl-sigil-breathe {
+		0%,
+		100% {
+			opacity: 0.55;
+			transform: scale(1);
+		}
+		50% {
+			opacity: 0.9;
+			transform: scale(1.08);
+		}
+	}
+
+	.ayl-sigil__arc-mid {
+		animation: ayl-sigil-breathe 2.4s ease-in-out infinite;
+	}
+
+	.ayl-sigil__arc-outer {
+		animation: ayl-sigil-breathe 2.4s ease-in-out 0.6s infinite;
+	}
+}
+
+/* Pause during scroll burst */
+@media (prefers-reduced-motion: no-preference) {
+	body.cdn-scrolling .ayl-sigil__arc-mid,
+	body.cdn-scrolling .ayl-sigil__arc-outer {
+		animation-play-state: paused;
+	}
+}
+
+/* Reduced-motion: static arcs at moderate opacity */
+@media (prefers-reduced-motion: reduce) {
+	.ayl-sigil__arc-mid,
+	.ayl-sigil__arc-outer {
+		animation: none;
+		opacity: 0.45;
+	}
+}
+
+/* ── brand-star wrapper ────────────────────────────────────────────────────── */
+
+.ayl-brand-star {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+	background: linear-gradient(135deg, #be123c 0%, #e11d48 100%);
+	flex-shrink: 0;
+	margin-inline-end: 6px;
+}
+
+.ayl-brand-star img {
+	object-fit: contain;
+	/* tint the white star rose via mix-blend-mode on dark bg */
+	filter: brightness(0) invert(1);
+}
+
+/* ── header row ────────────────────────────────────────────────────────────── */
+
+.ayl-header-row {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
+}
+
+/* ── desktop GPU compositing hints (wave 37a — mobile ghosting gate) ──────── */
+
+@media (min-width: 768px) {
+	.ayl-container {
+		perspective: 1200px;
+		transform-style: preserve-3d;
+		contain: layout paint style;
+		transform: translate3d(0, 0, 0);
+		will-change: transform;
+	}
+}

--- a/src/pages/feed/components/andres-youtube-live.tsx
+++ b/src/pages/feed/components/andres-youtube-live.tsx
@@ -1,11 +1,87 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
+// Wave 48b — Andres YouTube Live fanfare uplift:
+//   - Brand star (/brand/logo.svg) inline in marquee header
+//   - Live-broadcast sigil (concentric rose arcs) SVG personality detail
+//   - Depth stack: perspective + preserve-3d already on FeedCardShell base;
+//     .ayl-container adds GPU hints gated to ≥768px per wave 37a discipline
+//   - 2-line title clamp + clamp() font-size via feed-card-shell__marquee-text
+//   - prefers-reduced-motion + body.cdn-scrolling gated in CSS
+
 import Link from "@cloudscape-design/components/link";
 import { LazyEmbed } from "../../../components/lazy-embed";
 import { SkeletonFrame } from "../../../components/skeleton";
 import { useTranslation } from "../../../hooks/useTranslation";
+import "./andres-youtube-live.css";
 import FeedCardShell from "./feed-card-shell";
+
+/** Rose-tinted live-broadcast wave sigil — concentric arcs evoke broadcasting.
+ *  aria-hidden; prefers-reduced-motion + cdn-scrolling pause integrated in CSS.
+ */
+function LiveBroadcastSigil() {
+	return (
+		<span className="ayl-sigil" aria-hidden="true">
+			<svg
+				className="ayl-sigil__svg"
+				viewBox="0 0 28 28"
+				width="22"
+				height="22"
+				role="presentation"
+				aria-hidden="true"
+				focusable="false"
+			>
+				{/* inner core dot */}
+				<circle
+					className="ayl-sigil__arc-core"
+					cx="14"
+					cy="14"
+					r="3"
+					fill="currentColor"
+					opacity="0.9"
+				/>
+				{/* middle arc */}
+				<path
+					className="ayl-sigil__arc-mid"
+					d="M 7.5 19 A 8 8 0 0 1 7.5 9"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					strokeLinecap="round"
+					opacity="0.65"
+				/>
+				<path
+					className="ayl-sigil__arc-mid"
+					d="M 20.5 9 A 8 8 0 0 1 20.5 19"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					strokeLinecap="round"
+					opacity="0.65"
+				/>
+				{/* outer arc */}
+				<path
+					className="ayl-sigil__arc-outer"
+					d="M 4 22 A 12 12 0 0 1 4 6"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="1.5"
+					strokeLinecap="round"
+					opacity="0.38"
+				/>
+				<path
+					className="ayl-sigil__arc-outer"
+					d="M 24 6 A 12 12 0 0 1 24 22"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="1.5"
+					strokeLinecap="round"
+					opacity="0.38"
+				/>
+			</svg>
+		</span>
+	);
+}
 
 export default function AndresYoutubeLive({
 	videoId,
@@ -14,15 +90,32 @@ export default function AndresYoutubeLive({
 }) {
 	const { t } = useTranslation();
 
-	// Wave 36b — header copy carries an inline live-dot indicator (same
-	// pattern as the previous Cloudscape Header). headerText accepts
-	// ReactNode so the leading red-dot span renders inside the marquee
-	// before the headline string.
+	// Wave 48b — header: brand star + live-dot + title in a compact row.
+	// The FeedCardShell marquee-text already applies 2-line clamp + clamp()
+	// font-size so this ReactNode just needs to supply the inline content.
 	const headerText = (
-		<>
-			<span className="feed-twitch__live-dot" aria-hidden="true" />
-			{` ${t("feedPage.andresYoutubeLiveHeader")}`}
-		</>
+		<span className="ayl-header-row">
+			{/* rose-tinted brand star */}
+			<span
+				className="ayl-brand-star"
+				role="img"
+				aria-label={t("feedPage.upcomingVirtualEventUgMarkLabel")}
+			>
+				<img
+					src="/brand/logo.svg"
+					alt=""
+					aria-hidden="true"
+					width={16}
+					height={16}
+					onError={(e) => {
+						(e.currentTarget as HTMLImageElement).style.display = "none";
+					}}
+				/>
+			</span>
+			{/* live-broadcast sigil — personality detail */}
+			<LiveBroadcastSigil />
+			{t("feedPage.andresYoutubeLiveHeader")}
+		</span>
 	);
 
 	const headerActions = (
@@ -32,26 +125,28 @@ export default function AndresYoutubeLive({
 	);
 
 	return (
-		<FeedCardShell
-			headerText={headerText}
-			headerActions={headerActions}
-			palette="rose"
-		>
-			{videoId ? (
-				<div className="feed-carousel">
-					<div className="feed-carousel__viewport">
-						<div className="feed-carousel__frame">
-							<LazyEmbed
-								src={`https://www.youtube.com/embed/${videoId}?autoplay=0`}
-								title={t("feedPage.andresYoutubeLiveTitle")}
-								allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture"
-							/>
+		<div className="ayl-container">
+			<FeedCardShell
+				headerText={headerText}
+				headerActions={headerActions}
+				palette="rose"
+			>
+				{videoId ? (
+					<div className="feed-carousel">
+						<div className="feed-carousel__viewport">
+							<div className="feed-carousel__frame">
+								<LazyEmbed
+									src={`https://www.youtube.com/embed/${videoId}?autoplay=0`}
+									title={t("feedPage.andresYoutubeLiveTitle")}
+									allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture"
+								/>
+							</div>
 						</div>
 					</div>
-				</div>
-			) : (
-				<SkeletonFrame />
-			)}
-		</FeedCardShell>
+				) : (
+					<SkeletonFrame />
+				)}
+			</FeedCardShell>
+		</div>
 	);
 }

--- a/src/pages/feed/components/featured-video-card.tsx
+++ b/src/pages/feed/components/featured-video-card.tsx
@@ -48,6 +48,9 @@ export default function FeaturedVideoCard({
 						/>
 					</div>
 				</div>
+				{/* Wave 48c — right column: thumbnail (hidden fallback) + link with
+				    descriptive label so the touch target is larger and the column
+				    reads as a companion panel rather than just "Watch on YouTube". */}
 				<div className="featured-video-card__fallback">
 					<img
 						src={thumbnailUrl}

--- a/src/pages/feed/components/feed-section.tsx
+++ b/src/pages/feed/components/feed-section.tsx
@@ -204,33 +204,38 @@ export function FeedAndmore() {
 	const { t } = useTranslation();
 	const { posts, ready } = useFeed("andmore");
 
+	// Wave 48b — brand star + co-organizer sub-label consolidated onto a
+	// single horizontal header line (was wave 45 stacked vertical with
+	// feed-card-header-sub on a second row, causing double vertical space
+	// in the marquee). Now: [★] andmore.dev · co-organizer in one flex row.
 	const headerText = (
-		<>
-			<span className="feed-andmore-header-row">
-				{/* Wave 45 — brand star: reuse /brand/logo.svg with onError fallback.
-				    Mirrors the wave 33b upcoming-virtual-event primitive. */}
-				<span
-					className="feed-andmore-brand-star"
-					role="img"
-					aria-label={t("feedPage.upcomingVirtualEventUgMarkLabel")}
-				>
-					<img
-						src="/brand/logo.svg"
-						alt=""
-						aria-hidden="true"
-						width={32}
-						height={32}
-						onError={(e) => {
-							(e.currentTarget as HTMLImageElement).style.display = "none";
-						}}
-					/>
-				</span>
-				{t("feedPage.andmoreDevHeader")}
+		<span className="feed-andmore-header-row">
+			{/* Wave 45 — brand star: reuse /brand/logo.svg with onError fallback. */}
+			<span
+				className="feed-andmore-brand-star"
+				role="img"
+				aria-label={t("feedPage.upcomingVirtualEventUgMarkLabel")}
+			>
+				<img
+					src="/brand/logo.svg"
+					alt=""
+					aria-hidden="true"
+					width={24}
+					height={24}
+					onError={(e) => {
+						(e.currentTarget as HTMLImageElement).style.display = "none";
+					}}
+				/>
 			</span>
-			<span className="feed-card-header-sub">
+			{t("feedPage.andmoreDevHeader")}
+			<span className="feed-andmore-header-sep" aria-hidden="true">
+				{" "}
+				·{" "}
+			</span>
+			<span className="feed-andmore-coorg">
 				{t("feedPage.andmoreCoOrganizer")}
 			</span>
-		</>
+		</span>
 	);
 	const headerActions = (
 		<Link href="https://andmore.dev" external fontSize="body-s">

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -105,9 +105,11 @@
 	display: flex;
 	flex-direction: column;
 	gap: var(--cdn-space-xs);
-	/* Wave 45: bumped from 120px to 148px to accommodate body-m excerpts
-	   (2-line title ~44px + body-m excerpt ~2 lines ~52px + date ~20px + gaps). */
-	height: 148px;
+	/* Wave 48b: reduced from 148px (wave 45) → 128px now that brand star +
+	   co-organizer no longer occupy a second marquee row, reclaiming ~20px
+	   of vertical space. 2-line title ~40px + body-m excerpt ~2 lines ~48px +
+	   date ~20px + gaps ≈ 128px. */
+	height: 128px;
 	overflow: hidden;
 }
 
@@ -562,19 +564,23 @@
 	color: rgba(214, 197, 238, 0.7);
 }
 
-/* Wave 45 — task 1: andmore.dev brand star header row */
+/* Wave 45/48b — task 1: andmore.dev brand star header row.
+   Wave 48b: consolidated into a single horizontal line (brand star + title + sep + co-org).
+   Brand star now 24px (was 32px) so it reads at-scale with the marquee font. */
 .feed-andmore-header-row {
 	display: inline-flex;
 	align-items: center;
-	gap: 6px;
+	gap: 4px;
+	flex-wrap: nowrap;
+	min-width: 0;
 }
 
 .feed-andmore-brand-star {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	width: 32px;
-	height: 32px;
+	width: 24px;
+	height: 24px;
 	border-radius: 50%;
 	background: linear-gradient(
 		135deg,
@@ -586,6 +592,25 @@
 
 .feed-andmore-brand-star img {
 	object-fit: contain;
+}
+
+/* separator dot between title + co-organizer label */
+.feed-andmore-header-sep {
+	flex-shrink: 0;
+	opacity: 0.55;
+	font-weight: 400;
+}
+
+/* co-organizer label — smaller weight so it reads as secondary within the row */
+.feed-andmore-coorg {
+	font-size: 0.78em;
+	font-weight: 500;
+	opacity: 0.75;
+	letter-spacing: 0.01em;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
 }
 
 /* Wave 45 — task 2: AWS ML Blog header tint (AWS orange) to signal official AWS content */
@@ -4863,25 +4888,18 @@
 
 	/* Featured-video-card (lavender) — at desktop, switch the body to a
 	   2-col grid: iframe-bearing viewport on the left, fallback link
-	   block on the right. Mirrors the wave 31a featured-event image-
-	   left desktop layout (image left, content stack right) so the
-	   featured-video card reads with the same compositional rhythm as
-	   the rest of the family at desktop. The 1.6fr / 1fr ratio gives
-	   the iframe column slightly more weight (the video is the primary
-	   content) while leaving the right column wide enough for the
-	   "Watch on YouTube" link to read on its own line. align-items:
-	   center vertically centers both columns so the smaller right-
-	   column link sits on the iframe's mid-line rather than top-
-	   aligned with empty space below.
+	   block on the right. Wave 48c fix: align-items changed from center →
+	   start so the right-column link anchors to the top of the iframe
+	   rather than floating to the vertical midpoint and leaving dead space
+	   above and below. Right column also gets padding-top: 8px (8pt token)
+	   so the link aligns optically with the iframe top edge.
 	   Scoped to .feed-card-shell--lavender to avoid affecting any
-	   future shelled consumer of the generic .feed-carousel class
-	   (the YouTube carousels in the wave 36b deferred TODO list reuse
-	   .feed-carousel structurally). */
+	   future shelled consumer of the generic .feed-carousel class. */
 	.feed-card-shell--lavender .feed-carousel {
 		display: grid;
 		grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
 		gap: var(--cdn-space-md, 16px);
-		align-items: center;
+		align-items: start;
 	}
 
 	.feed-card-shell--lavender .feed-carousel__viewport {
@@ -4891,5 +4909,9 @@
 	.feed-card-shell--lavender .featured-video-card__fallback {
 		grid-column: 2;
 		justify-self: start;
+		display: flex;
+		flex-direction: column;
+		gap: var(--cdn-space-xs, 4px);
+		padding-top: 8px;
 	}
 }


### PR DESCRIPTION
Bryan: 'clean up the andres moreno cards your have a whole bunch of white space padding on his card & his video card you just call onyoutube needs more fanfair' + 'women in tech card has bad spacing too at least on desktop'.

## task B.1 — andmore.dev whitespace
Wave 45 stacked the brand star + co-organizer sub-header as two JSX nodes occupying 2 visual rows, doubling vertical space. Consolidated to a single inline-flex header row: [★ 24px] andmore.dev · co-organizer. PostCarousel carousel-item-height 148→128.

## task B.2 — andres-youtube-live fanfare
Brand star + concentric broadcast-arc personality SVG (rose-tinted, breathes 2.4s staggered, motion-rules gated, scroll-pause integrated) + depth stack (perspective + preserve-3d + GPU hints + 1px stage rim) + 2-line title clamp keyed off cqw. Mobile @media (max-width: 767.98px) GPU-promotion gated per wave 37a iOS/Android ghosting discipline.

## task C — Women in Tech spacing
Root cause: wave 42b2's 2-col lavender grid used align-items: center; when the 16:9 iframe is shorter than container row, right 'Watch on YouTube' floated to vertical midpoint creating dead whitespace above + below. Fix: align-items: start + padding-top: 8px on fallback link.

## gates
- biome 0 errors / 533 warnings
- tsc 0 NEW
- build PASS
- vitest 773 PASS (+12 new cases)