### PR TITLE
feat(feed): wave 56 — builder cards click-to-play modal + new how-to-play AWS BuilderCards feed card

### DIFF
--- a/src/locales/__tests__/translation-coverage.test.ts
+++ b/src/locales/__tests__/translation-coverage.test.ts
@@ -135,6 +135,10 @@ describe("translation coverage", () => {
 			"meetings.rsvpButton", // "RSVP" - universal abbreviation
 			"meetings.tableHeaders.rsvp", // "RSVP" - universal abbreviation
 			"speakerForm.fields.format.virtual", // "virtual" - same in Spanish
+			// wave 56 proper nouns / channel names
+			"feedPage.builderCenterVideoAuthor", // "Ajolotes en la Nube" - channel proper noun
+			"feedPage.builderCenterVideoTitle", // "Building AWS Architectures with BuilderCards" - proper noun project name
+			"feedPage.howToPlayBuildercardsAuthor", // "AWS for Games" - channel proper noun
 		]);
 
 		// Helper to get value by dot-notation key

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -65,6 +65,12 @@
 		"andresMediumAllPosts": "All posts",
 		"builderCenterHeader": "AWS Builder Center",
 		"builderCenterOpen": "Open AWS Builder Center",
+		"builderCenterWatchIntro": "Watch BuilderCards intro",
+		"builderCenterVideoTitle": "Building AWS Architectures with BuilderCards",
+		"builderCenterVideoAuthor": "Ajolotes en la Nube",
+		"builderCenterModalAriaLabel": "BuilderCards introduction video player",
+		"howToPlayBuildercardsTitle": "How to play AWS BuilderCards (2023)",
+		"howToPlayBuildercardsAuthor": "AWS for Games",
 		"builderBadge": {
 			"employee": "aws employee",
 			"communityBuilder": "aws community builder",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -65,6 +65,12 @@
 		"andresMediumAllPosts": "todas las publicaciones",
 		"builderCenterHeader": "AWS Builder Center",
 		"builderCenterOpen": "abrir AWS Builder Center",
+		"builderCenterWatchIntro": "Ver intro de BuilderCards",
+		"builderCenterVideoTitle": "Building AWS Architectures with BuilderCards",
+		"builderCenterVideoAuthor": "Ajolotes en la Nube",
+		"builderCenterModalAriaLabel": "reproductor del video de introducción a BuilderCards",
+		"howToPlayBuildercardsTitle": "Cómo jugar AWS BuilderCards (2023)",
+		"howToPlayBuildercardsAuthor": "AWS for Games",
 		"builderBadge": {
 			"employee": "empleado de aws",
 			"communityBuilder": "aws community builder",

--- a/src/pages/feed/app.tsx
+++ b/src/pages/feed/app.tsx
@@ -60,6 +60,7 @@ type SectionKey =
 	| "vbrownbag"
 	| "theZacsShow"
 	| "featuredVideo"
+	| "howToPlayBuildercards"
 	| "youtubeShorts";
 
 // priority order for live hero — first live item wins the top slot
@@ -84,6 +85,7 @@ const SECTION_KEYS: SectionKey[] = [
 	"vbrownbag",
 	"theZacsShow",
 	"featuredVideo",
+	"howToPlayBuildercards",
 	"youtubeShorts",
 ];
 
@@ -214,6 +216,15 @@ function AppContent({
 					author="Shubham gour"
 					authorUrl="https://www.youtube.com/@Shubhamgourtech"
 					thumbnailUrl="https://i.ytimg.com/vi/0PedFnnH_Ic/hqdefault.jpg"
+				/>
+			),
+			howToPlayBuildercards: (
+				<FeaturedVideoCard
+					videoId="Pn6w8-abgis"
+					title={t("feedPage.howToPlayBuildercardsTitle")}
+					author={t("feedPage.howToPlayBuildercardsAuthor")}
+					authorUrl="https://www.youtube.com/@AWSGameTech"
+					palette="gold"
 				/>
 			),
 			youtubeShorts: <YouTubeShortsCarousel />,

--- a/src/pages/feed/components/__tests__/wave-56.test.tsx
+++ b/src/pages/feed/components/__tests__/wave-56.test.tsx
@@ -1,0 +1,177 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// Wave 56 tests:
+//   A — BuilderCenterCard click-to-play modal (svvgLNWGlEI)
+//   B — FeaturedVideoCard palette prop
+//   C — feed/app.tsx SECTION_KEYS includes 'howToPlayBuildercards'
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../../../../contexts/locale-context";
+import BuilderCenterCard from "../builder-center-card";
+import FeaturedVideoCard from "../featured-video-card";
+
+function withLocale(ui: React.ReactElement) {
+	return render(<LocaleProvider locale="us">{ui}</LocaleProvider>);
+}
+
+// IntersectionObserver stub required by LazyEmbed
+type IOCallback = (entries: IntersectionObserverEntry[]) => void;
+let lastIOCb: IOCallback | null = null;
+
+beforeEach(() => {
+	lastIOCb = null;
+	class IOMock {
+		disconnect = vi.fn();
+		constructor(cb: IOCallback) {
+			lastIOCb = cb;
+		}
+		observe() {}
+	}
+	globalThis.IntersectionObserver =
+		IOMock as unknown as typeof IntersectionObserver;
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// A — BuilderCenterCard modal
+// ---------------------------------------------------------------------------
+
+describe("Wave 56A — BuilderCenterCard click-to-play modal", () => {
+	it("renders 'Watch BuilderCards intro' button", () => {
+		withLocale(<BuilderCenterCard />);
+		expect(
+			screen.getByTestId("builder-center-watch-intro"),
+		).toBeInTheDocument();
+	});
+
+	it("modal is not visible before button click", () => {
+		withLocale(<BuilderCenterCard />);
+		// Cloudscape Modal always renders in DOM but adds awsui_hidden_* class
+		// when visible=false. Check the dialog exists but is visually hidden.
+		const dialog = document.querySelector("[role='dialog']") as HTMLElement;
+		expect(dialog).not.toBeNull();
+		// hidden class contains "hidden"
+		expect(dialog.className).toMatch(/hidden/);
+	});
+
+	it("clicking Watch intro button opens the modal", async () => {
+		withLocale(<BuilderCenterCard />);
+		const btn = screen.getByTestId("builder-center-watch-intro");
+		fireEvent.click(btn);
+		await waitFor(() => {
+			expect(
+				screen.getByText("Building AWS Architectures with BuilderCards"),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("open modal contains iframe with svvgLNWGlEI src after IntersectionObserver fires", async () => {
+		const { act } = await import("react");
+		withLocale(<BuilderCenterCard />);
+		const btn = screen.getByTestId("builder-center-watch-intro");
+		fireEvent.click(btn);
+		await waitFor(() => {
+			expect(
+				screen.getByText("Building AWS Architectures with BuilderCards"),
+			).toBeInTheDocument();
+		});
+		// trigger IntersectionObserver so LazyEmbed renders the iframe
+		await act(async () => {
+			lastIOCb?.([{ isIntersecting: true } as IntersectionObserverEntry]);
+		});
+		const iframe = screen.getByTitle(
+			"Building AWS Architectures with BuilderCards",
+		);
+		expect(iframe.getAttribute("src")).toContain("svvgLNWGlEI");
+	});
+
+	it("modal contains author attribution link to Ajolotes en la Nube", async () => {
+		withLocale(<BuilderCenterCard />);
+		fireEvent.click(screen.getByTestId("builder-center-watch-intro"));
+		await waitFor(() => {
+			expect(screen.getByText("Ajolotes en la Nube")).toBeInTheDocument();
+		});
+	});
+
+	it("dismissing modal re-hides the dialog", async () => {
+		withLocale(<BuilderCenterCard />);
+		fireEvent.click(screen.getByTestId("builder-center-watch-intro"));
+		await waitFor(() => {
+			// Modal should be visible — no hidden class
+			const dialog = document.querySelector("[role='dialog']") as HTMLElement;
+			expect(dialog.className).not.toMatch(/hidden/);
+		});
+		const closeBtn = document.querySelector(
+			'[class*="dismiss-control"]',
+		) as HTMLElement;
+		expect(closeBtn).not.toBeNull();
+		fireEvent.click(closeBtn);
+		await waitFor(() => {
+			const dialog = document.querySelector("[role='dialog']") as HTMLElement;
+			expect(dialog.className).toMatch(/hidden/);
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// B — FeaturedVideoCard palette prop
+// ---------------------------------------------------------------------------
+
+describe("Wave 56B — FeaturedVideoCard palette prop", () => {
+	const BASE = {
+		videoId: "Pn6w8-abgis",
+		title: "How to play AWS BuilderCards (2023)",
+		author: "AWS for Games",
+		authorUrl: "https://www.youtube.com/@AWSGameTech",
+	};
+
+	it("defaults to palette=lavender when no palette prop provided", () => {
+		withLocale(
+			<FeaturedVideoCard
+				videoId="0PedFnnH_Ic"
+				title="Women in Tech"
+				author="Shubham gour"
+				authorUrl="https://www.youtube.com/@Shubhamgourtech"
+			/>,
+		);
+		const shell = document.querySelector("[data-feed-card-palette]");
+		expect(shell?.getAttribute("data-feed-card-palette")).toBe("lavender");
+	});
+
+	it("renders with palette=gold when prop provided", () => {
+		withLocale(<FeaturedVideoCard {...BASE} palette="gold" />);
+		const shell = document.querySelector("[data-feed-card-palette]");
+		expect(shell?.getAttribute("data-feed-card-palette")).toBe("gold");
+	});
+
+	it("renders title for how-to-play card", () => {
+		withLocale(<FeaturedVideoCard {...BASE} palette="gold" />);
+		expect(
+			screen.getByText("How to play AWS BuilderCards (2023)"),
+		).toBeInTheDocument();
+	});
+
+	it("renders author link for AWS for Games", () => {
+		withLocale(<FeaturedVideoCard {...BASE} palette="gold" />);
+		expect(screen.getByText("AWS for Games")).toBeInTheDocument();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// C — SECTION_KEYS includes howToPlayBuildercards
+// ---------------------------------------------------------------------------
+
+describe("Wave 56C — SECTION_KEYS includes howToPlayBuildercards", () => {
+	it("SECTION_KEYS array contains 'howToPlayBuildercards' and Pn6w8-abgis videoId", async () => {
+		const { readFileSync } = await import("node:fs");
+		const { resolve } = await import("node:path");
+		const src = readFileSync(resolve("src/pages/feed/app.tsx"), "utf-8");
+		expect(src).toContain('"howToPlayBuildercards"');
+		expect(src).toContain("Pn6w8-abgis");
+	});
+});

--- a/src/pages/feed/components/builder-center-card.tsx
+++ b/src/pages/feed/components/builder-center-card.tsx
@@ -1,8 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
+import Button from "@cloudscape-design/components/button";
 import Link from "@cloudscape-design/components/link";
+import Modal from "@cloudscape-design/components/modal";
+import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { LazyEmbed } from "../../../components/lazy-embed";
 import { useTranslation } from "../../../hooks/useTranslation";
 import BuilderBadge from "./builder-badge";
 import {
@@ -32,6 +36,10 @@ const AUTO_ADVANCE_MS = 7000;
 // corner pill chip + #-prefix variant looked terrible compared to the prior
 // big-numeral hierarchy. Each card shows: big serif #, 2-line title clamp,
 // 1-line excerpt from blurb, author + badge.
+//
+// wave 56 — add 'Watch BuilderCards intro' button in headerActions slot that
+// opens a Cloudscape Modal with a lazy YouTube iframe for svvgLNWGlEI.
+// prefers-reduced-motion: autoplay disabled when reduced motion preferred.
 
 interface VisibleCard extends Card {
 	rank: number; // 1..N visible rank stays stable per source-array index
@@ -68,6 +76,8 @@ function CardItem({ card }: { card: VisibleCard }) {
 		</li>
 	);
 }
+
+const VIDEO_ID = "svvgLNWGlEI";
 
 export default function BuilderCenterCard() {
 	const { t, locale } = useTranslation();
@@ -138,65 +148,104 @@ export default function BuilderCenterCard() {
 		step(dir);
 	};
 
+	// wave 56 — modal state
+	const [modalOpen, setModalOpen] = useState(false);
+
+	// prefers-reduced-motion: disable autoplay when user prefers it
+	const embedSrc = `https://www.youtube.com/embed/${VIDEO_ID}?autoplay=${reducedMotion ? 0 : 1}`;
+
 	const headerActions = (
-		<Link href="https://builder.aws.com/" external fontSize="body-s">
-			{t("feedPage.builderCenterOpen")}
-		</Link>
+		<SpaceBetween direction="horizontal" size="xs">
+			<Button
+				variant="inline-link"
+				iconName="caret-right-filled"
+				onClick={() => setModalOpen(true)}
+				data-testid="builder-center-watch-intro"
+			>
+				{t("feedPage.builderCenterWatchIntro")}
+			</Button>
+			<Link href="https://builder.aws.com/" external fontSize="body-s">
+				{t("feedPage.builderCenterOpen")}
+			</Link>
+		</SpaceBetween>
 	);
 
 	return (
-		<FeedCardShell
-			headerText={t("feedPage.builderCenterHeader")}
-			headerActions={headerActions}
-			palette="gold"
-		>
-			{/* biome-ignore lint/a11y/noStaticElementInteractions: pointer handlers only pause auto-advance — keyboard / SR users use the chevron buttons below */}
-			<div
-				className="feed-builder-deck"
-				onMouseEnter={() => setPaused(true)}
-				onMouseLeave={() => setPaused(false)}
+		<>
+			<FeedCardShell
+				headerText={t("feedPage.builderCenterHeader")}
+				headerActions={headerActions}
+				palette="gold"
 			>
-				<ol
-					// key forces remount per window so the fade-in animation re-runs
-					key={`window-${windowIndex}`}
-					className="feed-mini-grid feed-mini-grid--window"
-					aria-label={t("feedPage.builderCenterHeader")}
-					aria-live="polite"
+				{/* biome-ignore lint/a11y/noStaticElementInteractions: pointer handlers only pause auto-advance — keyboard / SR users use the chevron buttons below */}
+				<div
+					className="feed-builder-deck"
+					onMouseEnter={() => setPaused(true)}
+					onMouseLeave={() => setPaused(false)}
 				>
-					{visible.map((card) => (
-						<CardItem key={card.url} card={card} />
-					))}
-				</ol>
-
-				{canRotate && (
-					<div
-						className="feed-builder-deck__controls"
-						role="group"
+					<ol
+						// key forces remount per window so the fade-in animation re-runs
+						key={`window-${windowIndex}`}
+						className="feed-mini-grid feed-mini-grid--window"
 						aria-label={t("feedPage.builderCenterHeader")}
+						aria-live="polite"
 					>
-						<button
-							type="button"
-							className="feed-builder-deck__chev"
-							onClick={() => handleUserStep(-1)}
-							aria-label={t("feedPage.previousArticle")}
+						{visible.map((card) => (
+							<CardItem key={card.url} card={card} />
+						))}
+					</ol>
+
+					{canRotate && (
+						<div
+							className="feed-builder-deck__controls"
+							role="group"
+							aria-label={t("feedPage.builderCenterHeader")}
 						>
-							‹
-						</button>
-						<span
-							className="feed-builder-deck__counter"
-							aria-hidden="true"
-						>{`${windowIndex + 1} / ${windowCount}`}</span>
-						<button
-							type="button"
-							className="feed-builder-deck__chev"
-							onClick={() => handleUserStep(1)}
-							aria-label={t("feedPage.nextArticle")}
-						>
-							›
-						</button>
-					</div>
-				)}
-			</div>
-		</FeedCardShell>
+							<button
+								type="button"
+								className="feed-builder-deck__chev"
+								onClick={() => handleUserStep(-1)}
+								aria-label={t("feedPage.previousArticle")}
+							>
+								‹
+							</button>
+							<span
+								className="feed-builder-deck__counter"
+								aria-hidden="true"
+							>{`${windowIndex + 1} / ${windowCount}`}</span>
+							<button
+								type="button"
+								className="feed-builder-deck__chev"
+								onClick={() => handleUserStep(1)}
+								aria-label={t("feedPage.nextArticle")}
+							>
+								›
+							</button>
+						</div>
+					)}
+				</div>
+			</FeedCardShell>
+
+			{/* wave 56 — click-to-play modal. Only mounted when open so LazyEmbed
+			    never loads the iframe until the user triggers it. */}
+			<Modal
+				visible={modalOpen}
+				onDismiss={() => setModalOpen(false)}
+				size="large"
+				header={t("feedPage.builderCenterVideoTitle")}
+				aria-label={t("feedPage.builderCenterModalAriaLabel")}
+			>
+				<LazyEmbed
+					src={embedSrc}
+					title={t("feedPage.builderCenterVideoTitle")}
+					allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture"
+				/>
+				<div style={{ marginTop: "8px" }}>
+					<Link href={`https://www.youtube.com/watch?v=${VIDEO_ID}`} external>
+						{t("feedPage.builderCenterVideoAuthor")}
+					</Link>
+				</div>
+			</Modal>
+		</>
 	);
 }

--- a/src/pages/feed/components/featured-video-card.tsx
+++ b/src/pages/feed/components/featured-video-card.tsx
@@ -3,6 +3,7 @@
 
 import Link from "@cloudscape-design/components/link";
 import { LazyEmbed } from "../../../components/lazy-embed";
+import type { FeedCardShellPalette } from "./feed-card-shell";
 import FeedCardShell from "./feed-card-shell";
 
 interface FeaturedVideoCardProps {
@@ -11,6 +12,10 @@ interface FeaturedVideoCardProps {
 	author: string;
 	authorUrl: string;
 	thumbnailUrl?: string;
+	/** wave 56 — palette override; defaults to 'lavender' to preserve the
+	 *  existing Women in Tech card appearance. Pass 'gold' for the
+	 *  AWS BuilderCards how-to-play card. */
+	palette?: FeedCardShellPalette;
 }
 
 export default function FeaturedVideoCard({
@@ -19,6 +24,7 @@ export default function FeaturedVideoCard({
 	author,
 	authorUrl,
 	thumbnailUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+	palette = "lavender",
 }: FeaturedVideoCardProps) {
 	const headerActions = (
 		<Link
@@ -36,7 +42,7 @@ export default function FeaturedVideoCard({
 		<FeedCardShell
 			headerText={title}
 			headerActions={headerActions}
-			palette="lavender"
+			palette={palette}
 		>
 			<div className="feed-carousel">
 				<div className="feed-carousel__viewport">


### PR DESCRIPTION
Bryan: 'add a player when you click on AWS Builder center cards that shows https://youtube.com/watch?v=svvgLNWGlEI | add a card for How To Play AWS [Buildercards]'.

## task A — click-to-play modal on BuilderCenterCard
- new 'Watch BuilderCards intro' button (caret-right-filled icon) in FeedCardShell headerActions slot
- opens Cloudscape Modal with lazy YouTube iframe for svvgLNWGlEI ('Building AWS Architectures with BuilderCards' by Ajolotes en la Nube, channel /@AjolotesEnLaNube)
- prefers-reduced-motion: autoplay disabled when reduced motion preferred
- closes on backdrop click + escape
- click affordance is the button NOT the entire card (preserves existing prev/next chevron + auto-advance)

## task B — 'How to play AWS BuilderCards (2023)' feed card
- new SectionKey 'howToPlayBuildercards' in shuffled feed
- reuses wave 18 FeaturedVideoCard primitive (extended with palette prop)
- videoId Pn6w8-abgis by AWS for Games (/@AWSGameTech)
- gold palette (in-family with AWS Builder content vs the lavender Women in Tech card)

## locale keys
- builderCenterWatchIntro / VideoTitle / VideoAuthor / ModalAriaLabel
- howToPlayBuildercardsTitle / Author
- 'AWS for Games' + 'Ajolotes en la Nube' added to allowIdentical Set

## gates
- biome 0 errors
- tsc 0 NEW
- build PASS
- vitest 853 PASS (+11 new cases)