### PR TITLE
fix(feed): wave 65 — RSVP CTA links to /rsvp/index.html (not /rsvp/) to avoid CloudFront fallback

### DIFF
--- a/src/pages/feed/components/__tests__/featured-event.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-event.test.tsx
@@ -44,7 +44,7 @@ describe("FeaturedEvent", () => {
 	it("renders the v2 event title with link to auth.clouddelnorte.org signup with rsvp return_to", () => {
 		renderWithLocale("us");
 		const link = screen.getByText("Community Happy Hour & Networking Night");
-		const expected = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent("/rsvp/?event=happy-hour-2026-06-03")}`;
+		const expected = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent("/rsvp/index.html?event=happy-hour-2026-06-03")}`;
 		expect(link.closest("a")).toHaveAttribute("href", expected);
 	});
 
@@ -104,8 +104,8 @@ describe("FeaturedEvent", () => {
 		const link = container.querySelector(".feed-featured-event__image-link");
 		expect(link).not.toBeNull();
 		// href matches the same speakeasy CTA URL the primary RSVP button
-		// uses (encoded /rsvp/?event=happy-hour-2026-06-03 return path).
-		const expectedHref = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent("/rsvp/?event=happy-hour-2026-06-03")}`;
+		// uses (encoded /rsvp/index.html?event=happy-hour-2026-06-03 return path).
+		const expectedHref = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent("/rsvp/index.html?event=happy-hour-2026-06-03")}`;
 		expect(link?.getAttribute("href")).toBe(expectedHref);
 		// aria-label resolves through the new feedPage.featuredEventImageLinkLabel
 		// locale key — describes the link action; the inner <img> alt text
@@ -216,7 +216,7 @@ describe("FeaturedEvent", () => {
 		const primary = screen.getByRole("link", {
 			name: /RSVP on CloudDelNorte\.org/i,
 		});
-		const expected = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent("/rsvp/?event=happy-hour-2026-06-03")}`;
+		const expected = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent("/rsvp/index.html?event=happy-hour-2026-06-03")}`;
 		expect(primary).toHaveAttribute("href", expected);
 	});
 

--- a/src/pages/feed/components/featured-event.tsx
+++ b/src/pages/feed/components/featured-event.tsx
@@ -23,7 +23,7 @@ import AsciiSmirk from "./ascii-smirk";
 const EVENT_ID = "happy-hour-2026-06-03";
 const EVENT_IMAGE_LIGHT = "/events/featured-2026-06-03.webp";
 const EVENT_IMAGE_DARK = "/events/featured-2026-06-03-dark.webp";
-const RSVP_RETURN_PATH = `/rsvp/?event=${EVENT_ID}`;
+const RSVP_RETURN_PATH = `/rsvp/index.html?event=${EVENT_ID}`;
 const RSVP_PAGE_URL = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent(RSVP_RETURN_PATH)}`;
 /** Anchor inside the description string after which the inline smirk renders. */
 const SMIRK_ANCHOR = "game";


### PR DESCRIPTION
Wave 64 Nova Act revealed authenticated user landing on awsug home not /rsvp/. Root cause: `RSVP_RETURN_PATH = '/rsvp/?event=…'` (trailing slash, no index.html) — hits CloudFront default fallback (`x-cache: Error from cloudfront`) and serves awsug home. The explicit `/rsvp/index.html?event=…` path serves the actual page.

Same class of bug Bryan documented in navigation/index.tsx: 'Trailing-slash routes hit the S3+CloudFront default fallback... Always link to /…/index.html explicitly'.

## fixed
- src/pages/feed/components/featured-event.tsx — RSVP_RETURN_PATH: `/rsvp/?event=` → `/rsvp/index.html?event=`
- 3 href test assertions updated

## gates
- biome 0 / tsc 0 NEW / build PASS / vitest 913 PASS