### PR TITLE
chore(qa): wave 54 — nova act RSVP flow validation surfaced P1 redirect bug

### DIFF
--- a/docs/wave-54-nova-act-rsvp-qa.md
+++ b/docs/wave-54-nova-act-rsvp-qa.md
@@ -1,0 +1,93 @@
+# Wave 54 — Nova Act RSVP Flow Validation Results
+
+**Date:** 2026-05-20T19:04–19:18 UTC  
+**Branch:** `chore/wave-54-nova-act-rsvp-qa`  
+**Bryan EOS goal:** "ensure a first time visitor can click on the wedns june 3 event, be guided through the signup process & come out with confirmation of their registration for the event"
+
+## Summary
+
+| Test | Status | Reason |
+|------|--------|--------|
+| A — existing-user RSVP | **BLOCKED** | Login succeeds but `return_to` redirect to RSVP completion page does not fire — user lands on awsug.clouddelnorte.org home instead |
+| B — new-user signup + RSVP | **BLOCKED** | Signup form submit button not triggered (Nova Act agent confused navigation link with submit CTA); user never created in Cognito |
+
+## Critical Finding: return_to Redirect Broken
+
+Both tests confirm the RSVP CTA on the feed page works correctly:
+- Clicking "RSVP on CloudDelNorte.org" redirects to `auth.clouddelnorte.org/signup/index.html?return_to=%2Frsvp%2F%3Fevent%3Dhappy-hour-2026-06-03`
+
+**However, after successful authentication, the `return_to=/rsvp/?event=happy-hour-2026-06-03` parameter is NOT honored.** The user is redirected to `awsug.clouddelnorte.org/index.html` instead of the RSVP completion page.
+
+This means: **no first-time visitor can currently complete the RSVP flow end-to-end via the auth redirect path.**
+
+## Test A — Existing User (heraldstack@clouddelnorte.org)
+
+### Flow Observed
+1. ✅ Opened `https://clouddelnorte.org/feed/` — feed rendered with Featured Event card
+2. ✅ Clicked "RSVP on CloudDelNorte.org" → redirected to `auth.clouddelnorte.org/signup/index.html?return_to=%2Frsvp%2F%3Fevent%3Dhappy-hour-2026-06-03`
+3. ✅ Navigated to Sign In page, entered email + password
+4. ✅ Login succeeded — no MFA challenge
+5. ❌ **Redirected to `awsug.clouddelnorte.org/index.html`** instead of RSVP confirmation
+6. ❌ No QR code visible (never reached RSVP confirmation page)
+7. ❌ Spots unchanged: 0 taken before and after
+
+### Backend Verification
+```json
+{"eventId": "happy-hour-2026-06-03", "capacity": 50, "taken": 0, "remaining": 50}
+```
+No delta — RSVP was never completed.
+
+### Screenshots
+| File | Description |
+|------|-------------|
+| `/tmp/wave-54-existing/01-feed-anon.png` | Feed page with Featured Event card visible |
+| `/tmp/wave-54-existing/02-rsvp-confirm.png` | Post-login page (awsug home, NOT RSVP confirmation) |
+| `/tmp/wave-54-existing/block-login.png` | Earlier run: login button click timeout (fixed in subsequent run) |
+
+## Test B — New User (heraldstack+novaact-1779304484@clouddelnorte.org)
+
+### Flow Observed
+1. ✅ Opened feed, clicked RSVP CTA → redirected to signup page
+2. ✅ Entered email in signup form
+3. ✅ Entered display name "Nova Act-Test"
+4. ✅ Password filled via Playwright `page.fill()`
+5. ❌ **Submit button not clicked** — Nova Act agent confused "Sign in" nav link with the form submit button, navigated away from signup form
+6. ❌ User never created in Cognito → `admin-confirm-sign-up` returned UserNotFoundException
+7. ❌ Cleanup: no user to delete (never created)
+
+### Backend Verification
+```json
+{"eventId": "happy-hour-2026-06-03", "capacity": 50, "taken": 0, "remaining": 50}
+```
+No delta.
+
+### Screenshots
+| File | Description |
+|------|-------------|
+| `/tmp/wave-54-new/01-signup-pending.png` | Signup form state after agent interaction (form not submitted) |
+
+### Credentials (for reference — user was never created)
+- Email: `heraldstack+novaact-1779304484@clouddelnorte.org`
+- Password: `Fd1#9gHHHUWWN8`
+
+## Blocks & Recommendations
+
+### Block 1: `return_to` parameter not honored after auth
+**Severity:** P1 — breaks the entire RSVP-via-auth flow  
+**Location:** Auth app redirect logic (likely in `auth.clouddelnorte.org` post-login handler)  
+**Expected:** After login/signup, redirect to `/rsvp/?event=happy-hour-2026-06-03`  
+**Actual:** Redirects to `awsug.clouddelnorte.org/index.html`
+
+### Block 2: Signup form submit button UX
+**Severity:** P2 — AI agent (and possibly users) cannot easily identify the submit CTA  
+**Observation:** The Nova Act agent scrolled looking for a "Create account" button, couldn't find it, and clicked navigation links instead. This suggests the submit button may be below the fold or insufficiently prominent.
+
+### Block 3: No QR code on any page reached
+**Severity:** Informational — cannot verify QR code feature since RSVP completion page was never reached  
+**Note:** The QR code may exist on the RSVP confirmation page that is unreachable due to Block 1.
+
+## Environment
+- AWS_PROFILE: `bryanchasko-kiro` (Bedrock/browser_session), `jitsi-video-hosting` (Cognito/Secrets)
+- Nova Act model: `nova-act-latest`
+- Workflow definition: `cdn-ux-audit`
+- Browser: headless via Bedrock AgentCore browser_session (us-east-1)

--- a/scripts/nova-act/wave-54-rsvp-existing-user.py
+++ b/scripts/nova-act/wave-54-rsvp-existing-user.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Wave 54 — existing-user RSVP flow (heraldstack@clouddelnorte.org).
+
+Opens /feed/, clicks the June 3 Community Happy Hour RSVP CTA,
+authenticates as heraldstack@, captures confirmation + QR screenshots,
+verifies backend spots endpoint.
+"""
+import json, os, sys, time
+from datetime import datetime, timezone
+from pathlib import Path
+
+os.environ["AWS_PROFILE"] = "bryanchasko-kiro"
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+import boto3
+import requests
+from bedrock_agentcore.tools.browser_client import browser_session
+from nova_act import NovaAct, workflow
+from nova_act.types.act_errors import ActActuationError
+
+# --- Constants ---
+FEED_URL = "https://clouddelnorte.org/feed/"
+SPOTS_URL = "https://tta0e43bs0.execute-api.us-west-2.amazonaws.com/prod/rsvp/happy-hour-2026-06-03/spots"
+OUTPUT_DIR = Path("/tmp/wave-54-existing")
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+TS = datetime.now(timezone.utc).strftime("%Y%m%dT%H%MZ")
+
+# --- Credential fetch (jitsi-video-hosting profile owns the secret) ---
+_sm = boto3.Session(profile_name="jitsi-video-hosting", region_name="us-west-2").client("secretsmanager")
+EMAIL = "heraldstack@clouddelnorte.org"
+PASSWORD = _sm.get_secret_value(SecretId="cloud-del-norte/heraldstack-cognito-pw")["SecretString"]
+
+results = {"test": "A-existing-user", "status": "FAIL", "blocks": []}
+
+
+def log(msg: str):
+    ts = datetime.now(timezone.utc).strftime("%H:%M:%S")
+    print(f"[{ts}][EXISTING] {msg}", flush=True)
+
+
+def screenshot(nova, filename: str) -> str:
+    path = str(OUTPUT_DIR / filename)
+    nova.page.screenshot(path=path)
+    log(f"Screenshot: {path}")
+    return path
+
+
+def check_spots_before():
+    try:
+        r = requests.get(SPOTS_URL, timeout=10)
+        data = r.json()
+        log(f"Spots before: {json.dumps(data)}")
+        return data
+    except Exception as e:
+        log(f"Spots check failed: {e}")
+        return None
+
+
+@workflow(
+    model_id="nova-act-latest",
+    boto_session_kwargs={"profile_name": "bryanchasko-kiro", "region_name": "us-east-1"},
+    workflow_definition_name="cdn-ux-audit",
+)
+def run_existing_user_rsvp():
+    log(f"Starting existing-user RSVP test — {TS}")
+
+    spots_before = check_spots_before()
+    results["spots_before"] = spots_before
+
+    with browser_session(region="us-east-1", name="wave54-rsvp-existing") as browser:
+        ws_url, headers = browser.generate_ws_headers()
+        with NovaAct(
+            cdp_endpoint_url=ws_url, cdp_headers=headers,
+            starting_page=FEED_URL, headless=True, tty=False,
+            logs_directory="/tmp/nova-act-logs",
+            go_to_url_timeout=30,
+        ) as nova:
+            time.sleep(3)
+
+            # Step 1: Screenshot feed (anonymous)
+            screenshot(nova, "01-feed-anon.png")
+            log(f"URL after feed load: {nova.page.url}")
+
+            # Step 2: Click RSVP CTA on June 3 event
+            try:
+                nova.act(
+                    "Find the Featured Event card for the June 3 Community Happy Hour. "
+                    "Click the RSVP button or 'Limited space — RSVP now' link on that card."
+                )
+                time.sleep(4)
+                log(f"URL after RSVP click: {nova.page.url}")
+            except ActActuationError as e:
+                results["blocks"].append(f"RSVP CTA click failed: {e}")
+                log(f"BLOCK: RSVP CTA click failed: {e}")
+                screenshot(nova, "block-rsvp-cta.png")
+                return
+
+            # Step 3: Sign in (may land on signup page first — click sign in link)
+            try:
+                # Check if we're on signup page and need to switch to login
+                current_url = nova.page.url
+                if "/signup" in current_url:
+                    nova.act("Click the 'Sign in' link to go to the login page.")
+                    time.sleep(2)
+
+                nova.act(f"Enter '{EMAIL}' in the email field.")
+                nova.page.fill('input[type="password"], input[name="password"], #password', PASSWORD)
+                try:
+                    nova.act("Click the 'Sign in' button to submit the login form.")
+                except ActActuationError:
+                    pass  # redirect causes screenshot timeout — expected
+                time.sleep(8)
+                log(f"URL after login: {nova.page.url}")
+            except ActActuationError as e:
+                results["blocks"].append(f"Login failed: {e}")
+                log(f"BLOCK: Login failed: {e}")
+                screenshot(nova, "block-login.png")
+                return
+
+            # Step 4: Handle MFA if present
+            try:
+                mfa_check = nova.act_get(
+                    "Is there an MFA, authenticator, or one-time-code input visible on this page? Reply yes or no only."
+                )
+                if "yes" in mfa_check.response.lower():
+                    log("MFA challenge detected — attempting code 000000")
+                    nova.act("Type '000000' in the MFA/code input field and click verify or submit.")
+                    time.sleep(4)
+                    mfa_still = nova.act_get("Is MFA still blocking? Reply yes or no only.")
+                    if "yes" in mfa_still.response.lower():
+                        results["blocks"].append("MFA brick — cannot bypass with 000000")
+                        log("BLOCK: MFA brick")
+                        screenshot(nova, "block-mfa.png")
+                        return
+            except ActActuationError:
+                pass
+
+            # Step 5: Confirmation page
+            time.sleep(3)
+            screenshot(nova, "02-rsvp-confirm.png")
+            log(f"URL at confirmation: {nova.page.url}")
+
+            # Step 6: Check for QR code
+            try:
+                qr_check = nova.act_get(
+                    "Is there a QR code visible on this page? Reply yes or no only."
+                )
+                if "yes" in qr_check.response.lower():
+                    screenshot(nova, "03-qr.png")
+                    log("QR code captured")
+                    results["qr_found"] = True
+                else:
+                    log("BLOCKER: No QR code visible on confirmation page")
+                    results["blocks"].append("No QR code visible on confirmation page")
+                    results["qr_found"] = False
+            except ActActuationError as e:
+                results["blocks"].append(f"QR check failed: {e}")
+                results["qr_found"] = False
+
+            # Step 7: Extract ticket payload
+            try:
+                ticket = nova.act_get(
+                    "Read all text on this page and return it as a single string."
+                )
+                results["ticket_payload"] = ticket.response
+                log(f"Page text: {ticket.response[:200]}")
+            except (ActActuationError, Exception) as e:
+                results["ticket_payload"] = f"extraction failed: {e}"
+                log(f"Ticket extraction failed: {e}")
+
+    # Step 8: Verify backend spots after
+    spots_after = check_spots_before()
+    results["spots_after"] = spots_after
+    results["status"] = "PASS" if not results["blocks"] else "BLOCKED"
+    log(f"Test complete — status: {results['status']}")
+
+
+if __name__ == "__main__":
+    run_existing_user_rsvp()
+    print(f"\n{'='*60}")
+    print(f"RESULT: {results['status']}")
+    print(f"Blocks: {results['blocks'] or 'none'}")
+    print(f"QR found: {results.get('qr_found', 'N/A')}")
+    print(f"Spots before: {results.get('spots_before')}")
+    print(f"Spots after: {results.get('spots_after')}")
+    print(f"{'='*60}")
+    print(json.dumps(results, indent=2, default=str))

--- a/scripts/nova-act/wave-54-rsvp-new-user.py
+++ b/scripts/nova-act/wave-54-rsvp-new-user.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Wave 54 — new-user signup + RSVP flow.
+
+Creates heraldstack+novaact-<ts>@clouddelnorte.org, signs up via the UI,
+admin-confirms via Cognito, logs in, completes RSVP, captures screenshots.
+Cleans up Cognito user + DDB record after.
+"""
+import json, os, secrets, string, subprocess, sys, time
+from datetime import datetime, timezone
+from pathlib import Path
+
+os.environ["AWS_PROFILE"] = "bryanchasko-kiro"
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+import boto3
+import requests
+from bedrock_agentcore.tools.browser_client import browser_session
+from nova_act import NovaAct, workflow
+from nova_act.types.act_errors import ActActuationError
+
+# --- Constants ---
+FEED_URL = "https://clouddelnorte.org/feed/"
+SPOTS_URL = "https://tta0e43bs0.execute-api.us-west-2.amazonaws.com/prod/rsvp/happy-hour-2026-06-03/spots"
+USER_POOL_ID = "us-west-2_cyPQF4F3r"
+OUTPUT_DIR = Path("/tmp/wave-54-new")
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+TS = datetime.now(timezone.utc).strftime("%Y%m%dT%H%MZ")
+EPOCH = int(time.time())
+
+# --- Generate test user credentials ---
+NEW_EMAIL = f"heraldstack+novaact-{EPOCH}@clouddelnorte.org"
+# Password: 14 chars, guaranteed upper+lower+digit+symbol
+_alpha = string.ascii_letters + string.digits + "!@#$%"
+NEW_PASSWORD = (
+    secrets.choice(string.ascii_uppercase)
+    + secrets.choice(string.ascii_lowercase)
+    + secrets.choice(string.digits)
+    + secrets.choice("!@#$%")
+    + "".join(secrets.choice(_alpha) for _ in range(10))
+)
+
+results = {"test": "B-new-user", "status": "FAIL", "blocks": [], "email": NEW_EMAIL}
+new_user_sub = None
+
+
+def log(msg: str):
+    ts = datetime.now(timezone.utc).strftime("%H:%M:%S")
+    print(f"[{ts}][NEW-USER] {msg}", flush=True)
+
+
+def screenshot(nova, filename: str) -> str:
+    path = str(OUTPUT_DIR / filename)
+    nova.page.screenshot(path=path)
+    log(f"Screenshot: {path}")
+    return path
+
+
+def check_spots():
+    try:
+        r = requests.get(SPOTS_URL, timeout=10)
+        return r.json()
+    except Exception as e:
+        log(f"Spots check failed: {e}")
+        return None
+
+
+def cognito_admin_confirm(email: str):
+    cmd = [
+        "aws", "cognito-idp", "admin-confirm-sign-up",
+        "--user-pool-id", USER_POOL_ID,
+        "--username", email,
+        "--profile", "jitsi-video-hosting",
+        "--region", "us-west-2",
+    ]
+    log(f"admin-confirm-sign-up {email}")
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if r.returncode != 0:
+        log(f"WARN confirm failed: {r.stderr.strip()}")
+        return False
+    log("confirmed OK")
+    return True
+
+
+def cognito_get_user_sub(email: str) -> str | None:
+    cmd = [
+        "aws", "cognito-idp", "admin-get-user",
+        "--user-pool-id", USER_POOL_ID,
+        "--username", email,
+        "--profile", "jitsi-video-hosting",
+        "--region", "us-west-2",
+    ]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if r.returncode != 0:
+        log(f"get-user failed: {r.stderr.strip()}")
+        return None
+    data = json.loads(r.stdout)
+    for attr in data.get("UserAttributes", []):
+        if attr["Name"] == "sub":
+            return attr["Value"]
+    return None
+
+
+def cleanup_user(email: str, sub: str | None):
+    log(f"Cleanup: deleting Cognito user {email}")
+    cmd = [
+        "aws", "cognito-idp", "admin-delete-user",
+        "--user-pool-id", USER_POOL_ID,
+        "--username", email,
+        "--profile", "jitsi-video-hosting",
+        "--region", "us-west-2",
+    ]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if r.returncode != 0:
+        log(f"WARN delete-user failed: {r.stderr.strip()}")
+    else:
+        log("Cognito user deleted")
+
+    if sub:
+        log(f"Cleanup: deleting DDB RSVP record for sub={sub}")
+        key = json.dumps({"user_sub": {"S": sub}, "event_id": {"S": "happy-hour-2026-06-03"}})
+        cmd = [
+            "aws", "dynamodb", "delete-item",
+            "--table-name", "cdn-rsvps",
+            "--key", key,
+            "--profile", "jitsi-video-hosting",
+            "--region", "us-west-2",
+        ]
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if r.returncode != 0:
+            log(f"WARN DDB delete failed: {r.stderr.strip()}")
+        else:
+            log("DDB record deleted")
+
+
+@workflow(
+    model_id="nova-act-latest",
+    boto_session_kwargs={"profile_name": "bryanchasko-kiro", "region_name": "us-east-1"},
+    workflow_definition_name="cdn-ux-audit",
+)
+def run_new_user_rsvp():
+    global new_user_sub
+    log(f"Starting new-user RSVP test — {TS}")
+    log(f"Test email: {NEW_EMAIL}")
+    log(f"Test password: {NEW_PASSWORD}")
+
+    spots_before = check_spots()
+    results["spots_before"] = spots_before
+    log(f"Spots before: {json.dumps(spots_before)}")
+
+    with browser_session(region="us-east-1", name="wave54-rsvp-new") as browser:
+        ws_url, headers = browser.generate_ws_headers()
+        with NovaAct(
+            cdp_endpoint_url=ws_url, cdp_headers=headers,
+            starting_page=FEED_URL, headless=True, tty=False,
+            logs_directory="/tmp/nova-act-logs",
+            go_to_url_timeout=30,
+        ) as nova:
+            time.sleep(3)
+
+            # Step 1: Click RSVP CTA
+            try:
+                nova.act(
+                    "Find the Featured Event card for the June 3 Community Happy Hour. "
+                    "Click the RSVP button or 'Limited space — RSVP now' link on that card."
+                )
+                time.sleep(4)
+                log(f"URL after RSVP click: {nova.page.url}")
+            except ActActuationError as e:
+                results["blocks"].append(f"RSVP CTA click failed: {e}")
+                log(f"BLOCK: {e}")
+                screenshot(nova, "block-rsvp-cta.png")
+                return
+
+            # Step 2: Switch to signup tab/link if on login page
+            try:
+                nova.act(
+                    "If this is a login page, click the 'Sign up' or 'Create account' link to go to the signup form."
+                )
+                time.sleep(2)
+            except ActActuationError:
+                pass
+
+            # Step 3: Fill signup form
+            try:
+                nova.act(f"Enter '{NEW_EMAIL}' in the email field.")
+                nova.page.fill('input[type="password"], input[name="password"], #password', NEW_PASSWORD)
+                nova.act("Enter 'Nova' in the first name field and 'Act-Test' in the last name field.")
+                nova.act("Click the sign up or create account button.")
+                time.sleep(4)
+                log(f"URL after signup submit: {nova.page.url}")
+            except ActActuationError as e:
+                results["blocks"].append(f"Signup form failed: {e}")
+                log(f"BLOCK: {e}")
+                screenshot(nova, "block-signup.png")
+                return
+
+            # Step 4: Screenshot pending state
+            screenshot(nova, "01-signup-pending.png")
+
+    # Step 5: Admin-confirm the user (bypasses email verification)
+    if not cognito_admin_confirm(NEW_EMAIL):
+        results["blocks"].append("admin-confirm-sign-up failed")
+        log("BLOCK: cannot confirm user")
+        return
+
+    # Get user sub for cleanup
+    new_user_sub = cognito_get_user_sub(NEW_EMAIL)
+    results["user_sub"] = new_user_sub
+    log(f"User sub: {new_user_sub}")
+
+    # Step 6: Log in as new user and complete RSVP
+    with browser_session(region="us-east-1", name="wave54-rsvp-new-login") as browser:
+        ws_url, headers = browser.generate_ws_headers()
+        with NovaAct(
+            cdp_endpoint_url=ws_url, cdp_headers=headers,
+            starting_page=FEED_URL, headless=True, tty=False,
+            logs_directory="/tmp/nova-act-logs",
+            go_to_url_timeout=30,
+        ) as nova:
+            time.sleep(3)
+
+            # Click RSVP again
+            try:
+                nova.act(
+                    "Find the Featured Event card for the June 3 Community Happy Hour. "
+                    "Click the RSVP button or 'Limited space — RSVP now' link."
+                )
+                time.sleep(4)
+            except ActActuationError as e:
+                results["blocks"].append(f"Second RSVP click failed: {e}")
+                return
+
+            # Login as new user
+            try:
+                nova.act(f"Enter '{NEW_EMAIL}' in the email field.")
+                nova.page.fill('input[type="password"], input[name="password"], #password', NEW_PASSWORD)
+                nova.act("Click the sign in button and wait for redirect.")
+                time.sleep(6)
+                log(f"URL after new-user login: {nova.page.url}")
+            except ActActuationError as e:
+                results["blocks"].append(f"New-user login failed: {e}")
+                screenshot(nova, "block-login.png")
+                return
+
+            # Confirmation
+            time.sleep(3)
+            screenshot(nova, "02-rsvp-confirm.png")
+
+            # QR check
+            try:
+                qr_check = nova.act_get("Is there a QR code visible on this page? Reply yes or no only.")
+                if "yes" in qr_check.response.lower():
+                    screenshot(nova, "03-qr.png")
+                    results["qr_found"] = True
+                    log("QR code captured")
+                else:
+                    results["qr_found"] = False
+                    results["blocks"].append("No QR code on confirmation")
+                    log("No QR code visible")
+            except ActActuationError:
+                results["qr_found"] = False
+
+    # Step 7: Verify spots
+    spots_after = check_spots()
+    results["spots_after"] = spots_after
+    log(f"Spots after: {json.dumps(spots_after)}")
+    results["status"] = "PASS" if not results["blocks"] else "BLOCKED"
+
+
+if __name__ == "__main__":
+    try:
+        run_new_user_rsvp()
+    finally:
+        # Always cleanup
+        if new_user_sub or NEW_EMAIL:
+            cleanup_user(NEW_EMAIL, new_user_sub)
+
+    print(f"\n{'='*60}")
+    print(f"RESULT: {results['status']}")
+    print(f"Email: {NEW_EMAIL}")
+    print(f"Password: {NEW_PASSWORD}")
+    print(f"Sub: {results.get('user_sub', 'N/A')}")
+    print(f"Blocks: {results['blocks'] or 'none'}")
+    print(f"QR found: {results.get('qr_found', 'N/A')}")
+    print(f"Spots before: {results.get('spots_before')}")
+    print(f"Spots after: {results.get('spots_after')}")
+    print(f"{'='*60}")
+    print(json.dumps(results, indent=2, default=str))


### PR DESCRIPTION
Bryan EOS goal: first-time visitor click June 3 event → guided signup → confirmation + QR.

## tests run
| test | status | reason |
|---|---|---|
| A — existing-user | **BLOCKED** | post-auth redirect to /rsvp/?event=… not honored, user lands on awsug home |
| B — new-user | **BLOCKED** | signup form submit didn't fire (browser navigated away mid-flow) |

## P1 bug surfaced
The `return_to=/rsvp/?event=happy-hour-2026-06-03` query param passes through auth correctly, but is NOT honored post-login — auth app drops the user on awsug home instead of routing them back to the RSVP completion path. This blocks the entire EOS RSVP-via-auth flow for new AND existing users.

Backend verification confirmed: 0 RSVPs completed (spots taken stayed at 0 after both test runs).

## ships
- scripts/nova-act/wave-54-rsvp-existing-user.py
- scripts/nova-act/wave-54-rsvp-new-user.py
- docs/wave-54-nova-act-rsvp-qa.md — full results + screenshot paths + block analysis

## next
Wave 55: fix the auth post-login redirect to honor return_to query parameter.