### PR TITLE
chore(i18n): wave 50 — close truncated community blurb in footer (en + es-MX)

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -49,7 +49,7 @@
 		"joinUs": "Join us on Meetup →",
 		"communityDescription": "AWS User Group Cloud Del Norte is part of AWS User Groups'",
 		"globalCommunity": "Global AWS User Group Community",
-		"communityFullDescription": "We are run by volunteers local to New Mexico, West Texas & Chihuahua, Mexico. We believe projects, careers & issues can be accelerated using AWS, & wish to pass our knowledge, connections & experiences on to you & see what you",
+		"communityFullDescription": "We are run by volunteers local to New Mexico, West Texas & Chihuahua, Mexico. We believe projects, careers & issues can be accelerated using AWS, & wish to pass our knowledge, connections & experiences on to you & see what you build.",
 		"goBuild": "Go Build"
 	},
 	"aboutPage": {

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -49,7 +49,7 @@
 		"joinUs": "Únete en Meetup →",
 		"communityDescription": "AWS User Group Nube of the North es parte de",
 		"globalCommunity": "Comunidad Global de AWS User Groups",
-		"communityFullDescription": "Somos voluntarios locales de Nuevo México, West Texas y Chihuahua, México. Creemos que los proyectos, las carreras y los problemas se pueden acelerar usando AWS, y queremos compartir nuestro conocimiento, conexiones y experiencias contigo para que veas lo que tú puedes",
+		"communityFullDescription": "Somos voluntarios locales de Nuevo México, West Texas y Chihuahua, México. Creemos que los proyectos, las carreras y los problemas se pueden acelerar usando AWS, y queremos compartir nuestro conocimiento, conexiones y experiencias contigo para que veas lo que tú puedes armar.",
 		"goBuild": "Go Build"
 	},
 	"aboutPage": {


### PR DESCRIPTION
Both footer.communityFullDescription strings truncated mid-sentence. Closed via:
- en-US: append 'build.' (matches 'Go Build' footer theme)
- es-MX: append 'armar.' (norteño verb, matches wave 47 tone)

biome 0 / tsc 0 NEW / build PASS / vitest 781 PASS.