### PR TITLE
feat(nav): wave 61 — CSS-shader neon-sign typography on sidepanel menu labels

### DIFF
--- a/src/components/navigation/__tests__/menu-signage.test.ts
+++ b/src/components/navigation/__tests__/menu-signage.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CSS_PATH = resolve(__dirname, "..", "menu-signage.css");
+const css = readFileSync(CSS_PATH, "utf-8");
+
+describe("wave 61 — menu-signage neon-sign typography", () => {
+	it("light-mode idle text-shadow meets WCAG-safe low-alpha glow (no high-alpha that would bleed)", () => {
+		// Idle light-mode shadow: 0 0 3px violet at 0.18 + depth shadow at 0.25
+		expect(css).toContain("0 0 3px rgba(90, 31, 138, 0.18)");
+		expect(css).toContain("0 2px 0 rgba(90, 58, 20, 0.25)");
+	});
+
+	it("hover state has more shadow layers than idle (sign lights up)", () => {
+		// Light hover block has 4 shadow layers vs idle's 2
+		const hoverMatch = css.match(
+			/:root:not\(\.awsui-dark-mode\)[^{]*:hover[^{]*\{([^}]+)\}/,
+		);
+		expect(hoverMatch).not.toBeNull();
+		const hoverShadows = (hoverMatch?.[1] ?? "").split(",").length;
+		expect(hoverShadows).toBeGreaterThanOrEqual(4);
+	});
+
+	it("prefers-reduced-motion sets transition: none", () => {
+		expect(css).toContain("@media (prefers-reduced-motion: reduce)");
+		expect(css).toContain("transition: none !important");
+	});
+
+	it("does not contain any infinite animation keywords", () => {
+		expect(css).not.toContain("infinite");
+		expect(css).not.toContain("@keyframes");
+	});
+
+	it("all property overrides use !important per cloudscape-overrides doctrine", () => {
+		// Every text-shadow and transition declaration must end with !important
+		const declarations = css.match(/text-shadow:[^;]+;/g) ?? [];
+		for (const decl of declarations) {
+			expect(decl).toContain("!important");
+		}
+		const transitions = css.match(/transition:[^;]+;/g) ?? [];
+		for (const t of transitions) {
+			expect(t).toContain("!important");
+		}
+	});
+
+	it("dark-mode idle shadow uses violet palette (not amber)", () => {
+		// Dark idle: violet glow + deep depth shadow
+		expect(css).toContain("0 0 3px rgba(144, 96, 240, 0.22)");
+		expect(css).toContain("0 2px 0 rgba(20, 10, 40, 0.4)");
+	});
+});

--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "../../hooks/useAuth";
 import { useTranslation } from "../../hooks/useTranslation";
 import FionaFrame from "../fiona-frame";
 import "./fiona.css";
+import "./menu-signage.css";
 
 // w24 v0.0.0098 added contributor article cards (andres / bryan / wayne) here
 // as a floating <nav> sibling to SideNavigation. v0.0.0104 moved them to the

--- a/src/components/navigation/menu-signage.css
+++ b/src/components/navigation/menu-signage.css
@@ -1,0 +1,84 @@
+/* wave 61 — CSS-shader neon-sign typography on sidepanel menu labels
+   Bryan: 'think adding shaders to 2d to make 3d, thats our approach'
+   Inspiration: babylon playground 8BQJH7 area-light signs
+
+   Design call: flat text color (no background-clip:text gradient) to
+   guarantee WCAG AA 4.5:1 contrast. The 3D depth comes entirely from
+   the multi-layer text-shadow stack. */
+
+/* ── Light mode: warm cream-on-amber ─────────────────────────────────── */
+:root:not(.awsui-dark-mode)
+	[class*="awsui_side-navigation"]
+	[class*="awsui_link"] {
+	text-shadow:
+		0 0 3px rgba(90, 31, 138, 0.18),
+		0 2px 0 rgba(90, 58, 20, 0.25) !important;
+	transition: text-shadow 240ms ease-out !important;
+}
+
+:root:not(.awsui-dark-mode)
+	[class*="awsui_side-navigation"]
+	[class*="awsui_link"]:hover,
+:root:not(.awsui-dark-mode)
+	[class*="awsui_side-navigation"]
+	[class*="awsui_link"]:focus-visible {
+	text-shadow:
+		0 0 4px rgba(90, 31, 138, 0.35),
+		0 0 8px rgba(144, 96, 240, 0.2),
+		0 2px 0 rgba(90, 58, 20, 0.3),
+		0 0 14px rgba(201, 162, 63, 0.15) !important;
+}
+
+/* Active/current page — persistent low glow */
+:root:not(.awsui-dark-mode)
+	[class*="awsui_side-navigation"]
+	[class*="awsui_link"][class*="active"],
+:root:not(.awsui-dark-mode)
+	[class*="awsui_side-navigation"]
+	[class*="awsui_link"][aria-current="page"] {
+	text-shadow:
+		0 0 4px rgba(90, 31, 138, 0.25),
+		0 2px 0 rgba(90, 58, 20, 0.28),
+		0 0 10px rgba(144, 96, 240, 0.12) !important;
+}
+
+/* ── Dark mode: violet-on-navy with amber accent on hover ────────────── */
+.awsui-dark-mode [class*="awsui_side-navigation"] [class*="awsui_link"] {
+	text-shadow:
+		0 0 3px rgba(144, 96, 240, 0.22),
+		0 2px 0 rgba(20, 10, 40, 0.4) !important;
+	transition: text-shadow 240ms ease-out !important;
+}
+
+.awsui-dark-mode [class*="awsui_side-navigation"] [class*="awsui_link"]:hover,
+.awsui-dark-mode
+	[class*="awsui_side-navigation"]
+	[class*="awsui_link"]:focus-visible {
+	text-shadow:
+		0 0 5px rgba(144, 96, 240, 0.4),
+		0 0 10px rgba(90, 31, 138, 0.3),
+		0 2px 0 rgba(20, 10, 40, 0.45),
+		0 0 16px rgba(201, 162, 63, 0.2) !important;
+}
+
+/* Active/current page — persistent low glow */
+.awsui-dark-mode [class*="awsui_side-navigation"]
+	[class*="awsui_link"][class*="active"],
+.awsui-dark-mode
+	[class*="awsui_side-navigation"]
+	[class*="awsui_link"][aria-current="page"] {
+	text-shadow:
+		0 0 4px rgba(144, 96, 240, 0.3),
+		0 2px 0 rgba(20, 10, 40, 0.42),
+		0 0 12px rgba(90, 31, 138, 0.15) !important;
+}
+
+/* ── prefers-reduced-motion: no transitions ──────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+	:root:not(.awsui-dark-mode)
+		[class*="awsui_side-navigation"]
+		[class*="awsui_link"],
+	.awsui-dark-mode [class*="awsui_side-navigation"] [class*="awsui_link"] {
+		transition: none !important;
+	}
+}

--- a/src/components/weather/__tests__/atmosphere-scene.test.tsx
+++ b/src/components/weather/__tests__/atmosphere-scene.test.tsx
@@ -18,9 +18,17 @@ vi.mock("@babylonjs/core", () => {
 	const scene = { clearColor: null, render: vi.fn(), beginAnimation };
 
 	// biome-ignore lint/complexity/noStaticOnlyClass: vitest requires class syntax for constructable mocks
-	class Engine { constructor() { Object.assign(this, eng); } }
+	class Engine {
+		constructor() {
+			Object.assign(this, eng);
+		}
+	}
 	// biome-ignore lint/complexity/noStaticOnlyClass: same
-	class Scene { constructor() { Object.assign(this, scene); } }
+	class Scene {
+		constructor() {
+			Object.assign(this, scene);
+		}
+	}
 	// biome-ignore lint/complexity/noStaticOnlyClass: vitest requires class syntax for constructable mocks
 	class ArcRotateCamera {
 		inputs = { clear: vi.fn() };
@@ -28,11 +36,27 @@ vi.mock("@babylonjs/core", () => {
 		constructor() {}
 	}
 	// biome-ignore lint/complexity/noStaticOnlyClass: same
-	class HemisphericLight { constructor() { Object.assign(this, { intensity: 1, diffuse: null }); } }
+	class HemisphericLight {
+		constructor() {
+			Object.assign(this, { intensity: 1, diffuse: null });
+		}
+	}
 	// biome-ignore lint/complexity/noStaticOnlyClass: same
-	class DirectionalLight { constructor() { Object.assign(this, { intensity: 1, diffuse: null }); } }
+	class DirectionalLight {
+		constructor() {
+			Object.assign(this, { intensity: 1, diffuse: null });
+		}
+	}
 	// biome-ignore lint/complexity/noStaticOnlyClass: same
-	class StandardMaterial { constructor() { Object.assign(this, { emissiveColor: null, alpha: 1, disableLighting: false }); } }
+	class StandardMaterial {
+		constructor() {
+			Object.assign(this, {
+				emissiveColor: null,
+				alpha: 1,
+				disableLighting: false,
+			});
+		}
+	}
 	// biome-ignore lint/complexity/noStaticOnlyClass: same
 	class Animation {
 		constructor(public name: string) {}
@@ -59,7 +83,9 @@ vi.mock("@babylonjs/core", () => {
 		return m;
 	};
 
-	(globalThis as unknown as { __babylonMeshes: typeof meshes }).__babylonMeshes = meshes;
+	(
+		globalThis as unknown as { __babylonMeshes: typeof meshes }
+	).__babylonMeshes = meshes;
 	(globalThis as unknown as { __babylonEng: typeof eng }).__babylonEng = eng;
 
 	return {
@@ -69,9 +95,21 @@ vi.mock("@babylonjs/core", () => {
 		HemisphericLight,
 		DirectionalLight,
 		Animation,
-		Color4: class Color4 { constructor() {} },
-		Color3: class Color3 { constructor() {} static White() { return {}; } },
-		Vector3: class Vector3 { static Zero() { return {}; } constructor() {} },
+		Color4: class Color4 {
+			constructor() {}
+		},
+		Color3: class Color3 {
+			constructor() {}
+			static White() {
+				return {};
+			}
+		},
+		Vector3: class Vector3 {
+			static Zero() {
+				return {};
+			}
+			constructor() {}
+		},
 		MeshBuilder: {
 			CreateSphere: vi.fn((name: string) => mockMesh(name)),
 			CreateCylinder: vi.fn((name: string) => mockMesh(name)),
@@ -108,11 +146,13 @@ afterEach(() => {
 // ── codeToVariantExact unit ──────────────────────────────────────────────────
 describe("codeToVariantExact", () => {
 	it("0 → clear", () => expect(codeToVariantExact(0)).toBe("clear"));
-	it("2 → partly-cloudy", () => expect(codeToVariantExact(2)).toBe("partly-cloudy"));
+	it("2 → partly-cloudy", () =>
+		expect(codeToVariantExact(2)).toBe("partly-cloudy"));
 	it("45 → fog", () => expect(codeToVariantExact(45)).toBe("fog"));
 	it("61 → rain", () => expect(codeToVariantExact(61)).toBe("rain"));
 	it("73 → snow", () => expect(codeToVariantExact(73)).toBe("snow"));
-	it("95 → thunderstorm", () => expect(codeToVariantExact(95)).toBe("thunderstorm"));
+	it("95 → thunderstorm", () =>
+		expect(codeToVariantExact(95)).toBe("thunderstorm"));
 });
 
 // ── Canvas mount ─────────────────────────────────────────────────────────────
@@ -128,7 +168,9 @@ describe("AtmosphereScene", () => {
 		const { container } = render(
 			<AtmosphereScene weatherCode={0} timezone="America/Denver" hour={14} />,
 		);
-		expect(container.querySelector("canvas")?.getAttribute("aria-hidden")).toBe("true");
+		expect(container.querySelector("canvas")?.getAttribute("aria-hidden")).toBe(
+			"true",
+		);
 	});
 
 	it("unmounts without throwing (no engine leaks)", () => {
@@ -153,7 +195,9 @@ describe("AtmosphereScene", () => {
 		// The async Babylon import fires asynchronously after render; synchronously
 		// the render loop has not been started, and with reduced motion the async
 		// branch only calls scene.render() once (static frame) rather than runRenderLoop.
-		const g = globalThis as unknown as { __babylonEng: { runRenderLoop: ReturnType<typeof vi.fn> } };
+		const g = globalThis as unknown as {
+			__babylonEng: { runRenderLoop: ReturnType<typeof vi.fn> };
+		};
 		expect(g.__babylonEng.runRenderLoop).not.toHaveBeenCalled();
 		unmount();
 	});

--- a/src/components/weather/index.tsx
+++ b/src/components/weather/index.tsx
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: MIT-0
 
 import { lazy, useCallback, useEffect, useRef, useState } from "react";
-import BabylonGate from "../babylon-gate";
 import { getBandBass } from "../../lib/background-viz/audio";
+import BabylonGate from "../babylon-gate";
 import { CITIES, type City } from "./cities";
 import "./styles.css";
 
-const AtmosphereScene = lazy(
-	() => import("./atmosphere-scene"),
-);
+const AtmosphereScene = lazy(() => import("./atmosphere-scene"));
 
 /** Extract the current local hour (0–23) in the given IANA timezone. */
 function localHour(timezone: string): number {
@@ -375,10 +373,7 @@ export default function Weather() {
 			onKeyDown={onKeyDown}
 			style={{ position: "relative", overflow: "hidden" }}
 		>
-			<BabylonGate
-				tier="medium"
-				fallback={null}
-			>
+			<BabylonGate tier="medium" fallback={null}>
 				<AtmosphereScene
 					weatherCode={cur.weather_code}
 					timezone={city.timezone}


### PR DESCRIPTION
Bryan: 'see the signs on [babylon playground 8BQJH7]... think adding shaders to 2d to make 3d, thats our approach'.

Multi-layer text-shadow stack on SideNavigation menu labels — 'sign lighting up' effect without mounting full Babylon per label.

- Idle 2-layer / hover 4-layer / active 3-layer shadows
- Light/dark mode parity (violet+brown / violet+navy+amber)
- WCAG AA contrast preserved (flat color)
- 240ms transition, no infinite animation per epilepsy rules
- prefers-reduced-motion: instant swap

biome 0 / tsc 0 NEW / build PASS / vitest 890+ PASS (+6 wave-61 cases)