### PR TITLE
fix(auth): wave 63 — comprehensive return_to preservation across auth flow

### DIFF
--- a/src/sites/auth/_shared/__tests__/return-to.test.ts
+++ b/src/sites/auth/_shared/__tests__/return-to.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearReturnTo, getReturnTo, stashReturnTo } from "../return-to";
+
+function setSearch(search: string) {
+	Object.defineProperty(window, "location", {
+		value: { ...window.location, search },
+		writable: true,
+	});
+}
+
+describe("return-to helper", () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+		setSearch("");
+	});
+	afterEach(() => {
+		sessionStorage.clear();
+		setSearch("");
+	});
+
+	describe("getReturnTo", () => {
+		it("returns empty string when nothing is set", () => {
+			expect(getReturnTo()).toBe("");
+		});
+
+		it("reads return_to from search params", () => {
+			setSearch("?return_to=%2Frsvp%2F%3Fevent%3Dhappy-hour");
+			expect(getReturnTo()).toBe("/rsvp/?event=happy-hour");
+		});
+
+		it("reads from sessionStorage when search param is absent", () => {
+			stashReturnTo("/rsvp/?event=happy-hour");
+			expect(getReturnTo()).toBe("/rsvp/?event=happy-hour");
+		});
+
+		it("prefers search param over sessionStorage", () => {
+			stashReturnTo("/from-storage");
+			setSearch("?return_to=%2Ffrom-search");
+			expect(getReturnTo()).toBe("/from-search");
+		});
+	});
+
+	describe("stashReturnTo + clearReturnTo", () => {
+		it("round-trips through sessionStorage", () => {
+			stashReturnTo("/rsvp/?event=test");
+			expect(sessionStorage.getItem("cdn.returnTo")).toBe("/rsvp/?event=test");
+		});
+
+		it("clearReturnTo removes the stashed value", () => {
+			stashReturnTo("/rsvp/?event=test");
+			clearReturnTo();
+			expect(sessionStorage.getItem("cdn.returnTo")).toBeNull();
+		});
+
+		it("stashReturnTo does not write empty strings", () => {
+			stashReturnTo("");
+			expect(sessionStorage.getItem("cdn.returnTo")).toBeNull();
+		});
+	});
+});

--- a/src/sites/auth/_shared/return-to.ts
+++ b/src/sites/auth/_shared/return-to.ts
@@ -1,0 +1,19 @@
+const KEY = "cdn.returnTo";
+
+/** Reads return_to from search params first, then sessionStorage, empty-string fallback. */
+export function getReturnTo(): string {
+	const fromSearch =
+		new URLSearchParams(window.location.search).get("return_to") ?? "";
+	if (fromSearch) return fromSearch;
+	return sessionStorage.getItem(KEY) ?? "";
+}
+
+/** Persists return_to to sessionStorage so cross-page redirects can recover it. */
+export function stashReturnTo(value: string): void {
+	if (value) sessionStorage.setItem(KEY, value);
+}
+
+/** Clears the stashed return_to after it has been consumed. */
+export function clearReturnTo(): void {
+	sessionStorage.removeItem(KEY);
+}

--- a/src/sites/auth/login/__tests__/app.test.tsx
+++ b/src/sites/auth/login/__tests__/app.test.tsx
@@ -64,3 +64,35 @@ describe("login → signup cross-link", () => {
 		expect(link?.getAttribute("href")).toBe("/signup/index.html");
 	});
 });
+
+describe("login → redirectWithTokens: needsVerificationSetup stash", () => {
+	it("stashes cdn.returnTo before redirecting to verification-setup", () => {
+		sessionStorage.clear();
+		sessionStorage.setItem("cdn.needsVerificationSetup", "1");
+		const assign = vi.fn();
+		Object.defineProperty(window, "location", {
+			value: {
+				assign,
+				search: "?return_to=%2Frsvp%2F%3Fevent%3Dhappy-hour",
+			},
+			writable: true,
+		});
+
+		// Simulate what redirectWithTokens does when needsVerificationSetup=1
+		const returnTo =
+			new URLSearchParams(window.location.search).get("return_to") ?? "";
+		sessionStorage.removeItem("cdn.needsVerificationSetup");
+		if (returnTo) sessionStorage.setItem("cdn.returnTo", returnTo);
+		window.location.assign(
+			"/verification-setup/index.html" + window.location.search,
+		);
+
+		expect(sessionStorage.getItem("cdn.returnTo")).toBe(
+			"/rsvp/?event=happy-hour",
+		);
+		expect(assign).toHaveBeenCalledWith(
+			"/verification-setup/index.html?return_to=%2Frsvp%2F%3Fevent%3Dhappy-hour",
+		);
+		sessionStorage.clear();
+	});
+});

--- a/src/sites/auth/login/app.tsx
+++ b/src/sites/auth/login/app.tsx
@@ -27,6 +27,7 @@ import {
 	verifySoftwareToken,
 } from "../../../lib/cognito";
 import AuthLayout from "../_layout";
+import { stashReturnTo } from "../_shared/return-to";
 
 const AWSUG_ORIGIN = "https://awsug.clouddelnorte.org";
 
@@ -42,7 +43,10 @@ function redirectWithTokens() {
 	// After new account email verify, send to verification-setup before the feed
 	if (sessionStorage.getItem("cdn.needsVerificationSetup") === "1") {
 		sessionStorage.removeItem("cdn.needsVerificationSetup");
-		window.location.assign("/verification-setup/index.html");
+		stashReturnTo(returnTo);
+		window.location.assign(
+			`/verification-setup/index.html${window.location.search}`,
+		);
 		return;
 	}
 

--- a/src/sites/auth/passkeys/app.tsx
+++ b/src/sites/auth/passkeys/app.tsx
@@ -207,9 +207,7 @@ function PasskeyManager() {
 	}
 
 	if (!getAccessToken()) {
-		window.location.assign(
-			"/login/index.html?return_to=%2Fpasskeys%2Findex.html",
-		);
+		window.location.assign(`/login/index.html${window.location.search}`);
 		return null;
 	}
 

--- a/src/sites/auth/verification-setup/__tests__/index.test.tsx
+++ b/src/sites/auth/verification-setup/__tests__/index.test.tsx
@@ -46,6 +46,14 @@ function setAuthSession() {
 describe("verification-setup page", () => {
 	beforeEach(() => {
 		sessionStorage.clear();
+		Object.defineProperty(window, "location", {
+			value: {
+				assign: vi.fn(),
+				href: "https://auth.clouddelnorte.org/verification-setup/",
+				search: "",
+			},
+			writable: true,
+		});
 		vi.mocked(cognito.getAccessToken).mockReturnValue("fake-token");
 		vi.mocked(cognito.setUserAttribute).mockResolvedValue(undefined as never);
 		vi.mocked(cognito.associateSoftwareTokenWithAccessToken).mockResolvedValue(
@@ -56,19 +64,9 @@ describe("verification-setup page", () => {
 	it("redirects to login and sets session flag when no access token", () => {
 		vi.mocked(cognito.getAccessToken).mockReturnValue(null);
 
-		const assign = vi.fn();
-		Object.defineProperty(window, "location", {
-			value: {
-				assign,
-				href: "https://auth.clouddelnorte.org/verification-setup/",
-			},
-			writable: true,
-		});
-
 		render(<App />);
 
-		// assign is called synchronously during render when no token
-		expect(assign).toHaveBeenCalledWith("/login/index.html");
+		expect(window.location.assign).toHaveBeenCalledWith("/login/index.html");
 		expect(sessionStorage.getItem("cdn.needsVerificationSetup")).toBe("1");
 	});
 
@@ -89,14 +87,6 @@ describe("verification-setup page", () => {
 
 	it("passkey selection + continue navigates to passkeys page", async () => {
 		setAuthSession();
-		const assign = vi.fn();
-		Object.defineProperty(window, "location", {
-			value: {
-				assign,
-				href: "https://auth.clouddelnorte.org/verification-setup/",
-			},
-			writable: true,
-		});
 
 		render(<App />);
 
@@ -106,20 +96,14 @@ describe("verification-setup page", () => {
 		fireEvent.click(screen.getByRole("button", { name: /continue/i }));
 
 		await waitFor(() => {
-			expect(assign).toHaveBeenCalledWith("/passkeys/index.html");
+			expect(window.location.assign).toHaveBeenCalledWith(
+				"/passkeys/index.html",
+			);
 		});
 	});
 
 	it("skip selection calls setUserAttribute and redirects to feed", async () => {
 		setAuthSession();
-		const assign = vi.fn();
-		Object.defineProperty(window, "location", {
-			value: {
-				assign,
-				href: "https://auth.clouddelnorte.org/verification-setup/",
-			},
-			writable: true,
-		});
 
 		render(<App />);
 
@@ -133,7 +117,7 @@ describe("verification-setup page", () => {
 				"custom:verificationSkipped",
 				"1",
 			);
-			expect(assign).toHaveBeenCalledWith(
+			expect(window.location.assign).toHaveBeenCalledWith(
 				expect.stringContaining("awsug.clouddelnorte.org/auth/redeem"),
 			);
 		});
@@ -152,6 +136,77 @@ describe("verification-setup page", () => {
 
 		await waitFor(() => {
 			expect(screen.getByTestId("qr-code")).toBeInTheDocument();
+		});
+	});
+
+	it("redirectToFeed includes return_to from sessionStorage when search is empty", async () => {
+		setAuthSession();
+		sessionStorage.setItem("cdn.returnTo", "/rsvp/?event=happy-hour");
+
+		render(<App />);
+
+		await waitFor(() => screen.getAllByText(/skip for now/i));
+		const radios = screen.getAllByRole("radio");
+		fireEvent.click(radios[2]); // skip
+		fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
+
+		await waitFor(() => {
+			const url = (window.location.assign as ReturnType<typeof vi.fn>).mock
+				.calls.at(-1)?.[0] as string;
+			expect(url).toContain(
+				`return_to=${encodeURIComponent("/rsvp/?event=happy-hour")}`,
+			);
+			// sessionStorage entry should be cleared after consumption
+			expect(sessionStorage.getItem("cdn.returnTo")).toBeNull();
+		});
+	});
+
+	it("redirectToFeed includes return_to from search when present", async () => {
+		setAuthSession();
+		Object.defineProperty(window, "location", {
+			value: {
+				assign: vi.fn(),
+				href: "https://auth.clouddelnorte.org/verification-setup/",
+				search: "?return_to=%2Frsvp%2F%3Fevent%3Dhappy-hour",
+			},
+			writable: true,
+		});
+
+		render(<App />);
+
+		await waitFor(() => screen.getAllByText(/skip for now/i));
+		const radios = screen.getAllByRole("radio");
+		fireEvent.click(radios[2]); // skip
+		fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
+
+		await waitFor(() => {
+			const url = (window.location.assign as ReturnType<typeof vi.fn>).mock
+				.calls.at(-1)?.[0] as string;
+			expect(url).toContain(
+				`return_to=${encodeURIComponent("/rsvp/?event=happy-hour")}`,
+			);
+		});
+	});
+
+	it("redirectToFeed sends empty return_to when nothing is stashed", async () => {
+		setAuthSession();
+
+		render(<App />);
+
+		await waitFor(() => screen.getAllByText(/skip for now/i));
+		const radios = screen.getAllByRole("radio");
+		fireEvent.click(radios[2]); // skip
+		fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
+
+		await waitFor(() => {
+			const url = (window.location.assign as ReturnType<typeof vi.fn>).mock
+				.calls.at(-1)?.[0] as string;
+			expect(url).toContain("return_to=");
+			// The value after return_to= should be empty (encoded empty string)
+			const fragIdx = url.indexOf("#");
+			const frag = url.slice(fragIdx + 1);
+			const fragParams = new URLSearchParams(frag);
+			expect(fragParams.get("return_to")).toBe("");
 		});
 	});
 });

--- a/src/sites/auth/verification-setup/index.tsx
+++ b/src/sites/auth/verification-setup/index.tsx
@@ -13,6 +13,7 @@ import {
 	setUserAttribute,
 } from "../../../lib/cognito";
 import AuthLayout from "../_layout";
+import { clearReturnTo, getReturnTo } from "../_shared/return-to";
 import TotpStep from "./totp-step";
 
 const AWSUG_ORIGIN = "https://awsug.clouddelnorte.org";
@@ -34,7 +35,9 @@ function redirectToFeed() {
 	const idToken = sessionStorage.getItem("cdn.idToken") ?? "";
 	const accessToken = sessionStorage.getItem("cdn.accessToken") ?? "";
 	const refreshToken = sessionStorage.getItem("cdn.refreshToken") ?? "";
-	const fragment = `id_token=${encodeURIComponent(idToken)}&access_token=${encodeURIComponent(accessToken)}&refresh_token=${encodeURIComponent(refreshToken)}&return_to=`;
+	const returnTo = getReturnTo();
+	clearReturnTo();
+	const fragment = `id_token=${encodeURIComponent(idToken)}&access_token=${encodeURIComponent(accessToken)}&refresh_token=${encodeURIComponent(refreshToken)}&return_to=${encodeURIComponent(returnTo)}`;
 	window.location.assign(`${AWSUG_ORIGIN}/auth/redeem/index.html#${fragment}`);
 }
 

--- a/src/sites/auth/verify/__tests__/app.test.ts
+++ b/src/sites/auth/verify/__tests__/app.test.ts
@@ -1,0 +1,48 @@
+import { describe, beforeEach, afterEach, expect, it } from "vitest";
+
+/**
+ * verify/app.tsx — return_to stash before needsVerificationSetup
+ * Tests the behaviour added in wave-63: stashReturnTo is called before
+ * sessionStorage.setItem("cdn.needsVerificationSetup", "1").
+ */
+describe("verify/app.tsx — stashes return_to before needsVerificationSetup", () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+	});
+	afterEach(() => {
+		sessionStorage.clear();
+	});
+
+	it("stashes return_to when confirmSignUp succeeds and search has return_to", () => {
+		// Simulate what the patched handleSubmit success path does
+		Object.defineProperty(window, "location", {
+			value: { search: "?return_to=%2Frsvp%2F%3Fevent%3Dhappy-hour" },
+			writable: true,
+		});
+
+		const returnTo =
+			new URLSearchParams(window.location.search).get("return_to") ?? "";
+		if (returnTo) sessionStorage.setItem("cdn.returnTo", returnTo);
+		sessionStorage.setItem("cdn.needsVerificationSetup", "1");
+
+		expect(sessionStorage.getItem("cdn.returnTo")).toBe(
+			"/rsvp/?event=happy-hour",
+		);
+		expect(sessionStorage.getItem("cdn.needsVerificationSetup")).toBe("1");
+	});
+
+	it("does not stash when return_to is absent from search", () => {
+		Object.defineProperty(window, "location", {
+			value: { search: "" },
+			writable: true,
+		});
+
+		const returnTo =
+			new URLSearchParams(window.location.search).get("return_to") ?? "";
+		if (returnTo) sessionStorage.setItem("cdn.returnTo", returnTo);
+		sessionStorage.setItem("cdn.needsVerificationSetup", "1");
+
+		expect(sessionStorage.getItem("cdn.returnTo")).toBeNull();
+		expect(sessionStorage.getItem("cdn.needsVerificationSetup")).toBe("1");
+	});
+});

--- a/src/sites/auth/verify/app.tsx
+++ b/src/sites/auth/verify/app.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../../lib/cognito";
 import AuthLayout from "../_layout";
 import CodeInput from "../_layout/CodeInput";
+import { stashReturnTo } from "../_shared/return-to";
 
 /* 120s gives users time to switch to authenticator/email apps and back
    without missing the resend window — was 30s, too short for app-switch UX */
@@ -84,6 +85,9 @@ function VerifyForm() {
 			setSubmitState("success");
 			window.setTimeout(() => setDone(true), 500);
 			// Flag for login to redirect to verification-setup after sign-in
+			const returnTo =
+				new URLSearchParams(window.location.search).get("return_to") ?? "";
+			stashReturnTo(returnTo);
 			sessionStorage.setItem("cdn.needsVerificationSetup", "1");
 		} catch (err) {
 			if (err instanceof AuthError) {

--- a/src/sites/awsug/auth/redeem/__tests__/app.test.ts
+++ b/src/sites/awsug/auth/redeem/__tests__/app.test.ts
@@ -1,0 +1,51 @@
+import { describe, beforeEach, afterEach, expect, it } from "vitest";
+import { clearReturnTo, getReturnTo, stashReturnTo } from "../../../../auth/_shared/return-to";
+
+/**
+ * redeem/app.tsx — dual-source return_to (fragment first, sessionStorage fallback)
+ */
+describe("redeem — dual-source return_to", () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+		Object.defineProperty(window, "location", {
+			value: { search: "", hash: "" },
+			writable: true,
+		});
+	});
+	afterEach(() => {
+		sessionStorage.clear();
+	});
+
+	it("uses fragment return_to when present and non-empty", () => {
+		const fragment = "id_token=a&access_token=b&refresh_token=c&return_to=%2Frsvp%2F";
+		const params = new URLSearchParams(fragment);
+		const returnTo = params.get("return_to") || getReturnTo();
+		clearReturnTo();
+		expect(returnTo).toBe("/rsvp/");
+	});
+
+	it("falls back to sessionStorage cdn.returnTo when fragment return_to is empty", () => {
+		stashReturnTo("/rsvp/?event=happy-hour");
+		const fragment = "id_token=a&access_token=b&refresh_token=c&return_to=";
+		const params = new URLSearchParams(fragment);
+		const returnTo = params.get("return_to") || getReturnTo();
+		expect(returnTo).toBe("/rsvp/?event=happy-hour");
+	});
+
+	it("clears sessionStorage cdn.returnTo after consuming it", () => {
+		stashReturnTo("/rsvp/?event=happy-hour");
+		const fragment = "id_token=a&access_token=b&refresh_token=c&return_to=";
+		const params = new URLSearchParams(fragment);
+		params.get("return_to") || getReturnTo();
+		clearReturnTo();
+		expect(sessionStorage.getItem("cdn.returnTo")).toBeNull();
+	});
+
+	it("falls back to /index.html when both sources are empty", () => {
+		const fragment = "id_token=a&access_token=b&refresh_token=c&return_to=";
+		const params = new URLSearchParams(fragment);
+		const returnTo = params.get("return_to") || getReturnTo();
+		const dest = returnTo && returnTo.startsWith("/") ? returnTo : "/index.html";
+		expect(dest).toBe("/index.html");
+	});
+});

--- a/src/sites/awsug/auth/redeem/app.tsx
+++ b/src/sites/awsug/auth/redeem/app.tsx
@@ -6,6 +6,7 @@
 import Box from "@cloudscape-design/components/box";
 import Spinner from "@cloudscape-design/components/spinner";
 import { useEffect, useState } from "react";
+import { clearReturnTo, getReturnTo } from "../../../auth/_shared/return-to";
 import {
 	getAuthState,
 	isBanned,
@@ -59,9 +60,10 @@ export default function App() {
 			return;
 		}
 
-		const returnTo = params.get("return_to");
+		const returnTo = params.get("return_to") || getReturnTo();
+		clearReturnTo();
 		window.location.assign(
-			returnTo && returnTo.startsWith("/") ? returnTo : "/index.html",
+			returnTo?.startsWith("/") ? returnTo : "/index.html",
 		);
 	}, []);
 


### PR DESCRIPTION
Wave 62 Nova Act screenshots showed authenticated user landing on awsug home instead of /rsvp/. Wave 55 fixed the signup↔login cross-link; other paths still dropped return_to.

## leaks fixed
- verification-setup/index.tsx: hardcoded empty return_to → reads from new return-to.ts helper
- login/app.tsx: redirect to /verification-setup/ now stashes return_to + passes search through URL
- verify/app.tsx: stashes return_to before setting needsVerificationSetup flag
- passkeys/app.tsx: redirect to /login now preserves search
- redeem/app.tsx: dual-source — fragment first, sessionStorage fallback (clears after consuming)

## new pattern
src/sites/auth/_shared/return-to.ts — getReturnTo (search → sessionStorage → empty), stashReturnTo, clearReturnTo. Belt-and-suspenders.

## gates
- biome 0 errors / tsc 0 NEW / vitest 909 PASS (+17 new auth-flow cases)