### PR TITLE
fix(feed): wave 68 — shorts carousel: drop wave 52 spin placeholder + 3-line 'Fight For Our Existence' header

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -136,7 +136,7 @@
 		"spinOldestBadge": "oldest",
 		"spinPlaceholderAriaLabel": "Video preview — spin to browse",
 		"shortsHeader": "Mescalero shorts on YouTube",
-		"shortsHostBlurb": "Hosted by Ma-tonth, sharing conversations on Oak Flat, Indigenous culture, and the MMIP movement.",
+		"shortsHostBlurb": "Fight For Our Existence Podcast, hosted by Ma-tonth, sharing conversations on Oak Flat, Indigenous culture, & the MMIP movement",
 		"shortsEmpty": "No shorts yet — check back soon",
 		"shortsPlay": "Play short",
 		"shortsModalTitle": "Mescalero short",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -136,7 +136,7 @@
 		"spinOldestBadge": "más antiguo",
 		"spinPlaceholderAriaLabel": "Vista previa de video — gira para explorar",
 		"shortsHeader": "shorts mescaleros en YouTube",
-		"shortsHostBlurb": "Conducido por Ma-tonth, compartiendo conversaciones sobre Oak Flat, cultura indígena y el movimiento MMIP.",
+		"shortsHostBlurb": "Podcast Fight For Our Existence, conducido por Ma-tonth, compartiendo pláticas sobre Oak Flat, cultura indígena y el movimiento MMIP",
 		"shortsEmpty": "todavía no hay shorts — vuelve pronto, raza",
 		"shortsPlay": "ponle play al short",
 		"shortsModalTitle": "short mescalero",

--- a/src/pages/feed/components/__tests__/wave-52-spin.test.tsx
+++ b/src/pages/feed/components/__tests__/wave-52-spin.test.tsx
@@ -14,9 +14,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { LocaleProvider } from "../../../../contexts/locale-context";
-import YouTubeShortsCarousel, {
-	type YouTubeShort,
-} from "../youtube-shorts-carousel";
 import {
 	type SpinItem,
 	YouTubeSpinPlaceholder,
@@ -43,27 +40,6 @@ const OLDEST: SpinItem = {
 	thumbnailUrl: "https://i.ytimg.com/vi/v-old/hqdefault.jpg",
 	publishedAt: "2024-01-10",
 };
-
-const SHORTS: YouTubeShort[] = [
-	{
-		videoId: "v-new",
-		title: "Newest video title",
-		thumbnailUrl: "https://i.ytimg.com/vi/v-new/hqdefault.jpg",
-		publishedAt: "2026-05-15",
-	},
-	{
-		videoId: "v-mid",
-		title: "Middle video title",
-		thumbnailUrl: "https://i.ytimg.com/vi/v-mid/hqdefault.jpg",
-		publishedAt: "2025-06-01",
-	},
-	{
-		videoId: "v-old",
-		title: "Oldest video title",
-		thumbnailUrl: "https://i.ytimg.com/vi/v-old/hqdefault.jpg",
-		publishedAt: "2024-01-10",
-	},
-];
 
 // ---------------------------------------------------------------------------
 // 1. Skeleton placeholder renders when no data
@@ -364,44 +340,8 @@ describe("Wave 52 — CSS guards", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 5. YouTubeShortsCarousel — placeholder integration
+// 5. (removed wave 68) — YouTubeShortsCarousel no longer renders
+//    YouTubeSpinPlaceholder. Tests for the primitive itself stay above (1–4).
+//    Tests for its usage on youtube-carousel + youtube-channel-carousel live
+//    in their own test files.
 // ---------------------------------------------------------------------------
-
-describe("Wave 52 — YouTubeShortsCarousel placeholder", () => {
-	it("renders spin placeholder (spin-btn) while data is loading (no shorts prop)", () => {
-		// No shorts prop → ready=false, should show placeholder
-		withLocale(
-			<LocaleProvider locale="us">
-				<YouTubeShortsCarousel dataUrl="/data/nonexistent.json" />
-			</LocaleProvider>,
-		);
-		// spin-btn is present in the placeholder even before data arrives
-		expect(screen.getByTestId("spin-btn")).toBeInTheDocument();
-	});
-
-	it("renders newest spin card after data arrives", () => {
-		withLocale(<YouTubeShortsCarousel shorts={SHORTS} />);
-		const cards = screen.getAllByTestId("spin-card");
-		expect(cards[0]).toHaveAttribute("aria-label", SHORTS[0].title);
-	});
-
-	it("renders oldest spin card after data arrives", () => {
-		withLocale(<YouTubeShortsCarousel shorts={SHORTS} />);
-		const cards = screen.getAllByTestId("spin-card");
-		expect(cards[1]).toHaveAttribute(
-			"aria-label",
-			SHORTS[SHORTS.length - 1].title,
-		);
-	});
-
-	it("renders empty-state message when shorts array is empty", () => {
-		withLocale(<YouTubeShortsCarousel shorts={[]} />);
-		expect(screen.getByTestId("shorts-empty-state")).toBeInTheDocument();
-	});
-
-	it("spin placeholder uses data-spin-anchor for wave 53 Babylon mount", () => {
-		withLocale(<YouTubeShortsCarousel shorts={SHORTS} />);
-		const anchor = document.querySelector("[data-spin-anchor='true']");
-		expect(anchor).toBeInTheDocument();
-	});
-});

--- a/src/pages/feed/components/__tests__/youtube-shorts-carousel.test.tsx
+++ b/src/pages/feed/components/__tests__/youtube-shorts-carousel.test.tsx
@@ -87,7 +87,9 @@ describe("YouTubeShortsCarousel", () => {
 
 	it("renders the host-attribution blurb above the carousel", () => {
 		renderWith(SAMPLE_SHORTS);
-		expect(screen.getByText(/Hosted by Ma-tonth,/i)).toBeInTheDocument();
+		expect(
+			screen.getByText(/Fight For Our Existence Podcast,/i),
+		).toBeInTheDocument();
 	});
 
 	it("opens the modal embed when a thumbnail is clicked", () => {

--- a/src/pages/feed/components/youtube-shorts-carousel.css
+++ b/src/pages/feed/components/youtube-shorts-carousel.css
@@ -11,38 +11,25 @@
 	width: 100%;
 }
 
-/* ----- Wave 42a — host attribution header --------------------------------
-   Bryan asked to replace the Cloudscape <Header variant="h2">"Mescalero
-   shorts on YouTube"</Header> with the host blurb, and to "ensure it
-   responsively fits all text on 2 lines at all screen sizes — there's
-   some wasted / awkward spacing on this card". The youtube-shorts-
-   carousel.tsx Container now renders this div as its header slot. The
-   role="heading" + aria-level=2 attributes in the JSX preserve the h2
-   ARIA contract that Cloudscape Header provided.
-   - clamp() font-size scales between mobile (~14px) and desktop (~17px)
-     without media queries; the floor preserves legibility on phones,
-     the ceiling matches the wave 38b headline tier on the event cards.
-   - display: -webkit-box + -webkit-line-clamp: 2 + -webkit-box-orient:
-     vertical caps the rendering at 2 lines — the longest blurb today
-     ("Hosted by Ma-tonth (Rolling Fox), this channel shares real
-     conversations on Oak Flat, Indigenous culture, and the MMIP
-     movement.") wraps to 2 lines at desktop and stays at 2 lines via
-     ellipsis at the narrowest mobile widths.
-   - line-height: 1.25 keeps the two lines tight without crowding.
-   - color + font-weight match the other shell marquee headers so the
-     family read stays cohesive across the feed grid.
+/* ----- Wave 42a / Wave 68 — host attribution header ---------------------
+   Wave 68: blurb expanded to full podcast name ("Fight For Our Existence
+   Podcast, hosted by Ma-tonth, ..."); -webkit-line-clamp bumped to 3 so
+   the longer text fills 3 lines at all breakpoints without overflow.
+   font-size clamp() floor lowered to 0.8rem so the full text fits 3 tight
+   lines even at narrow mobile; line-height tightened to 1.3 (was 1.25)
+   to prevent the 3-line block from dominating vertical space.
    ------------------------------------------------------------------------ */
 .feed-shorts__attribution-header {
 	display: -webkit-box;
-	-webkit-line-clamp: 2;
+	-webkit-line-clamp: 3;
 	-webkit-box-orient: vertical;
 	overflow: hidden;
 	white-space: normal;
 	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-	font-size: clamp(0.875rem, 0.78rem + 0.4cqw, 1.0625rem);
+	font-size: clamp(0.8rem, 0.72rem + 0.5cqw, 1.0625rem);
 	font-weight: 700;
 	letter-spacing: 0.01em;
-	line-height: 1.25;
+	line-height: 1.3;
 	color: var(--cdn-color-text);
 	margin: 0;
 }

--- a/src/pages/feed/components/youtube-shorts-carousel.tsx
+++ b/src/pages/feed/components/youtube-shorts-carousel.tsx
@@ -19,9 +19,9 @@ import Container from "@cloudscape-design/components/container";
 import Modal from "@cloudscape-design/components/modal";
 import SegmentedControl from "@cloudscape-design/components/segmented-control";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { SkeletonLine, SkeletonTitle } from "../../../components/skeleton";
 import { useTranslation } from "../../../hooks/useTranslation";
 import "./youtube-shorts-carousel.css";
-import { YouTubeSpinPlaceholder } from "./youtube-spin-placeholder";
 
 export interface YouTubeShort {
 	videoId: string;
@@ -159,32 +159,9 @@ export default function YouTubeShortsCarousel({
 			: t("feedPage.shortsEmpty")
 		: "";
 
-	// Wave 52 — newest/oldest for the spin placeholder.
-	// posts[0] = newest (RSS order), posts[posts.length-1] = oldest.
-	const newestShort = shorts.length > 0 ? shorts[0] : null;
-	const oldestShort = shorts.length > 1 ? shorts[shorts.length - 1] : null;
-
 	return (
 		<Container
 			header={
-				// Wave 42a — Bryan asked: "instead of putting Hosted by Ma-tonth
-				// (Rolling Fox)... under 'Mescalero shorts on YouTube' replace
-				// 'Mescalero shorts on YouTube' with it". The wave 24e
-				// Cloudscape <Header variant="h2"> + the wave 41a body Box that
-				// rendered the host blurb under the header are both retired —
-				// the host attribution IS the header now. role="heading" +
-				// aria-level=2 reasserts the h2 ARIA contract since we're
-				// trading Cloudscape's <h2> chrome for the custom div. The
-				// .feed-shorts__attribution-header CSS rule (in
-				// youtube-shorts-carousel.css) clamps the font-size with
-				// clamp() and caps at 2 lines via -webkit-line-clamp so the
-				// blurb fits responsively at every viewport — addressing
-				// Bryan's "wasted / awkward spacing on this card" note.
-				// feedPage.shortsHeader is preserved as the aria-label on the
-				// inner carousel <div role="group"> below so AT users still
-				// hear "Mescalero shorts on YouTube" as the carousel
-				// description even though the visible header is now the host
-				// blurb.
 				<div
 					className="feed-shorts__attribution-header"
 					role="heading"
@@ -194,51 +171,21 @@ export default function YouTubeShortsCarousel({
 				</div>
 			}
 		>
-			{/* Wave 52 — spin placeholder shown while loading or when data is empty */}
 			{!ready ? (
-				<YouTubeSpinPlaceholder
-					newest={null}
-					oldest={null}
-					spinLabel={t("feedPage.spinBtnLabel")}
-					ariaLabel={t("feedPage.spinPlaceholderAriaLabel")}
-					i18n={{
-						newestBadge: t("feedPage.spinNewestBadge"),
-						oldestBadge: t("feedPage.spinOldestBadge"),
-					}}
-				/>
-			) : orderedShorts.length === 0 ? (
 				<>
-					<YouTubeSpinPlaceholder
-						newest={null}
-						oldest={null}
-						spinLabel={t("feedPage.spinBtnLabel")}
-						ariaLabel={t("feedPage.spinPlaceholderAriaLabel")}
-						i18n={{
-							newestBadge: t("feedPage.spinNewestBadge"),
-							oldestBadge: t("feedPage.spinOldestBadge"),
-						}}
-					/>
-					<Box
-						color="text-status-inactive"
-						fontSize="body-s"
-						data-testid="shorts-empty-state"
-					>
-						{t("feedPage.shortsEmpty")}
-					</Box>
+					<SkeletonTitle />
+					<SkeletonLine />
 				</>
+			) : orderedShorts.length === 0 ? (
+				<Box
+					color="text-status-inactive"
+					fontSize="body-s"
+					data-testid="shorts-empty-state"
+				>
+					{t("feedPage.shortsEmpty")}
+				</Box>
 			) : (
 				<>
-					<YouTubeSpinPlaceholder
-						newest={newestShort}
-						oldest={oldestShort}
-						spinLabel={t("feedPage.spinBtnLabel")}
-						ariaLabel={t("feedPage.spinPlaceholderAriaLabel")}
-						onSelect={(id) => setModalShortId(id)}
-						i18n={{
-							newestBadge: t("feedPage.spinNewestBadge"),
-							oldestBadge: t("feedPage.spinOldestBadge"),
-						}}
-					/>
 					<div className="feed-shorts-carousel__sort" data-testid="shorts-sort">
 						<Box
 							fontSize="body-s"


### PR DESCRIPTION
Bryan: 'two rows of video only show one and ditch the spin feature - add to the front of the title "Fight For Our Existence Podcast, hosted by Ma-tonth, sharing conversations on Oak Flat, Indigenous culture, & the MMIP movement" work to ensure it responsively fills up 3 lines'.

## removals
- YouTubeSpinPlaceholder usage on shorts carousel (3 instances) — the wave 52 addition rendered above the actual carousel, creating the 2-row appearance. Component primitive stays for youtube-carousel + youtube-channel-carousel.
- newestShort/oldestShort derivations (only used by the removed placeholder)

## copy
- en shortsHostBlurb: 'Fight For Our Existence Podcast, hosted by Ma-tonth, sharing conversations on Oak Flat, Indigenous culture, & the MMIP movement'
- es: 'Podcast Fight For Our Existence, conducido por Ma-tonth, compartiendo pláticas sobre Oak Flat, cultura indígena y el movimiento MMIP'

## CSS
- header -webkit-line-clamp 2 → 3
- clamp() font-size tuned for 3-line fit at all breakpoints
- line-height tightened to ~1.3

## gates
- biome 0 / tsc 0 NEW / build PASS / vitest passes