### PR TITLE
fix(feed): wave 57 — event card right-edge overflow on buttons + text

### DIFF
--- a/src/pages/feed/components/__tests__/wave-57-event-card-overflow.test.ts
+++ b/src/pages/feed/components/__tests__/wave-57-event-card-overflow.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Wave 57 — event card right-edge overflow regression guard.
+ *
+ * Bryan: 'right side margins on the event cards the buttons & text currently
+ * go over the edges on the right, the left side margins are good'.
+ *
+ * Root cause: wave 44 added min-width:0 to grid items inside the desktop
+ * @container query for upcoming-virtual-event only. The same fix was never
+ * applied to featured-event or next-meetup — their title/date elements with
+ * white-space:nowrap pushed past the right edge of the minmax(0,1fr) column.
+ *
+ * These tests pin the surgical fix so it can't regress.
+ */
+
+const feedCss = readFileSync(
+	resolve(__dirname, "..", "..", "styles.css"),
+	"utf-8",
+);
+
+/** Extract the content of a @container block by name + breakpoint. */
+function extractContainerBlock(name: string, minWidth: string): string {
+	const pattern = new RegExp(
+		`@container\\s+${name}\\s*\\(min-width:\\s*${minWidth}\\)\\s*\\{`,
+	);
+	const match = feedCss.match(pattern);
+	if (!match?.index) return "";
+	let depth = 0;
+	let start = match.index + match[0].length;
+	for (let i = start; i < feedCss.length; i++) {
+		if (feedCss[i] === "{") depth++;
+		if (feedCss[i] === "}") {
+			if (depth === 0) return feedCss.slice(start, i);
+			depth--;
+		}
+	}
+	return "";
+}
+
+describe("Wave 57 — featured-event right-edge overflow containment", () => {
+	const block = extractContainerBlock("cdn-feed-featured", "860px");
+
+	it("desktop container query applies min-width:0 to .feed-featured-event__title", () => {
+		expect(block).toMatch(
+			/\.feed-featured-event__layout\s+\.feed-featured-event__title[\s\S]*?min-width:\s*0/,
+		);
+	});
+
+	it("desktop container query applies min-width:0 to .feed-featured-event__date", () => {
+		expect(block).toMatch(
+			/\.feed-featured-event__layout\s+\.feed-featured-event__date[\s\S]*?min-width:\s*0/,
+		);
+	});
+
+	it(".feed-featured-event__title has overflow:hidden + text-overflow:ellipsis", () => {
+		expect(feedCss).toMatch(
+			/\.feed-featured-event__title\s*\{[^}]*white-space:\s*nowrap;[^}]*overflow:\s*hidden;[^}]*text-overflow:\s*ellipsis/,
+		);
+	});
+});
+
+describe("Wave 57 — next-meetup right-edge overflow containment", () => {
+	const block = extractContainerBlock("cdn-feed-next-meetup", "860px");
+
+	it("desktop container query applies min-width:0 to .feed-next-meetup__title", () => {
+		expect(block).toMatch(
+			/\.feed-next-meetup__layout\s+\.feed-next-meetup__title[\s\S]*?min-width:\s*0/,
+		);
+	});
+
+	it("desktop container query applies min-width:0 to .feed-next-meetup__date", () => {
+		expect(block).toMatch(
+			/\.feed-next-meetup__layout\s+\.feed-next-meetup__date[\s\S]*?min-width:\s*0/,
+		);
+	});
+
+	it(".feed-next-meetup__title has overflow:hidden + text-overflow:ellipsis", () => {
+		expect(feedCss).toMatch(
+			/\.feed-next-meetup__title\s*\{[^}]*white-space:\s*nowrap;[^}]*overflow:\s*hidden;[^}]*text-overflow:\s*ellipsis/,
+		);
+	});
+});
+
+describe("Wave 57 — upcoming-virtual-event right-edge overflow containment", () => {
+	const block = extractContainerBlock(
+		"cdn-feed-upcoming-virtual-event",
+		"860px",
+	);
+
+	it("desktop container query applies min-width:0 to .feed-upcoming-virtual-event__title", () => {
+		expect(block).toMatch(
+			/\.feed-upcoming-virtual-event__layout\s+\.feed-upcoming-virtual-event__title[\s\S]*?min-width:\s*0/,
+		);
+	});
+
+	it("desktop container query applies min-width:0 to .feed-upcoming-virtual-event__date (wave 44 preserved)", () => {
+		expect(block).toMatch(
+			/\.feed-upcoming-virtual-event__layout\s+\.feed-upcoming-virtual-event__date[\s\S]*?min-width:\s*0/,
+		);
+	});
+
+	it(".feed-upcoming-virtual-event__title has overflow:hidden + text-overflow:ellipsis", () => {
+		expect(feedCss).toMatch(
+			/\.feed-upcoming-virtual-event__title\s*\{[^}]*white-space:\s*nowrap;[^}]*overflow:\s*hidden;[^}]*text-overflow:\s*ellipsis/,
+		);
+	});
+});

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -1461,6 +1461,8 @@
 	   lines at any viewport — the goal Bryan flagged. */
 	font-size: clamp(0.875rem, 3.4cqw, 1.5rem);
 	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .feed-featured-event__title a {
@@ -2161,6 +2163,18 @@
 	.feed-featured-event__layout .cdn-brand-btn-stack {
 		justify-self: start;
 	}
+
+	/* Wave 57 — prevent right-column grid items from overflowing their
+	   track. Grid items default to min-width:auto which respects content
+	   min-content size; the title's white-space:nowrap + date-plate's
+	   nowrap push the column past the container's right edge. min-width:0
+	   lets items shrink within their minmax(0,1fr) track. Mirrors the
+	   wave 44 fix on upcoming-virtual-event. */
+	.feed-featured-event__layout .feed-featured-event__title,
+	.feed-featured-event__layout .feed-featured-event__date,
+	.feed-featured-event__layout .cdn-brand-btn-stack {
+		min-width: 0;
+	}
 }
 
 /* ---------- Upcoming virtual event card — wave 33b uplift ----------
@@ -2555,6 +2569,8 @@
 	   to two lines at any viewport. */
 	font-size: clamp(0.875rem, 3.4cqw, 1.5rem);
 	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .feed-upcoming-virtual-event__title a {
@@ -3332,6 +3348,7 @@
 	   string (e.g. "MDT") pushed the column past the container edge,
 	   clipping the MeetupRsvpButton below it. min-width:0 lets items
 	   shrink within their minmax(0,1fr) track. */
+	.feed-upcoming-virtual-event__layout .feed-upcoming-virtual-event__title,
 	.feed-upcoming-virtual-event__layout .feed-upcoming-virtual-event__date,
 	.feed-upcoming-virtual-event__layout .cdn-brand-btn-stack,
 	.feed-upcoming-virtual-event__layout
@@ -3939,6 +3956,8 @@
 	   prevents the title from wrapping to two lines at any viewport. */
 	font-size: clamp(0.875rem, 3.4cqw, 1.5rem);
 	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .feed-next-meetup__title a {
@@ -4484,6 +4503,15 @@
 
 	.feed-next-meetup__layout .feed-next-meetup__description {
 		margin-inline: 0;
+	}
+
+	/* Wave 57 — prevent right-column grid items from overflowing their
+	   track. Mirrors the wave 44 fix on upcoming-virtual-event. The
+	   title's white-space:nowrap + date-plate's nowrap push the column
+	   past the container's right edge at desktop widths. */
+	.feed-next-meetup__layout .feed-next-meetup__title,
+	.feed-next-meetup__layout .feed-next-meetup__date {
+		min-width: 0;
 	}
 }
 


### PR DESCRIPTION
Bryan: 'please prioritize the right side margins on the event cards the buttons & text they currently go over the edges on the right, the left side margins are good'.

## root cause
Wave 44's min-width:0 fix on right-column grid items in @container ≥860px was applied ONLY to upcoming-virtual-event — NOT to featured-event or next-meetup. All 3 cards carry white-space:nowrap on title/date (wave 41b). Without min-width:0, grid item default min-width:auto prevents shrinking below content width — nowrap content overflows past the minmax(0, 1fr) column track and the card's right edge.

## fix
- min-width:0 on right-column grid items in featured-event + next-meetup desktop reflows (mirrors wave 44)
- overflow:hidden + text-overflow:ellipsis on all 3 cards' title elements (belt-and-suspenders clip)

## gates
- biome 0 errors / 536 warnings
- tsc 0 NEW
- build PASS
- vitest 866 PASS (+9 wave-57 regression cases)