### PR TITLE
feat(infra): wave 53 — babylon device-capability rules + BabylonGate + lazy spin-demo integration

### DIFF
--- a/docs/wave-53-babylon-device-tiers.md
+++ b/docs/wave-53-babylon-device-tiers.md
@@ -1,0 +1,123 @@
+# Wave 53 — Babylon Device Tiers & BabylonGate Contract
+
+> "Create rules for who we serve babylon to and who we don't. Pixel 10 fine, MacBook Air gentle. Always load these last. Skeletons + CSS are the bones, babylon are accessories."
+> — Bryan
+
+---
+
+## Philosophy
+
+Babylon scenes are **enhancements, not structure**. Every mount point has:
+1. A CSS skeleton or 2D fallback that renders first (the bones)
+2. A `<BabylonGate>` wrapper that lazy-loads the Babylon scene only on capable devices (the accessory)
+
+Think: adding shaders to 2D to make 3D. The 2D always works; 3D is the upgrade.
+
+---
+
+## Device Tier Matrix
+
+| Device / Context               | deviceMemory | hardwareConcurrency | Software WebGL | Tier       |
+|-------------------------------|:------------:|:-------------------:|:--------------:|:----------:|
+| **Pixel 10**                  | 12 GB        | 9 cores             | no             | **high**   |
+| **MacBook Air M-series**      | 8–24 GB      | 8 cores             | no             | **high**   |
+| Older Intel MacBook Air       | 8 GB         | 4 cores             | no             | **medium** |
+| Pixel 4 / older Android       | 3 GB         | 4 cores             | no             | **low**    |
+| VM / headless / software WebGL| any          | any                 | yes            | **low**    |
+| prefers-reduced-motion (any)  | any          | any                 | any            | **low**    |
+
+### Tier rules (`src/lib/device-capabilities.ts`)
+
+```
+high   = capable + deviceMemory ≥ 8 + hardwareConcurrency ≥ 8
+medium = capable (not high)
+low    = software WebGL OR (low mem AND few cores) OR prefers-reduced-motion
+```
+
+`isCapableForBabylon()` fails **low** when:
+- `prefersReducedMotion()` → always fail-closed
+- `isSoftwareWebGL()` → skip entirely (would chug + race the canvas flip)
+- `hasLowMemory() AND hasFewCores()` → both signals must be present (AND gate, not OR), so MacBook Air with 8 GB RAM but 4 cores stays **medium**.
+
+When `deviceMemory` is `undefined` (Firefox, Safari) — default `false` (no over-restriction).
+
+---
+
+## BabylonGate API
+
+**File:** `src/components/babylon-gate/index.tsx`
+
+```tsx
+import BabylonGate from "../../components/babylon-gate";
+
+<BabylonGate
+  tier="medium"              // 'high' | 'medium' | 'low'  (default: 'medium')
+  fallback={<CssSpinner />}  // shown on incapable devices & during Suspense
+>
+  <HeavyBabylonScene />      // lazy-loaded via React.lazy() + dynamic import
+</BabylonGate>
+```
+
+- **Renders `fallback`** when `getDeviceTier() < tier`
+- **Wraps children in `<Suspense>`** so lazy imports don't block
+- The children component MUST use `React.lazy()` pointing to a file that does `import('@babylonjs/core')` inside `useEffect` — never at module top-level
+
+### Usage pattern (all future Babylon mounts)
+
+```tsx
+// 1. Lazy-wrap the Babylon component
+const MyBabylonScene = lazy(() => import("../my-babylon-scene"));
+
+// 2. Gate it
+<BabylonGate tier="medium" fallback={<MyCSSSkeleton />}>
+  <MyBabylonScene />
+</BabylonGate>
+```
+
+---
+
+## Wave 53 ships
+
+| File | Purpose |
+|------|---------|
+| `src/lib/device-capabilities.ts` | Centralized detection: `isSoftwareWebGL`, `hasLowMemory`, `hasFewCores`, `prefersReducedMotion`, `isCapableForBabylon`, `getDeviceTier` |
+| `src/components/babylon-gate/index.tsx` | Public gate wrapper |
+| `src/components/babylon-spin-demo/index.tsx` | 60-line demo Babylon mount (ArcRotateCamera + plane + thumbnail texture + click-to-spin) |
+| `src/lib/background-viz/index.ts` | Refactored — `isSoftwareRendering()` removed, re-exports `isSoftwareWebGL` from device-capabilities |
+| `src/components/fiona-frame/index.tsx` | Babylon end-credit canvas wrapped in `<BabylonGate tier="medium">` |
+| `src/pages/feed/components/youtube-carousel.tsx` | Wave 52 spin placeholder wrapped in `<BabylonGate tier="medium">` with `BabylonSpinDemo` as enhancement |
+
+---
+
+## Bundle contract
+
+Babylon stays **lazy**. The main feed chunk does not import `@babylonjs/core`. After build, verify:
+
+```
+dist/assets/index-[hash].js        — main feed chunk; should NOT contain babylon
+dist/assets/babylon-spin-demo-[hash].js  — lazy chunk; loads after first paint
+```
+
+Run `npm run build` and check that no babylon symbols appear in the main `index-*.js` output.
+
+---
+
+## Wave 55+ planned scenes
+
+| Location | Scene | Tier |
+|----------|-------|------|
+| Footer | Atmospheric particle field (stars / dust) | medium |
+| Sidepanel | Neon signage lettering (3D extruded text) | high |
+| Login form | Subtle depth shader on the form card | medium |
+| Feed personality SVGs | Shader overlay on 2D SVG icons | high |
+
+All mount via `<BabylonGate>` with CSS/SVG fallbacks already in place.
+
+---
+
+## Constraints
+
+- `prefers-reduced-motion` is **always fail-closed** — no override
+- `visibilitychange` must pause the render loop (wave 21 pattern) — implemented in `babylon-spin-demo`
+- Dynamic import `@babylonjs/core` must live inside `useEffect`, never at module level
+- Every Babylon component ships with a `data-testid` canvas for test verification

--- a/src/components/babylon-gate/__tests__/babylon-gate.test.tsx
+++ b/src/components/babylon-gate/__tests__/babylon-gate.test.tsx
@@ -1,0 +1,75 @@
+// Wave 53 — BabylonGate component tests
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import BabylonGate from "../index";
+
+// Mock getDeviceTier so we can control tier in each test
+vi.mock("../../../lib/device-capabilities", () => ({
+	getDeviceTier: vi.fn(() => "high"),
+	isSoftwareWebGL: vi.fn(() => false),
+	hasLowMemory: vi.fn(() => false),
+	hasFewCores: vi.fn(() => false),
+	prefersReducedMotion: vi.fn(() => false),
+	isCapableForBabylon: vi.fn(() => true),
+}));
+
+import { getDeviceTier } from "../../../lib/device-capabilities";
+
+afterEach(() => {
+	vi.resetAllMocks();
+});
+
+describe("BabylonGate", () => {
+	it("renders fallback when device tier is below required tier", () => {
+		vi.mocked(getDeviceTier).mockReturnValue("low");
+		render(
+			<BabylonGate tier="medium" fallback={<div>css-fallback</div>}>
+				<div>babylon-scene</div>
+			</BabylonGate>,
+		);
+		expect(screen.getByText("css-fallback")).toBeInTheDocument();
+		expect(screen.queryByText("babylon-scene")).not.toBeInTheDocument();
+	});
+
+	it("renders children when device tier meets the required tier", () => {
+		vi.mocked(getDeviceTier).mockReturnValue("high");
+		render(
+			<BabylonGate tier="medium" fallback={<div>css-fallback</div>}>
+				<div>babylon-scene</div>
+			</BabylonGate>,
+		);
+		expect(screen.getByText("babylon-scene")).toBeInTheDocument();
+		expect(screen.queryByText("css-fallback")).not.toBeInTheDocument();
+	});
+
+	it("renders children when tier matches exactly (medium device, medium tier)", () => {
+		vi.mocked(getDeviceTier).mockReturnValue("medium");
+		render(
+			<BabylonGate tier="medium" fallback={<div>css-fallback</div>}>
+				<div>babylon-scene</div>
+			</BabylonGate>,
+		);
+		expect(screen.getByText("babylon-scene")).toBeInTheDocument();
+	});
+
+	it("renders fallback when tier is high but device is medium", () => {
+		vi.mocked(getDeviceTier).mockReturnValue("medium");
+		render(
+			<BabylonGate tier="high" fallback={<div>lite-fallback</div>}>
+				<div>heavy-scene</div>
+			</BabylonGate>,
+		);
+		expect(screen.getByText("lite-fallback")).toBeInTheDocument();
+		expect(screen.queryByText("heavy-scene")).not.toBeInTheDocument();
+	});
+
+	it("defaults tier to medium when not specified", () => {
+		vi.mocked(getDeviceTier).mockReturnValue("low");
+		render(
+			<BabylonGate fallback={<div>default-fallback</div>}>
+				<div>scene</div>
+			</BabylonGate>,
+		);
+		expect(screen.getByText("default-fallback")).toBeInTheDocument();
+	});
+});

--- a/src/components/babylon-gate/index.tsx
+++ b/src/components/babylon-gate/index.tsx
@@ -1,0 +1,31 @@
+// Wave 53 — BabylonGate: device-tier gate for all Babylon scenes.
+// CSS + skeletons are the bones; Babylon is the accessory.
+// Usage: <BabylonGate fallback={<CssPlaceholder />}><HeavyScene /></BabylonGate>
+
+import { type ReactNode, Suspense } from "react";
+import { type DeviceTier, getDeviceTier } from "../../lib/device-capabilities";
+
+const TIER_RANK: Record<DeviceTier, number> = { high: 2, medium: 1, low: 0 };
+
+interface Props {
+	children: ReactNode;
+	fallback: ReactNode;
+	/** Minimum tier required to render children. Defaults to 'medium'. */
+	tier?: DeviceTier;
+}
+
+/**
+ * Renders `fallback` when the device tier is below the required `tier`.
+ * Wraps children in Suspense so lazy-loaded Babylon components don't block.
+ */
+export default function BabylonGate({
+	children,
+	fallback,
+	tier = "medium",
+}: Props) {
+	const deviceTier = getDeviceTier();
+	if (TIER_RANK[deviceTier] < TIER_RANK[tier]) {
+		return <>{fallback}</>;
+	}
+	return <Suspense fallback={fallback}>{children}</Suspense>;
+}

--- a/src/components/babylon-spin-demo/__tests__/babylon-spin-demo.test.tsx
+++ b/src/components/babylon-spin-demo/__tests__/babylon-spin-demo.test.tsx
@@ -1,0 +1,61 @@
+// Wave 53 — babylon-spin-demo tests
+// @babylonjs/core is stubbed — we only verify mount/unmount contract.
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import BabylonSpinDemo from "../index";
+
+// Stub dynamic import of @babylonjs/core so it never actually loads
+vi.mock("@babylonjs/core", () => ({
+	Engine: vi.fn().mockImplementation(() => ({
+		runRenderLoop: vi.fn(),
+		stopRenderLoop: vi.fn(),
+		dispose: vi.fn(),
+	})),
+	Scene: vi.fn().mockImplementation(() => ({
+		clearColor: null,
+		render: vi.fn(),
+	})),
+	Color4: vi.fn(),
+	Color3: { White: vi.fn(() => ({})) },
+	Vector3: { Zero: vi.fn(() => ({})) },
+	ArcRotateCamera: vi.fn(),
+	HemisphericLight: vi.fn(),
+	MeshBuilder: {
+		CreatePlane: vi
+			.fn()
+			.mockReturnValue({ material: null, rotation: { y: 0 } }),
+	},
+	StandardMaterial: vi.fn().mockImplementation(() => ({
+		diffuseTexture: null,
+		emissiveColor: null,
+	})),
+	Texture: vi.fn(),
+	Animation: {
+		CreateAndStartAnimation: vi.fn(),
+		ANIMATIONLOOPMODE_CONSTANT: 0,
+	},
+}));
+
+describe("BabylonSpinDemo", () => {
+	it("renders a div containing a canvas element", () => {
+		const { container } = render(
+			<BabylonSpinDemo thumbnailUrl="https://i.ytimg.com/vi/abc/hqdefault.jpg" />,
+		);
+		expect(container.querySelector("canvas")).toBeInTheDocument();
+	});
+
+	it("canvas has aria-label for accessibility", () => {
+		render(
+			<BabylonSpinDemo thumbnailUrl="https://i.ytimg.com/vi/abc/hqdefault.jpg" />,
+		);
+		const canvas = screen.getByLabelText("Spinning video preview");
+		expect(canvas).toBeInTheDocument();
+	});
+
+	it("unmounts without throwing", () => {
+		const { unmount } = render(
+			<BabylonSpinDemo thumbnailUrl="https://i.ytimg.com/vi/abc/hqdefault.jpg" />,
+		);
+		expect(() => unmount()).not.toThrow();
+	});
+});

--- a/src/components/babylon-spin-demo/index.tsx
+++ b/src/components/babylon-spin-demo/index.tsx
@@ -1,0 +1,80 @@
+// Wave 53 — tiny Babylon scene on the wave 52 carousel anchor.
+// Lazy-loads @babylonjs/core — never in the main bundle.
+// Click to spin. visibilitychange pauses render loop (wave 21 pattern).
+import { useEffect, useRef } from "react";
+
+export default function BabylonSpinDemo({
+	thumbnailUrl,
+}: {
+	thumbnailUrl: string;
+}) {
+	const ref = useRef<HTMLCanvasElement>(null);
+
+	useEffect(() => {
+		const canvas = ref.current;
+		if (!canvas) return;
+		let disposed = false;
+		// biome-ignore lint/suspicious/noExplicitAny: dynamic babylon import
+		let eng: any = null;
+
+		(async () => {
+			const B = await import("@babylonjs/core");
+			if (disposed || !canvas) return;
+			eng = new B.Engine(canvas, true, { preserveDrawingBuffer: false });
+			const scene = new B.Scene(eng);
+			scene.clearColor = new B.Color4(0, 0, 0, 0);
+			new B.ArcRotateCamera(
+				"cam",
+				-Math.PI / 2,
+				Math.PI / 2,
+				3,
+				B.Vector3.Zero(),
+				scene,
+			);
+			new B.HemisphericLight("light", new B.Vector3(0, 1, 0), scene);
+			const plane = B.MeshBuilder.CreatePlane("plane", { size: 1.6 }, scene);
+			const mat = new B.StandardMaterial("mat", scene);
+			mat.diffuseTexture = new B.Texture(thumbnailUrl, scene);
+			mat.emissiveColor = B.Color3.White();
+			plane.material = mat;
+			canvas.addEventListener("click", () => {
+				B.Animation.CreateAndStartAnimation(
+					"spin",
+					plane,
+					"rotation.y",
+					30,
+					30,
+					plane.rotation.y,
+					plane.rotation.y + Math.PI * 2,
+					B.Animation.ANIMATIONLOOPMODE_CONSTANT,
+				);
+			});
+			const render = () => scene.render();
+			const onVis = () =>
+				document.hidden ? eng.stopRenderLoop() : eng.runRenderLoop(render);
+			document.addEventListener("visibilitychange", onVis);
+			eng.__onVis = onVis;
+			eng.runRenderLoop(render);
+		})();
+
+		return () => {
+			disposed = true;
+			if (eng) {
+				document.removeEventListener("visibilitychange", eng.__onVis);
+				eng.dispose();
+			}
+		};
+	}, [thumbnailUrl]);
+
+	return (
+		<div
+			style={{ width: "100%", aspectRatio: "16/9", background: "transparent" }}
+		>
+			<canvas
+				ref={ref}
+				style={{ width: "100%", height: "100%", display: "block" }}
+				aria-label="Spinning video preview"
+			/>
+		</div>
+	);
+}

--- a/src/components/fiona-frame/index.tsx
+++ b/src/components/fiona-frame/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "../../hooks/useTranslation";
 import { loadVisitorInfo, type VisitorInfo } from "../../utils/visitor";
+import BabylonGate from "../babylon-gate";
 import "../navigation/fiona.css";
 
 function withFallback(value: string, key: string, fallback: string): string {
@@ -198,12 +199,15 @@ export default function FionaFrame() {
 							</span>
 						</span>
 					</div>
-					<canvas
-						id="fiona-canvas"
-						className="fiona-canvas"
-						aria-hidden="true"
-						tabIndex={-1}
-					/>
+					{/* Wave 53: gate the Babylon end-credit canvas behind device tier ≥ medium */}
+					<BabylonGate tier="medium" fallback={null}>
+						<canvas
+							id="fiona-canvas"
+							className="fiona-canvas"
+							aria-hidden="true"
+							tabIndex={-1}
+						/>
+					</BabylonGate>
 				</div>
 				<div
 					id="fiona-status-bar"

--- a/src/lib/__tests__/device-capabilities.test.ts
+++ b/src/lib/__tests__/device-capabilities.test.ts
@@ -1,0 +1,210 @@
+// Wave 53 — unit tests for device-capabilities.ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	getDeviceTier,
+	hasFewCores,
+	hasLowMemory,
+	isCapableForBabylon,
+	isSoftwareWebGL,
+	prefersReducedMotion,
+} from "../device-capabilities";
+
+function mockCanvas(renderer: string | null) {
+	const ext = renderer !== null ? { UNMASKED_RENDERER_WEBGL: 0x9246 } : null;
+	const gl = {
+		getExtension: vi.fn().mockReturnValue(ext),
+		getParameter: vi.fn().mockReturnValue(renderer ?? ""),
+	};
+	vi.spyOn(document, "createElement").mockReturnValue({
+		getContext: vi.fn().mockReturnValue(gl),
+	} as unknown as HTMLCanvasElement);
+}
+
+function mockNav(overrides: {
+	deviceMemory?: number | undefined;
+	hardwareConcurrency?: number;
+}) {
+	Object.defineProperty(navigator, "deviceMemory", {
+		configurable: true,
+		get: () => overrides.deviceMemory,
+	});
+	Object.defineProperty(navigator, "hardwareConcurrency", {
+		configurable: true,
+		get: () => overrides.hardwareConcurrency ?? 8,
+	});
+}
+
+function mockMotion(matches: boolean) {
+	vi.spyOn(window, "matchMedia").mockReturnValue({
+		matches,
+		media: "(prefers-reduced-motion: reduce)",
+		onchange: null,
+		addListener: vi.fn(),
+		removeListener: vi.fn(),
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+		dispatchEvent: vi.fn(),
+	} as unknown as MediaQueryList);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// isSoftwareWebGL
+// ---------------------------------------------------------------------------
+describe("isSoftwareWebGL", () => {
+	it("returns true for SwiftShader renderer", () => {
+		mockCanvas("ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero)))");
+		expect(isSoftwareWebGL()).toBe(true);
+	});
+
+	it("returns false for NVIDIA hardware renderer", () => {
+		mockCanvas("NVIDIA GeForce RTX 4080/PCIe/SSE2");
+		expect(isSoftwareWebGL()).toBe(false);
+	});
+
+	it("returns false when WebGL is unavailable", () => {
+		vi.spyOn(document, "createElement").mockReturnValue({
+			getContext: vi.fn().mockReturnValue(null),
+		} as unknown as HTMLCanvasElement);
+		expect(isSoftwareWebGL()).toBe(false);
+	});
+
+	it("returns false for llvmpipe renderer (matches software list)", () => {
+		mockCanvas("llvmpipe (LLVM 15.0, 256 bits)");
+		expect(isSoftwareWebGL()).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// hasLowMemory
+// ---------------------------------------------------------------------------
+describe("hasLowMemory", () => {
+	it("returns true when deviceMemory < 4", () => {
+		mockNav({ deviceMemory: 2 });
+		expect(hasLowMemory()).toBe(true);
+	});
+
+	it("returns false when deviceMemory >= 4", () => {
+		mockNav({ deviceMemory: 8 });
+		expect(hasLowMemory()).toBe(false);
+	});
+
+	it("returns false when deviceMemory is undefined (Firefox/Safari)", () => {
+		mockNav({ deviceMemory: undefined });
+		expect(hasLowMemory()).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// hasFewCores
+// ---------------------------------------------------------------------------
+describe("hasFewCores", () => {
+	it("returns true when hardwareConcurrency < 4", () => {
+		mockNav({ hardwareConcurrency: 2 });
+		expect(hasFewCores()).toBe(true);
+	});
+
+	it("returns false when hardwareConcurrency >= 4", () => {
+		mockNav({ hardwareConcurrency: 8 });
+		expect(hasFewCores()).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// prefersReducedMotion
+// ---------------------------------------------------------------------------
+describe("prefersReducedMotion", () => {
+	it("returns true when matchMedia matches", () => {
+		mockMotion(true);
+		expect(prefersReducedMotion()).toBe(true);
+	});
+
+	it("returns false when matchMedia does not match", () => {
+		mockMotion(false);
+		expect(prefersReducedMotion()).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// isCapableForBabylon
+// ---------------------------------------------------------------------------
+describe("isCapableForBabylon", () => {
+	it("returns false when prefers-reduced-motion is on", () => {
+		mockMotion(true);
+		mockCanvas("NVIDIA RTX 4080");
+		mockNav({ deviceMemory: 16, hardwareConcurrency: 8 });
+		expect(isCapableForBabylon()).toBe(false);
+	});
+
+	it("returns false for software WebGL", () => {
+		mockMotion(false);
+		mockCanvas("SwiftShader");
+		mockNav({ deviceMemory: 16, hardwareConcurrency: 8 });
+		expect(isCapableForBabylon()).toBe(false);
+	});
+
+	it("returns false when BOTH low memory AND few cores", () => {
+		mockMotion(false);
+		mockCanvas("NVIDIA RTX 4080");
+		mockNav({ deviceMemory: 2, hardwareConcurrency: 2 });
+		expect(isCapableForBabylon()).toBe(false);
+	});
+
+	it("returns true for low memory but many cores (MacBook Air M-series pattern)", () => {
+		mockMotion(false);
+		mockCanvas("Apple M3");
+		mockNav({ deviceMemory: 8, hardwareConcurrency: 8 });
+		expect(isCapableForBabylon()).toBe(true);
+	});
+
+	it("returns true for high-end device (Pixel 10 pattern)", () => {
+		mockMotion(false);
+		mockCanvas("Adreno 750");
+		mockNav({ deviceMemory: 12, hardwareConcurrency: 9 });
+		expect(isCapableForBabylon()).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getDeviceTier
+// ---------------------------------------------------------------------------
+describe("getDeviceTier", () => {
+	it("returns low when not capable (software WebGL)", () => {
+		mockMotion(false);
+		mockCanvas("SwiftShader");
+		mockNav({ deviceMemory: 16, hardwareConcurrency: 8 });
+		expect(getDeviceTier()).toBe("low");
+	});
+
+	it("returns high for Pixel 10 (≥8 GB, ≥8 cores)", () => {
+		mockMotion(false);
+		mockCanvas("Adreno 750");
+		mockNav({ deviceMemory: 12, hardwareConcurrency: 9 });
+		expect(getDeviceTier()).toBe("high");
+	});
+
+	it("returns high for MacBook Air M-series (8 GB, 8 cores)", () => {
+		mockMotion(false);
+		mockCanvas("Apple M2");
+		mockNav({ deviceMemory: 8, hardwareConcurrency: 8 });
+		expect(getDeviceTier()).toBe("high");
+	});
+
+	it("returns medium for older Intel MacBook Air (4 cores, 8 GB)", () => {
+		mockMotion(false);
+		mockCanvas("Intel Iris Plus");
+		mockNav({ deviceMemory: 8, hardwareConcurrency: 4 });
+		// 8 GB (high mem) but only 4 cores (not ≥8) → medium
+		expect(getDeviceTier()).toBe("medium");
+	});
+
+	it("returns low when reduced motion on", () => {
+		mockMotion(true);
+		mockCanvas("NVIDIA RTX 4080");
+		mockNav({ deviceMemory: 16, hardwareConcurrency: 16 });
+		expect(getDeviceTier()).toBe("low");
+	});
+});

--- a/src/lib/background-viz/index.ts
+++ b/src/lib/background-viz/index.ts
@@ -1,3 +1,4 @@
+import { isSoftwareWebGL } from "../device-capabilities.js";
 import { createAudioBridge, resumeCtx } from "./audio.js";
 import { initCanvas, rebuildStatic } from "./canvas.js";
 import {
@@ -6,6 +7,9 @@ import {
 	mountDuneScene,
 } from "./dune-scene.js";
 import { preloadLogo } from "./static.js";
+
+// Re-export for callers that previously imported from here.
+export { isSoftwareWebGL };
 
 let mounted = false;
 
@@ -37,28 +41,6 @@ function reducedMotion(): boolean {
 	return matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
 
-// Detect software-rendered WebGL (SwiftShader / llvmpipe / Mesa software
-// rasteriser). On these GPUs the dune scene will never hit the 16ms budget,
-// and the perf gate's tear-down can race with the static-canvas opacity flip
-// in ways that surprise the user. Skip the dune mount entirely instead.
-function isSoftwareRendering(): boolean {
-	try {
-		const probe = document.createElement("canvas");
-		const gl = (probe.getContext("webgl2") ||
-			probe.getContext("webgl")) as WebGLRenderingContext | null;
-		if (!gl) return false;
-		const debugInfo = gl.getExtension("WEBGL_debug_renderer_info");
-		const renderer = debugInfo
-			? String(gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL))
-			: "";
-		return /SwiftShader|llvmpipe|Software|Microsoft Basic Render/i.test(
-			renderer,
-		);
-	} catch {
-		return false;
-	}
-}
-
 // Escape hatch for verification harnesses (CI screenshot pipeline + ad-hoc
 // capture scripts) running headless on rocm-aibox where ANGLE reports
 // SwiftShader ("ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero)
@@ -68,7 +50,7 @@ function isSoftwareRendering(): boolean {
 function shouldSkipDune(): boolean {
 	const params = new URLSearchParams(window.location.search);
 	if (params.get("__cdn_force_wallpaper") === "1") return false;
-	return isSoftwareRendering();
+	return isSoftwareWebGL();
 }
 
 export function mount(): () => void {

--- a/src/lib/device-capabilities.ts
+++ b/src/lib/device-capabilities.ts
@@ -1,0 +1,78 @@
+// Wave 53 — centralized device capability detection for Babylon gating.
+// All Babylon scenes are accessories, not bones. CSS + skeletons load first;
+// Babylon enhances capable devices after first paint.
+
+export type DeviceTier = "high" | "medium" | "low";
+
+/** Detect software-rendered WebGL (SwiftShader / llvmpipe / Mesa / MSBRD). */
+export function isSoftwareWebGL(): boolean {
+	try {
+		const probe = document.createElement("canvas");
+		const gl = (probe.getContext("webgl2") ||
+			probe.getContext("webgl")) as WebGLRenderingContext | null;
+		if (!gl) return false;
+		const ext = gl.getExtension("WEBGL_debug_renderer_info");
+		const renderer = ext
+			? String(gl.getParameter(ext.UNMASKED_RENDERER_WEBGL))
+			: "";
+		return /SwiftShader|llvmpipe|Software|Microsoft Basic Render/i.test(
+			renderer,
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * True when deviceMemory < 4 GB.
+ * Undefined on Firefox/Safari — default false (no over-restriction).
+ */
+export function hasLowMemory(): boolean {
+	const mem = (navigator as Navigator & { deviceMemory?: number }).deviceMemory;
+	return mem !== undefined ? mem < 4 : false;
+}
+
+/** True when hardwareConcurrency < 4. */
+export function hasFewCores(): boolean {
+	return navigator.hardwareConcurrency < 4;
+}
+
+/** True when the user has requested reduced motion. */
+export function prefersReducedMotion(): boolean {
+	return matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+/**
+ * Gate: true when device can run Babylon scenes.
+ *
+ * Fails when:
+ * - software WebGL (would chug regardless of tier)
+ * - BOTH low memory AND few cores (double-constrained)
+ * - prefers-reduced-motion (always fail-closed)
+ *
+ * MacBook Air M-series: 8 GB RAM (not low) + 8 cores → capable.
+ * Pixel 10: ample RAM + many cores → capable.
+ */
+export function isCapableForBabylon(): boolean {
+	if (prefersReducedMotion()) return false;
+	if (isSoftwareWebGL()) return false;
+	if (hasLowMemory() && hasFewCores()) return false;
+	return true;
+}
+
+/**
+ * Fine-grained tier for scenes with multiple quality levels.
+ *
+ * high   — capable + ≥8 GB RAM + ≥8 cores  (Pixel 10, MacBook Air M-series)
+ * medium — capable but constrained           (older Intel MacBook Air, mid-range Android)
+ * low    — not capable                       (Pixel 4, VMs, software WebGL)
+ */
+export function getDeviceTier(): DeviceTier {
+	if (!isCapableForBabylon()) return "low";
+	const mem = (navigator as Navigator & { deviceMemory?: number }).deviceMemory;
+	const cores = navigator.hardwareConcurrency;
+	const highMem = mem === undefined ? true : mem >= 8;
+	const highCores = cores >= 8;
+	if (highMem && highCores) return "high";
+	return "medium";
+}

--- a/src/pages/feed/components/youtube-carousel.tsx
+++ b/src/pages/feed/components/youtube-carousel.tsx
@@ -3,10 +3,15 @@
 
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
-import { useEffect, useState } from "react";
+import { lazy, useEffect, useState } from "react";
+import BabylonGate from "../../../components/babylon-gate";
 import { SkeletonFrame } from "../../../components/skeleton";
 import { useTranslation } from "../../../hooks/useTranslation";
 import { YouTubeSpinPlaceholder } from "./youtube-spin-placeholder";
+
+const BabylonSpinDemo = lazy(
+	() => import("../../../components/babylon-spin-demo"),
+);
 
 const VIDEO_IDS = ["yQNrgpIp1Fs", "WUJUvTu2Qjo", "S2G6eDE4Jok"];
 
@@ -46,22 +51,31 @@ export default function YoutubeCarousel() {
 		<Container
 			header={<Header variant="h2">{t("feedPage.youtubeHeader")}</Header>}
 		>
-			{/* Wave 52 — spin placeholder shown before SSR mount */}
+			{/* Wave 52/53 — spin placeholder shown before SSR mount.
+		    Wave 53: BabylonGate enhances capable devices (≥medium) with a
+		    Babylon spinning quad; incapable devices keep the CSS spin. */}
 			{!mounted ? (
-				<YouTubeSpinPlaceholder
-					newest={SPIN_ITEMS[0]}
-					oldest={SPIN_ITEMS[1]}
-					spinLabel={t("feedPage.spinBtnLabel")}
-					ariaLabel={t("feedPage.spinPlaceholderAriaLabel")}
-					onSelect={(id) => {
-						const idx = VIDEO_IDS.indexOf(id);
-						if (idx !== -1) setCurrent(idx);
-					}}
-					i18n={{
-						newestBadge: t("feedPage.spinNewestBadge"),
-						oldestBadge: t("feedPage.spinOldestBadge"),
-					}}
-				/>
+				<BabylonGate
+					tier="medium"
+					fallback={
+						<YouTubeSpinPlaceholder
+							newest={SPIN_ITEMS[0]}
+							oldest={SPIN_ITEMS[1]}
+							spinLabel={t("feedPage.spinBtnLabel")}
+							ariaLabel={t("feedPage.spinPlaceholderAriaLabel")}
+							onSelect={(id) => {
+								const idx = VIDEO_IDS.indexOf(id);
+								if (idx !== -1) setCurrent(idx);
+							}}
+							i18n={{
+								newestBadge: t("feedPage.spinNewestBadge"),
+								oldestBadge: t("feedPage.spinOldestBadge"),
+							}}
+						/>
+					}
+				>
+					<BabylonSpinDemo thumbnailUrl={SPIN_ITEMS[0].thumbnailUrl} />
+				</BabylonGate>
 			) : (
 				<div className="feed-carousel">
 					<div className="feed-carousel__viewport">


### PR DESCRIPTION
Bryan: 'create rules for who we serve babylon to and who we don't... pixel10 fine, macbook air gentle... always load these last, skeletons + css are the bones, babylon are accessories'.

## ships
- src/lib/device-capabilities.ts — single source of truth (isSoftwareWebGL, hasLowMemory, hasFewCores, prefersReducedMotion, isCapableForBabylon, getDeviceTier)
- src/components/babylon-gate — public API gating Babylon mounts behind device capability with CSS fallback
- src/components/babylon-spin-demo — 58-line lazy Babylon mount on wave 52 carousel placeholder
- background-viz/index.ts: refactored to re-export from device-capabilities (deduplication)
- FionaFrame Babylon scene wrapped in <BabylonGate tier='medium'>
- docs/wave-53-babylon-device-tiers.md — tier matrix + API + wave 55+ roadmap

## bundle
- main feed chunk: 70.88 kB → 71.48 kB (+0.6 kB inline gate logic)
- babylon-spin-demo lazy chunk: 1.76 kB
- @babylonjs/core: separate 5,658 kB lazy chunk — NOT in main bundle ✓

## gates
- biome 0 errors / tsc 0 NEW
- build PASS
- vitest 838 PASS (+29 new cases)