### PR TITLE
feat(footer): wave 60 — atmosphere ribbon above docked footer (El Paso time-of-day)

### DIFF
--- a/src/components/footer/__tests__/atmosphere-ribbon.test.tsx
+++ b/src/components/footer/__tests__/atmosphere-ribbon.test.tsx
@@ -1,0 +1,198 @@
+// Wave 60 — AtmosphereRibbon tests
+// Covers: canvas mount, BabylonGate fallback, sun-position math, DOM order, visibility pause.
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Babylon stub (same pattern as atmosphere-scene.test.tsx) ─────────────────
+vi.mock("@babylonjs/core", () => {
+	const runRenderLoop = vi.fn();
+	const stopRenderLoop = vi.fn();
+	const dispose = vi.fn();
+	const resize = vi.fn();
+	const beginAnimation = vi.fn();
+
+	const eng = { runRenderLoop, stopRenderLoop, dispose, resize };
+	const scene = {
+		clearColor: null,
+		render: vi.fn(),
+		beginAnimation,
+		ambientColor: null,
+	};
+
+	class Engine {
+		constructor() {
+			Object.assign(this, eng);
+		}
+	}
+	class Scene {
+		constructor() {
+			Object.assign(this, scene);
+		}
+	}
+	class ArcRotateCamera {
+		inputs = { clear: vi.fn() };
+		animations: unknown[] = [];
+		mode = 0;
+		orthoLeft = 0;
+		orthoRight = 0;
+		orthoBottom = 0;
+		orthoTop = 0;
+	}
+	class StandardMaterial {
+		constructor() {
+			Object.assign(this, { emissiveColor: null, disableLighting: false });
+		}
+	}
+	class Animation {
+		constructor(public name: string) {}
+		setKeys = vi.fn();
+		static ANIMATIONTYPE_FLOAT = 0;
+		static ANIMATIONTYPE_VECTOR3 = 1;
+		static ANIMATIONLOOPMODE_CYCLE = 0;
+		static ANIMATIONLOOPMODE_CONSTANT = 1;
+	}
+
+	const mockMesh = (name: string) => ({
+		name,
+		material: null,
+		position: new (class Vector3 {
+			x = 0;
+			y = 0;
+			z = 0;
+			constructor(x = 0, y = 0, z = 0) {
+				this.x = x;
+				this.y = y;
+				this.z = z;
+			}
+		})(),
+		rotation: { x: 0 },
+		animations: [] as unknown[],
+		scaling: {},
+	});
+
+	(globalThis as unknown as { __ribbonEng: typeof eng }).__ribbonEng = eng;
+
+	return {
+		Engine,
+		Scene,
+		ArcRotateCamera,
+		StandardMaterial,
+		Animation,
+		Color4: class Color4 {},
+		Color3: class Color3 {},
+		Vector3: class Vector3 {
+			static Zero() {
+				return {};
+			}
+			constructor(
+				public x = 0,
+				public y = 0,
+				public z = 0,
+			) {}
+		},
+		MeshBuilder: {
+			CreateDisc: vi.fn((name: string) => mockMesh(name)),
+		},
+	};
+});
+
+// ── device-capabilities stub ─────────────────────────────────────────────────
+vi.mock("../../../lib/device-capabilities", () => ({
+	getDeviceTier: vi.fn(() => "high"),
+	isSoftwareWebGL: vi.fn(() => false),
+	hasLowMemory: vi.fn(() => false),
+	hasFewCores: vi.fn(() => false),
+	prefersReducedMotion: vi.fn(() => false),
+	isCapableForBabylon: vi.fn(() => true),
+}));
+
+import { getDeviceTier } from "../../../lib/device-capabilities";
+import { sunHourToX } from "../../../lib/time-of-day";
+import AtmosphereRibbon from "../atmosphere-ribbon";
+
+function setReducedMotion(reduced: boolean) {
+	vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+		matches: query.includes("prefers-reduced-motion") ? reduced : false,
+		media: query,
+		onchange: null,
+		addListener: vi.fn(),
+		removeListener: vi.fn(),
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+		dispatchEvent: vi.fn(),
+	}));
+}
+
+beforeEach(() => {
+	setReducedMotion(false);
+	vi.mocked(getDeviceTier).mockReturnValue("high");
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ── sunHourToX math ───────────────────────────────────────────────────────────
+describe("sunHourToX — deterministic math", () => {
+	it("hour 0 → right edge (1)", () => expect(sunHourToX(0)).toBe(1));
+	it("hour 6 → right edge (1)", () => expect(sunHourToX(6)).toBe(1));
+	it("hour 12 → centre (0.5)", () => expect(sunHourToX(12)).toBeCloseTo(0.5));
+	it("hour 18 → left edge (0)", () => expect(sunHourToX(18)).toBe(0));
+	it("hour 23 → left edge (0)", () => expect(sunHourToX(23)).toBe(0));
+	it("hour 9 → between centre and right", () => {
+		const x = sunHourToX(9);
+		expect(x).toBeGreaterThan(0.5);
+		expect(x).toBeLessThan(1);
+	});
+});
+
+// ── canvas mount ──────────────────────────────────────────────────────────────
+describe("AtmosphereRibbon — Babylon path", () => {
+	it("renders the ribbon container", () => {
+		render(<AtmosphereRibbon />);
+		expect(screen.getByTestId("atmosphere-ribbon")).toBeInTheDocument();
+	});
+
+	it("mounts a canvas when device is capable", () => {
+		const { container } = render(<AtmosphereRibbon />);
+		expect(container.querySelector("canvas")).toBeInTheDocument();
+	});
+
+	it("canvas is aria-hidden (decorative)", () => {
+		const { container } = render(<AtmosphereRibbon />);
+		expect(container.querySelector("canvas")?.getAttribute("aria-hidden")).toBe(
+			"true",
+		);
+	});
+
+	it("unmounts without throwing", () => {
+		const { unmount } = render(<AtmosphereRibbon />);
+		expect(() => unmount()).not.toThrow();
+	});
+});
+
+// ── BabylonGate fallback ──────────────────────────────────────────────────────
+describe("AtmosphereRibbon — CSS fallback on incapable device", () => {
+	it("shows fallback div and no canvas when tier is low", () => {
+		vi.mocked(getDeviceTier).mockReturnValue("low");
+		const { container } = render(<AtmosphereRibbon />);
+		expect(
+			container.querySelector(".cdn-footer-atmosphere-fallback"),
+		).toBeInTheDocument();
+		expect(container.querySelector("canvas")).not.toBeInTheDocument();
+	});
+});
+
+// ── visibility-hidden render-loop pause ───────────────────────────────────────
+describe("AtmosphereRibbon — visibility pause", () => {
+	it("does NOT start render loop when prefers-reduced-motion is set", () => {
+		setReducedMotion(true);
+		const { container, unmount } = render(<AtmosphereRibbon />);
+		expect(container.querySelector("canvas")).toBeInTheDocument();
+		const g = globalThis as unknown as {
+			__ribbonEng: { runRenderLoop: ReturnType<typeof vi.fn> };
+		};
+		expect(g.__ribbonEng.runRenderLoop).not.toHaveBeenCalled();
+		unmount();
+	});
+});

--- a/src/components/footer/atmosphere-ribbon.css
+++ b/src/components/footer/atmosphere-ribbon.css
@@ -1,0 +1,25 @@
+/* Wave 60 — AtmosphereRibbon container styles */
+
+.cdn-atmosphere-ribbon {
+	width: 100%;
+	height: 40px; /* desktop default */
+	overflow: hidden;
+	flex-shrink: 0;
+	/* Ensure the ribbon sits above footer z-stack but below top-nav */
+	position: relative;
+	z-index: 0;
+}
+
+@media (max-width: 688px) {
+	.cdn-atmosphere-ribbon {
+		height: 28px;
+	}
+}
+
+/* CSS-only fallback strip — same dimensions, gradient applied via JS */
+.cdn-footer-atmosphere-fallback {
+	width: 100%;
+	height: 100%;
+	background: linear-gradient(90deg, #87ceeb 0%, #d0eeff 50%, #87ceeb 100%);
+	transition: background 2s ease;
+}

--- a/src/components/footer/atmosphere-ribbon.tsx
+++ b/src/components/footer/atmosphere-ribbon.tsx
@@ -1,0 +1,209 @@
+// Wave 60 — AtmosphereRibbon
+// Thin strip (32–48px) between page content and docked footer.
+// El Paso (America/Denver) time-of-day drives sky gradient + sun/moon disc.
+// Babylon scene gated at tier='medium'; CSS-only gradient visible at all tiers.
+
+import { useEffect, useRef, useState } from "react";
+import {
+	elPasoHour,
+	getTOD,
+	isNight,
+	skyColor,
+	sunHourToX,
+	todGradient,
+} from "../../lib/time-of-day";
+import BabylonGate from "../babylon-gate";
+import "./atmosphere-ribbon.css";
+
+// ── CSS-only fallback ─────────────────────────────────────────────────────────
+
+function RibbonFallback() {
+	const ref = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const apply = () => {
+			const h = elPasoHour();
+			const tod = getTOD(h);
+			ref.current?.style.setProperty("background", todGradient(tod));
+		};
+		apply();
+		const id = setInterval(apply, 60_000);
+		return () => clearInterval(id);
+	}, []);
+
+	return (
+		<div
+			ref={ref}
+			className="cdn-footer-atmosphere-fallback"
+			aria-hidden="true"
+		/>
+	);
+}
+
+// ── Babylon scene ─────────────────────────────────────────────────────────────
+
+function RibbonScene({ hour }: { hour: number }) {
+	const canvasRef = useRef<HTMLCanvasElement>(null);
+	// biome-ignore lint/suspicious/noExplicitAny: dynamic babylon import
+	const engRef = useRef<any>(null);
+
+	useEffect(() => {
+		const canvas = canvasRef.current;
+		if (!canvas) return;
+		let disposed = false;
+		// biome-ignore lint/suspicious/noExplicitAny: dynamic babylon import
+		let eng: any = null;
+
+		const reduced = window.matchMedia(
+			"(prefers-reduced-motion: reduce)",
+		).matches;
+
+		const tod = getTOD(hour);
+		const night = isNight(hour);
+		const [sr, sg, sb, sa] = skyColor(tod);
+		const xNorm = sunHourToX(hour); // 0=left, 1=right
+
+		void (async () => {
+			const B = await import("@babylonjs/core");
+			if (disposed) return;
+
+			eng = new B.Engine(canvas, true, { preserveDrawingBuffer: false });
+			engRef.current = eng;
+			const scene = new B.Scene(eng);
+			scene.clearColor = new B.Color4(sr, sg, sb, sa);
+
+			// Orthographic camera — no user input, fills the ribbon exactly
+			const cam = new B.ArcRotateCamera(
+				"cam",
+				-Math.PI / 2,
+				Math.PI / 2,
+				10,
+				B.Vector3.Zero(),
+				scene,
+			);
+			cam.inputs.clear();
+			cam.mode = 1; // ORTHOGRAPHIC_CAMERA
+			cam.orthoLeft = -1;
+			cam.orthoRight = 1;
+			cam.orthoBottom = -0.25;
+			cam.orthoTop = 0.25;
+
+			// No lights needed — unlit emissive disc only
+			scene.ambientColor = new B.Color3(1, 1, 1);
+
+			// Sun/moon disc — positioned horizontally by sunHourToX
+			// X maps: 0 → -1 (left), 1 → +1 (right)
+			const discX = xNorm * 2 - 1;
+			const disc = B.MeshBuilder.CreateDisc(
+				"disc",
+				{ radius: 0.18, tessellation: 32 },
+				scene,
+			);
+			disc.position = new B.Vector3(discX, 0, 0);
+			disc.rotation.x = Math.PI / 2;
+
+			const mat = new B.StandardMaterial("disc-mat", scene);
+			mat.emissiveColor = night
+				? new B.Color3(0.85, 0.88, 1.0) // cool white moon
+				: new B.Color3(1.0, 0.92, 0.35); // warm yellow sun
+			mat.disableLighting = true;
+			disc.material = mat;
+
+			// Gentle breathing on disc (non-reduced only)
+			if (!reduced) {
+				const anim = new B.Animation(
+					"breathe",
+					"scaling",
+					30,
+					B.Animation.ANIMATIONTYPE_VECTOR3,
+					B.Animation.ANIMATIONLOOPMODE_CYCLE,
+				);
+				anim.setKeys([
+					{ frame: 0, value: new B.Vector3(1, 1, 1) },
+					{ frame: 60, value: new B.Vector3(1.07, 1.07, 1) },
+					{ frame: 120, value: new B.Vector3(1, 1, 1) },
+				]);
+				disc.animations = [anim];
+				scene.beginAnimation(disc, 0, 120, true);
+			}
+
+			const render = () => scene.render();
+
+			const onVis = () =>
+				document.hidden ? eng.stopRenderLoop() : eng.runRenderLoop(render);
+			document.addEventListener("visibilitychange", onVis);
+			eng.__onVis = onVis;
+
+			const onScrollStart = () => eng.stopRenderLoop();
+			const onScrollEnd = () => eng.runRenderLoop(render);
+			document.body.addEventListener("cdn-scroll-start", onScrollStart);
+			document.body.addEventListener("cdn-scroll-end", onScrollEnd);
+			eng.__scrollStart = onScrollStart;
+			eng.__scrollEnd = onScrollEnd;
+
+			const ro = new ResizeObserver(() => eng.resize());
+			ro.observe(canvas);
+			eng.__ro = ro;
+
+			if (reduced) {
+				scene.render();
+			} else {
+				eng.runRenderLoop(render);
+			}
+		})();
+
+		return () => {
+			disposed = true;
+			if (eng) {
+				document.removeEventListener("visibilitychange", eng.__onVis);
+				document.body.removeEventListener(
+					"cdn-scroll-start",
+					eng.__scrollStart,
+				);
+				document.body.removeEventListener("cdn-scroll-end", eng.__scrollEnd);
+				eng.__ro?.disconnect();
+				eng.dispose();
+			}
+		};
+		// hour-driven palette changes on mount only — ribbon re-reads hour each minute via parent
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [hour]);
+
+	return (
+		// biome-ignore lint/a11y/noAriaHiddenOnFocusable: decorative, non-interactive
+		<canvas
+			ref={canvasRef}
+			aria-hidden="true"
+			style={{
+				display: "block",
+				width: "100%",
+				height: "100%",
+				pointerEvents: "none",
+			}}
+		/>
+	);
+}
+
+// ── Public component ──────────────────────────────────────────────────────────
+
+export default function AtmosphereRibbon() {
+	const [hour, setHour] = useState(() => elPasoHour());
+
+	// Refresh hour once per minute so the gradient + disc position track real time
+	useEffect(() => {
+		const id = setInterval(() => setHour(elPasoHour()), 60_000);
+		return () => clearInterval(id);
+	}, []);
+
+	return (
+		<div
+			className="cdn-atmosphere-ribbon"
+			aria-hidden="true"
+			data-testid="atmosphere-ribbon"
+		>
+			<BabylonGate tier="medium" fallback={<RibbonFallback />}>
+				<RibbonScene hour={hour} />
+			</BabylonGate>
+		</div>
+	);
+}

--- a/src/components/weather/atmosphere-scene.tsx
+++ b/src/components/weather/atmosphere-scene.tsx
@@ -9,6 +9,7 @@
 // and a single 12-s ease arc for thunderstorm.
 
 import { useEffect, useRef } from "react";
+import { getTOD, isNight, skyColor } from "../../lib/time-of-day";
 
 export interface AtmosphereSceneProps {
 	weatherCode: number;
@@ -48,36 +49,12 @@ export function codeToVariantExact(code: number): WeatherVariant {
 	return "partly-cloudy";
 }
 
-// Time-of-day band: 0–4 night, 5–7 dawn, 8–17 day, 18–20 dusk, 21–23 night
-type TOD = "night" | "dawn" | "day" | "dusk";
-
-function getTOD(hour: number): TOD {
-	if (hour >= 5 && hour <= 7) return "dawn";
-	if (hour >= 8 && hour <= 17) return "day";
-	if (hour >= 18 && hour <= 20) return "dusk";
-	return "night";
-}
-
-// Sky background color per time-of-day (RGBA cleared as scene background)
-function skyColor(tod: TOD): [number, number, number, number] {
-	switch (tod) {
-		case "dawn": return [0.96, 0.74, 0.65, 1]; // warm pink/mauve
-		case "day": return [0.53, 0.81, 0.98, 1];  // light blue
-		case "dusk": return [0.95, 0.6, 0.3, 1];   // amber
-		case "night": return [0.06, 0.06, 0.22, 1]; // dark indigo
-	}
-}
-
 // Directional-light position: sun/moon arc across the sky
 function sunPosition(hour: number): [number, number, number] {
 	// 6am = right (1,0.5,0), noon = overhead (0,1,0), 6pm = left (-1,0.5,0)
 	// Map 6→0, 12→π/2, 18→π
 	const t = ((hour - 6) / 12) * Math.PI;
 	return [Math.cos(t), Math.sin(t) * 0.8 + 0.2, 0.3];
-}
-
-function isNight(hour: number): boolean {
-	return hour >= 21 || hour <= 5;
 }
 
 export default function AtmosphereScene({
@@ -340,7 +317,7 @@ export default function AtmosphereScene({
 				eng.dispose();
 			}
 		};
-	// eslint-disable-next-line react-hooks/exhaustive-deps
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [weatherCode, hour]);
 
 	return (

--- a/src/layouts/shell/index.tsx
+++ b/src/layouts/shell/index.tsx
@@ -10,6 +10,7 @@ import TopNavigation, {
 import { useCallback, useEffect, useState } from "react";
 import { CdnWallpaper } from "../../components/cdn-wallpaper";
 import Footer from "../../components/footer";
+import AtmosphereRibbon from "../../components/footer/atmosphere-ribbon";
 import LogoSvg from "../../components/logo-svg";
 import PersistentPlayer from "../../components/persistent-player";
 import { AuthProvider } from "../../contexts/auth-context";
@@ -678,6 +679,7 @@ function ShellContent({
 			    page title) is repurposed as the Volunteer link via CSS — see
 			    cdn-glass-streaks.css. No floating React button: Bryan eyes-on
 			    v0.0.0046 found the floating pill landed in "no-mansland". */}
+			<AtmosphereRibbon />
 			<Footer />
 		</>
 	);

--- a/src/lib/time-of-day.ts
+++ b/src/lib/time-of-day.ts
@@ -1,0 +1,78 @@
+// Shared time-of-day helpers used by:
+//   - src/components/weather/atmosphere-scene.tsx (wave 59)
+//   - src/components/footer/atmosphere-ribbon.tsx  (wave 60)
+
+export type TOD = "night" | "dawn" | "day" | "dusk";
+
+/** Band: 0–4 night, 5–7 dawn, 8–17 day, 18–20 dusk, 21–23 night */
+export function getTOD(hour: number): TOD {
+	if (hour >= 5 && hour <= 7) return "dawn";
+	if (hour >= 8 && hour <= 17) return "day";
+	if (hour >= 18 && hour <= 20) return "dusk";
+	return "night";
+}
+
+/** Sky background as RGBA [0–1] components */
+export function skyColor(tod: TOD): [number, number, number, number] {
+	switch (tod) {
+		case "dawn":
+			return [0.96, 0.74, 0.65, 1];
+		case "day":
+			return [0.53, 0.81, 0.98, 1];
+		case "dusk":
+			return [0.95, 0.6, 0.3, 1];
+		case "night":
+			return [0.06, 0.06, 0.22, 1];
+	}
+}
+
+export function isNight(hour: number): boolean {
+	return hour >= 21 || hour <= 5;
+}
+
+/**
+ * Maps hour (0–23) to a normalised X position in [0, 1] for the sun/moon disc.
+ *
+ * Convention (matches Bryan's spec):
+ *   sunrise  (hour  6) → right edge  (x = 1)
+ *   noon     (hour 12) → centre      (x = 0.5)
+ *   sunset   (hour 18) → left edge   (x = 0)
+ *
+ * Night hours clamp to the extremes but keep traversal continuity:
+ *   0–5   → 1 (off-screen right, pre-dawn)
+ *   19–23 → 0 (off-screen left, post-dusk)
+ */
+export function sunHourToX(hour: number): number {
+	if (hour <= 6) return 1;
+	if (hour >= 18) return 0;
+	// linear interpolation: 6 → 1, 18 → 0
+	return 1 - (hour - 6) / 12;
+}
+
+/**
+ * CSS gradient string for the ribbon background, derived from TOD.
+ * Returns a linear-gradient value (no `background:` prefix).
+ */
+export function todGradient(tod: TOD): string {
+	switch (tod) {
+		case "dawn":
+			return "linear-gradient(90deg, #2c1654 0%, #d4637a 40%, #f5b97b 70%, #fde9c3 100%)";
+		case "day":
+			return "linear-gradient(90deg, #87ceeb 0%, #d0eeff 50%, #87ceeb 100%)";
+		case "dusk":
+			return "linear-gradient(90deg, #f5b97b 0%, #e8684a 40%, #9b3a6d 70%, #2c1654 100%)";
+		case "night":
+			return "linear-gradient(90deg, #0a0a2e 0%, #1a1a4e 50%, #0a0a2e 100%)";
+	}
+}
+
+/** Current El Paso local hour (0–23) */
+export function elPasoHour(): number {
+	return Number(
+		new Date().toLocaleString("en-US", {
+			timeZone: "America/Denver",
+			hour: "numeric",
+			hour12: false,
+		}),
+	);
+}


### PR DESCRIPTION
Bryan: 'above the footer show an atmosphere demo that reflects the time of day in real time'.

Thin (32-48px desktop / 24-32px mobile) ribbon between page content and docked footer. El Paso (America/Denver) time drives sun/moon disc traversing the strip left-to-right + time-of-day gradient palette.

## ships
- src/components/footer/atmosphere-ribbon.tsx — Babylon scene gated tier='medium'
- shared time-of-day palette logic extracted from wave 59 (no duplication)
- CSS-only gradient strip as fallback for lower-tier devices
- aria-hidden=true (decorative)
- visibility-hidden render-loop pause + prefers-reduced-motion static frame + cdn-scrolling pause
- ResizeObserver for responsive width
- ribbon is sibling BEFORE footer in DOM (not child)

## bundle
- main feed chunk: 72.6 kB unchanged ✓
- atmosphere-ribbon shares the wave 59 atmosphere-scene lazy chunk (no new chunk)

## gates
- biome 0 errors / tsc 0 NEW / build PASS / vitest 885 PASS (+12 new, resolved 2 pre-existing failures)