### PR TITLE
fix(streams): wave 67 — AWS podcast RSS CORS bypass via build-time JSON

### DIFF
--- a/src/lib/__tests__/streams.test.ts
+++ b/src/lib/__tests__/streams.test.ts
@@ -94,6 +94,19 @@ describe("STREAMS — Wave 22 fixes", () => {
 	});
 });
 
+describe("STREAMS — Wave 67 CORS bypass", () => {
+	it("aws_podcast has corsBlocked: true (CloudFront CDN emits no ACAO header)", () => {
+		const s = STREAMS.find((s) => s.key === "aws_podcast");
+		expect(s).toBeDefined();
+		expect(s?.corsBlocked).toBe(true);
+	});
+
+	it("rust_in_production retains corsBlocked: true (letscast.fm no ACAO)", () => {
+		const s = STREAMS.find((s) => s.key === "rust_in_production");
+		expect(s?.corsBlocked).toBe(true);
+	});
+});
+
 describe("STREAMS — Wave 23 additions", () => {
 	it("radio_unam_961 exists with correct location", () => {
 		const unam = STREAMS.find((s) => s.key === "radio_unam_961");

--- a/src/lib/streams.ts
+++ b/src/lib/streams.ts
@@ -737,12 +737,14 @@ export const STREAMS: StreamDef[] = [
 	{
 		// AWS Podcast RSS at d3gih7jbfe3jlq.cloudfront.net does not emit
 		// Access-Control-Allow-Origin headers → browser fetch() is CORS-blocked.
-		// Episode title will not surface in the player UI; the hardcoded Episode 754
-		// mp3 will play until go-aws.com DNS resolves and rssAudioUrl updates.
+		// corsBlocked: true skips the runtime RSS fetch; build-time fetch-feeds.mjs
+		// pre-fetches the feed server-side and writes to podcast-episodes.json,
+		// which is consumed instead (wave 67 fix for Bryan's reported CORS error).
 		// curated: Bryan's canonical AWS podcast (not the aws_developers_podcast which
 		// is hidden/broken). This is the production weekly AWS news show.
 		key: "aws_podcast",
 		curated: true, // Bryan's known-good list: canonical weekly AWS podcast, CloudFront audio CDN
+		corsBlocked: true, // d3gih7jbfe3jlq.cloudfront.net emits no ACAO header — browser fetch blocked
 		type: "podcast",
 		url: "https://d1le29qyzha1u4.cloudfront.net/AWS_Podcast_Episode_754.mp3",
 		rssFeedUrl: "https://d3gih7jbfe3jlq.cloudfront.net/aws-podcast.rss",


### PR DESCRIPTION
Bryan: console error 'Access to fetch at d3gih7jbfe3jlq.cloudfront.net/aws-podcast.rss... blocked by CORS policy'.

The AWS Podcast CDN doesn't emit CORS headers. Runtime browser fetch was blocked. fetch-feeds.mjs already pre-fetches the feed server-side at build time → public/data/podcast-episodes.json. The persistent-player already guards on `corsBlocked: true` flag (wave 13 pattern).

## fix
- src/lib/streams.ts `aws_podcast` stream: added `corsBlocked: true`
- Player skips runtime fetch(rssFeedUrl); uses build-time podcast-episodes.json
- Confirmed only one other CORS-blocked stream (`rust_in_production` — already has the flag from wave 23)

## gates
- biome 0 errors / tsc 0 NEW / build PASS / vitest 911+ PASS