### PR TITLE
fix(auth): wave 55 — preserve return_to query on signup↔login cross-links (P1 from wave 54)

### DIFF
--- a/src/sites/auth/login/__tests__/app.test.tsx
+++ b/src/sites/auth/login/__tests__/app.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../_layout", () => ({
+	default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../../../../hooks/useTranslation", () => ({
+	useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock("../../../../lib/cognito", () => ({
+	AuthError: class AuthError extends Error {
+		constructor(
+			message: string,
+			public code?: string,
+		) {
+			super(message);
+		}
+	},
+	assertNonEmpty: vi.fn(),
+	associateSoftwareToken: vi.fn(),
+	base64urlToBuffer: vi.fn(),
+	completePasskeyAuth: vi.fn(),
+	initiatePasskeyAuth: vi.fn(),
+	respondToMfaChallenge: vi.fn(),
+	signInWithPassword: vi.fn(),
+	verifySoftwareToken: vi.fn(),
+}));
+
+vi.mock("qrcode.react", () => ({
+	QRCodeSVG: () => <svg data-testid="qr-code" />,
+}));
+
+import App from "../app";
+
+describe("login → signup cross-link", () => {
+	it("includes return_to search params in sign-up link href", () => {
+		Object.defineProperty(window, "location", {
+			value: {
+				...window.location,
+				search: "?return_to=%2Frsvp%2F%3Fevent%3Dhappy-hour-2026-06-03",
+			},
+			writable: true,
+		});
+
+		render(<App />);
+
+		const link = screen.getByText("auth.login.signUpLink").closest("a");
+		expect(link?.getAttribute("href")).toContain(
+			"?return_to=%2Frsvp%2F%3Fevent%3Dhappy-hour-2026-06-03",
+		);
+	});
+
+	it("falls back to plain href when no search params present", () => {
+		Object.defineProperty(window, "location", {
+			value: { ...window.location, search: "" },
+			writable: true,
+		});
+
+		render(<App />);
+
+		const link = screen.getByText("auth.login.signUpLink").closest("a");
+		expect(link?.getAttribute("href")).toBe("/signup/index.html");
+	});
+});

--- a/src/sites/auth/login/app.tsx
+++ b/src/sites/auth/login/app.tsx
@@ -433,7 +433,11 @@ function LoginForm() {
 		<div className="cdn-auth-form-inner">
 			<Box variant="small" textAlign="right" margin={{ bottom: "s" }}>
 				{t("auth.login.noAccount")}{" "}
-				<Link href="/signup/index.html">{t("auth.login.signUpLink")}</Link>
+				<Link
+					href={`/signup/index.html${typeof window !== "undefined" && window.location.search ? window.location.search : ""}`}
+				>
+					{t("auth.login.signUpLink")}
+				</Link>
 			</Box>
 			<form
 				onSubmit={(e) => {

--- a/src/sites/auth/signup/__tests__/app.test.tsx
+++ b/src/sites/auth/signup/__tests__/app.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Minimal mocks to render SignupWizard without the full shell
+vi.mock("../../../_layout", () => ({
+	default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../../../../hooks/useTranslation", () => ({
+	useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock("../../../../lib/cognito", () => ({
+	AuthError: class AuthError extends Error {
+		constructor(
+			message: string,
+			public code?: string,
+		) {
+			super(message);
+		}
+	},
+	assertNonEmpty: vi.fn(),
+	associateSoftwareToken: vi.fn(),
+	confirmSignUp: vi.fn(),
+	FIELD_LIMITS: {
+		displayName: 50,
+		location: 100,
+		topics: 500,
+		background: 1000,
+	},
+	resendConfirmationCode: vi.fn(),
+	respondToMfaChallenge: vi.fn(),
+	signInWithPassword: vi.fn(),
+	signUp: vi.fn(),
+	verifySoftwareToken: vi.fn(),
+}));
+
+vi.mock("qrcode.react", () => ({
+	QRCodeSVG: () => <svg data-testid="qr-code" />,
+}));
+
+import App from "../app";
+
+describe("signup → login cross-link", () => {
+	it("includes return_to search params in sign-in link href", () => {
+		Object.defineProperty(window, "location", {
+			value: {
+				...window.location,
+				search: "?return_to=%2Frsvp%2F%3Fevent%3Dhappy-hour-2026-06-03",
+			},
+			writable: true,
+		});
+
+		render(<App />);
+
+		const link = screen.getByText("auth.signup.signInLink").closest("a");
+		expect(link?.getAttribute("href")).toContain(
+			"?return_to=%2Frsvp%2F%3Fevent%3Dhappy-hour-2026-06-03",
+		);
+	});
+
+	it("falls back to plain href when no search params present", () => {
+		Object.defineProperty(window, "location", {
+			value: { ...window.location, search: "" },
+			writable: true,
+		});
+
+		render(<App />);
+
+		const link = screen.getByText("auth.signup.signInLink").closest("a");
+		expect(link?.getAttribute("href")).toBe("/login/index.html");
+	});
+});

--- a/src/sites/auth/signup/app.tsx
+++ b/src/sites/auth/signup/app.tsx
@@ -660,7 +660,11 @@ function SignupWizard() {
 			{activeStepIndex === 0 && (
 				<Box variant="small" textAlign="right" margin={{ bottom: "s" }}>
 					{t("auth.signup.alreadyMember")}{" "}
-					<Link href="/login/index.html">{t("auth.signup.signInLink")}</Link>
+					<Link
+						href={`/login/index.html${typeof window !== "undefined" && window.location.search ? window.location.search : ""}`}
+					>
+						{t("auth.signup.signInLink")}
+					</Link>
 				</Box>
 			)}
 			<StepDots current={activeStepIndex} total={steps.length} />


### PR DESCRIPTION
Wave 54 Nova Act QA found that the wave 39b 'Already a Member? Sign in' link in signup (and inverse wave 40b 'Need an account?' link in login) drops the `return_to` query parameter when crossing between forms.

User journey: click RSVP CTA → lands on signup?return_to=/rsvp/?event=… → if already has account, clicks 'Sign in' → lands on login (NO return_to) → logs in → redirects to awsug home, NOT the RSVP completion page.

Backend confirms 0 RSVPs completed during wave 54 testing.

## fix
Cross-links now preserve `window.location.search` when crossing between signup and login forms. SSR-safe via typeof window check.

## gates
- biome 0 / tsc 0 NEW / build PASS / vitest 846 PASS (+4 new cases)