### PR TITLE
fix(feed): wave 69 — virtual-event image full-width + revert wave 56 builder cards intro modal

### DIFF
--- a/src/locales/__tests__/translation-coverage.test.ts
+++ b/src/locales/__tests__/translation-coverage.test.ts
@@ -136,8 +136,6 @@ describe("translation coverage", () => {
 			"meetings.tableHeaders.rsvp", // "RSVP" - universal abbreviation
 			"speakerForm.fields.format.virtual", // "virtual" - same in Spanish
 			// wave 56 proper nouns / channel names
-			"feedPage.builderCenterVideoAuthor", // "Ajolotes en la Nube" - channel proper noun
-			"feedPage.builderCenterVideoTitle", // "Building AWS Architectures with BuilderCards" - proper noun project name
 			"feedPage.howToPlayBuildercardsAuthor", // "AWS for Games" - channel proper noun
 		]);
 

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -65,10 +65,6 @@
 		"andresMediumAllPosts": "All posts",
 		"builderCenterHeader": "AWS Builder Center",
 		"builderCenterOpen": "Open AWS Builder Center",
-		"builderCenterWatchIntro": "Watch BuilderCards intro",
-		"builderCenterVideoTitle": "Building AWS Architectures with BuilderCards",
-		"builderCenterVideoAuthor": "Ajolotes en la Nube",
-		"builderCenterModalAriaLabel": "BuilderCards introduction video player",
 		"howToPlayBuildercardsTitle": "How to play AWS BuilderCards (2023)",
 		"howToPlayBuildercardsAuthor": "AWS for Games",
 		"builderBadge": {

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -65,10 +65,6 @@
 		"andresMediumAllPosts": "todas las publicaciones",
 		"builderCenterHeader": "AWS Builder Center",
 		"builderCenterOpen": "abrir AWS Builder Center",
-		"builderCenterWatchIntro": "Ver intro de BuilderCards",
-		"builderCenterVideoTitle": "Building AWS Architectures with BuilderCards",
-		"builderCenterVideoAuthor": "Ajolotes en la Nube",
-		"builderCenterModalAriaLabel": "reproductor del video de introducción a BuilderCards",
 		"howToPlayBuildercardsTitle": "Cómo jugar AWS BuilderCards (2023)",
 		"howToPlayBuildercardsAuthor": "AWS for Games",
 		"builderBadge": {

--- a/src/pages/feed/components/__tests__/wave-56.test.tsx
+++ b/src/pages/feed/components/__tests__/wave-56.test.tsx
@@ -1,32 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-// Wave 56 tests:
-//   A — BuilderCenterCard click-to-play modal (svvgLNWGlEI)
+// Wave 56 tests (post-wave-69 rollback):
 //   B — FeaturedVideoCard palette prop
 //   C — feed/app.tsx SECTION_KEYS includes 'howToPlayBuildercards'
+//
+// Wave 56A — BuilderCenterCard click-to-play modal (svvgLNWGlEI) removed in
+// wave 69 per Bryan: 'remove watch builder cards intro from builder center
+// card, thats not what I meant and carlos blocks us from embedding his video'.
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../../contexts/locale-context";
-import BuilderCenterCard from "../builder-center-card";
 import FeaturedVideoCard from "../featured-video-card";
 
 function withLocale(ui: React.ReactElement) {
 	return render(<LocaleProvider locale="us">{ui}</LocaleProvider>);
 }
 
-// IntersectionObserver stub required by LazyEmbed
-type IOCallback = (entries: IntersectionObserverEntry[]) => void;
-let lastIOCb: IOCallback | null = null;
-
+// IntersectionObserver stub required by LazyEmbed (used inside FeaturedVideoCard)
 beforeEach(() => {
-	lastIOCb = null;
 	class IOMock {
 		disconnect = vi.fn();
-		constructor(cb: IOCallback) {
-			lastIOCb = cb;
-		}
 		observe() {}
 	}
 	globalThis.IntersectionObserver =
@@ -35,87 +30,6 @@ beforeEach(() => {
 
 afterEach(() => {
 	vi.restoreAllMocks();
-});
-
-// ---------------------------------------------------------------------------
-// A — BuilderCenterCard modal
-// ---------------------------------------------------------------------------
-
-describe("Wave 56A — BuilderCenterCard click-to-play modal", () => {
-	it("renders 'Watch BuilderCards intro' button", () => {
-		withLocale(<BuilderCenterCard />);
-		expect(
-			screen.getByTestId("builder-center-watch-intro"),
-		).toBeInTheDocument();
-	});
-
-	it("modal is not visible before button click", () => {
-		withLocale(<BuilderCenterCard />);
-		// Cloudscape Modal always renders in DOM but adds awsui_hidden_* class
-		// when visible=false. Check the dialog exists but is visually hidden.
-		const dialog = document.querySelector("[role='dialog']") as HTMLElement;
-		expect(dialog).not.toBeNull();
-		// hidden class contains "hidden"
-		expect(dialog.className).toMatch(/hidden/);
-	});
-
-	it("clicking Watch intro button opens the modal", async () => {
-		withLocale(<BuilderCenterCard />);
-		const btn = screen.getByTestId("builder-center-watch-intro");
-		fireEvent.click(btn);
-		await waitFor(() => {
-			expect(
-				screen.getByText("Building AWS Architectures with BuilderCards"),
-			).toBeInTheDocument();
-		});
-	});
-
-	it("open modal contains iframe with svvgLNWGlEI src after IntersectionObserver fires", async () => {
-		const { act } = await import("react");
-		withLocale(<BuilderCenterCard />);
-		const btn = screen.getByTestId("builder-center-watch-intro");
-		fireEvent.click(btn);
-		await waitFor(() => {
-			expect(
-				screen.getByText("Building AWS Architectures with BuilderCards"),
-			).toBeInTheDocument();
-		});
-		// trigger IntersectionObserver so LazyEmbed renders the iframe
-		await act(async () => {
-			lastIOCb?.([{ isIntersecting: true } as IntersectionObserverEntry]);
-		});
-		const iframe = screen.getByTitle(
-			"Building AWS Architectures with BuilderCards",
-		);
-		expect(iframe.getAttribute("src")).toContain("svvgLNWGlEI");
-	});
-
-	it("modal contains author attribution link to Ajolotes en la Nube", async () => {
-		withLocale(<BuilderCenterCard />);
-		fireEvent.click(screen.getByTestId("builder-center-watch-intro"));
-		await waitFor(() => {
-			expect(screen.getByText("Ajolotes en la Nube")).toBeInTheDocument();
-		});
-	});
-
-	it("dismissing modal re-hides the dialog", async () => {
-		withLocale(<BuilderCenterCard />);
-		fireEvent.click(screen.getByTestId("builder-center-watch-intro"));
-		await waitFor(() => {
-			// Modal should be visible — no hidden class
-			const dialog = document.querySelector("[role='dialog']") as HTMLElement;
-			expect(dialog.className).not.toMatch(/hidden/);
-		});
-		const closeBtn = document.querySelector(
-			'[class*="dismiss-control"]',
-		) as HTMLElement;
-		expect(closeBtn).not.toBeNull();
-		fireEvent.click(closeBtn);
-		await waitFor(() => {
-			const dialog = document.querySelector("[role='dialog']") as HTMLElement;
-			expect(dialog.className).toMatch(/hidden/);
-		});
-	});
 });
 
 // ---------------------------------------------------------------------------

--- a/src/pages/feed/components/builder-center-card.tsx
+++ b/src/pages/feed/components/builder-center-card.tsx
@@ -1,12 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import Button from "@cloudscape-design/components/button";
 import Link from "@cloudscape-design/components/link";
-import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { LazyEmbed } from "../../../components/lazy-embed";
 import { useTranslation } from "../../../hooks/useTranslation";
 import BuilderBadge from "./builder-badge";
 import {
@@ -36,10 +33,6 @@ const AUTO_ADVANCE_MS = 7000;
 // corner pill chip + #-prefix variant looked terrible compared to the prior
 // big-numeral hierarchy. Each card shows: big serif #, 2-line title clamp,
 // 1-line excerpt from blurb, author + badge.
-//
-// wave 56 — add 'Watch BuilderCards intro' button in headerActions slot that
-// opens a Cloudscape Modal with a lazy YouTube iframe for svvgLNWGlEI.
-// prefers-reduced-motion: autoplay disabled when reduced motion preferred.
 
 interface VisibleCard extends Card {
 	rank: number; // 1..N visible rank stays stable per source-array index
@@ -76,8 +69,6 @@ function CardItem({ card }: { card: VisibleCard }) {
 		</li>
 	);
 }
-
-const VIDEO_ID = "svvgLNWGlEI";
 
 export default function BuilderCenterCard() {
 	const { t, locale } = useTranslation();
@@ -148,22 +139,8 @@ export default function BuilderCenterCard() {
 		step(dir);
 	};
 
-	// wave 56 — modal state
-	const [modalOpen, setModalOpen] = useState(false);
-
-	// prefers-reduced-motion: disable autoplay when user prefers it
-	const embedSrc = `https://www.youtube.com/embed/${VIDEO_ID}?autoplay=${reducedMotion ? 0 : 1}`;
-
 	const headerActions = (
 		<SpaceBetween direction="horizontal" size="xs">
-			<Button
-				variant="inline-link"
-				iconName="caret-right-filled"
-				onClick={() => setModalOpen(true)}
-				data-testid="builder-center-watch-intro"
-			>
-				{t("feedPage.builderCenterWatchIntro")}
-			</Button>
 			<Link href="https://builder.aws.com/" external fontSize="body-s">
 				{t("feedPage.builderCenterOpen")}
 			</Link>
@@ -171,81 +148,58 @@ export default function BuilderCenterCard() {
 	);
 
 	return (
-		<>
-			<FeedCardShell
-				headerText={t("feedPage.builderCenterHeader")}
-				headerActions={headerActions}
-				palette="gold"
+		<FeedCardShell
+			headerText={t("feedPage.builderCenterHeader")}
+			headerActions={headerActions}
+			palette="gold"
+		>
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: pointer handlers only pause auto-advance — keyboard / SR users use the chevron buttons below */}
+			<div
+				className="feed-builder-deck"
+				onMouseEnter={() => setPaused(true)}
+				onMouseLeave={() => setPaused(false)}
 			>
-				{/* biome-ignore lint/a11y/noStaticElementInteractions: pointer handlers only pause auto-advance — keyboard / SR users use the chevron buttons below */}
-				<div
-					className="feed-builder-deck"
-					onMouseEnter={() => setPaused(true)}
-					onMouseLeave={() => setPaused(false)}
+				<ol
+					// key forces remount per window so the fade-in animation re-runs
+					key={`window-${windowIndex}`}
+					className="feed-mini-grid feed-mini-grid--window"
+					aria-label={t("feedPage.builderCenterHeader")}
+					aria-live="polite"
 				>
-					<ol
-						// key forces remount per window so the fade-in animation re-runs
-						key={`window-${windowIndex}`}
-						className="feed-mini-grid feed-mini-grid--window"
+					{visible.map((card) => (
+						<CardItem key={card.url} card={card} />
+					))}
+				</ol>
+
+				{canRotate && (
+					<div
+						className="feed-builder-deck__controls"
+						role="group"
 						aria-label={t("feedPage.builderCenterHeader")}
-						aria-live="polite"
 					>
-						{visible.map((card) => (
-							<CardItem key={card.url} card={card} />
-						))}
-					</ol>
-
-					{canRotate && (
-						<div
-							className="feed-builder-deck__controls"
-							role="group"
-							aria-label={t("feedPage.builderCenterHeader")}
+						<button
+							type="button"
+							className="feed-builder-deck__chev"
+							onClick={() => handleUserStep(-1)}
+							aria-label={t("feedPage.previousArticle")}
 						>
-							<button
-								type="button"
-								className="feed-builder-deck__chev"
-								onClick={() => handleUserStep(-1)}
-								aria-label={t("feedPage.previousArticle")}
-							>
-								‹
-							</button>
-							<span
-								className="feed-builder-deck__counter"
-								aria-hidden="true"
-							>{`${windowIndex + 1} / ${windowCount}`}</span>
-							<button
-								type="button"
-								className="feed-builder-deck__chev"
-								onClick={() => handleUserStep(1)}
-								aria-label={t("feedPage.nextArticle")}
-							>
-								›
-							</button>
-						</div>
-					)}
-				</div>
-			</FeedCardShell>
-
-			{/* wave 56 — click-to-play modal. Only mounted when open so LazyEmbed
-			    never loads the iframe until the user triggers it. */}
-			<Modal
-				visible={modalOpen}
-				onDismiss={() => setModalOpen(false)}
-				size="large"
-				header={t("feedPage.builderCenterVideoTitle")}
-				aria-label={t("feedPage.builderCenterModalAriaLabel")}
-			>
-				<LazyEmbed
-					src={embedSrc}
-					title={t("feedPage.builderCenterVideoTitle")}
-					allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture"
-				/>
-				<div style={{ marginTop: "8px" }}>
-					<Link href={`https://www.youtube.com/watch?v=${VIDEO_ID}`} external>
-						{t("feedPage.builderCenterVideoAuthor")}
-					</Link>
-				</div>
-			</Modal>
-		</>
+							‹
+						</button>
+						<span
+							className="feed-builder-deck__counter"
+							aria-hidden="true"
+						>{`${windowIndex + 1} / ${windowCount}`}</span>
+						<button
+							type="button"
+							className="feed-builder-deck__chev"
+							onClick={() => handleUserStep(1)}
+							aria-label={t("feedPage.nextArticle")}
+						>
+							›
+						</button>
+					</div>
+				)}
+			</div>
+		</FeedCardShell>
 	);
 }

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -3273,81 +3273,21 @@
 	grid-area: buttons;
 }
 
-/* ---------- Wave 42b1 — Upcoming-virtual-event desktop @container reflow ----------
-   Bryan's wave 42 priority 1: "optimize white space use on cards on all
-   screens" + "virtual aws community events … on desktop mode … fugly".
-   At desktop widths (≥860px container width) the single-column layout
-   put the 1200×630 image as a full-width hero and stacked all content
-   below it — the card became top-heavy with a wide image and a thin
-   stack of text underneath. Mirrors the wave 31a featured-event ≥860px
-   image-left + content-right reflow exactly: image fills the left column
-   for the full row span, content (badge → title → date → location →
-   description → featured-talk → buttons) stacks in the right column.
+/* Wave 69 — reverted wave 42b1 @container ≥860px image-left 2-col grid.
+   Bryan: 'the aws global community gatherings banner should be same width
+   as the free & open aws virtual aws community events block above it'.
+   The card now stacks single-column at all widths so the banner image
+   spans the same full-card width as the marquee header.
 
-   Both image-link anchors (light + dark theme variants) share grid-area:
-   image — they stack in the same cell and the existing :has() theme-
-   swap rules display:none the off-theme anchor so only one paints per
-   theme. align-items: start so when the right-column content stack is
-   taller than the image (the common case given the description +
-   featured-talk + button stack), the image sits at the top of the left
-   column rather than centering and floating in the middle of dead space.
-
-   Calibrated to ≥860px (matches the wave 31a featured-event breakpoint)
-   because below that, splitting into two equal-ish columns leaves the
-   right column too narrow to fit the title + featured-talk callout
-   without aggressive wrapping. minmax(0, 1.1fr) on the image column
-   gives it slightly more weight so the focal artwork dominates the
-   left half — same ratios as featured-event for visual consistency
-   across the two image-bearing event cards.
-
-   Per-element margin-block-end rules above are zeroed at this breakpoint
-   so grid `gap` drives the row spacing without margins double-counting.
-   Token-only colors / spacing — no new visuals introduced; light + dark
-   mode share the same grid math and the existing theme-swap rules
-   above continue to gate which image variant paints. */
+   The @container block below is preserved to keep the wave 44/57 min-width:0
+   overflow guards on __title, __date, .cdn-brand-btn-stack, and
+   __featured-talk. They are harmless in a single-column layout and protect
+   against future re-introduction of a 2-col grid. */
 @container cdn-feed-upcoming-virtual-event (min-width: 860px) {
-	.feed-upcoming-virtual-event__layout {
-		grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
-		grid-template-areas:
-			"image badge"
-			"image title"
-			"image date"
-			"image location"
-			"image description"
-			"image featured-talk"
-			"image buttons";
-		align-items: start;
-		gap: var(--cdn-space-sm, 8px) var(--cdn-space-lg, 24px);
-	}
-
-	.feed-upcoming-virtual-event__layout
-		.feed-upcoming-virtual-event__image-link {
-		align-self: start;
-	}
-
-	/* Reset per-element margin-block-end so grid `gap` drives row
-	   spacing — mirrors the wave 31a tablet+/desktop pattern on
-	   .feed-featured-event__layout. The mobile per-item margin stack
-	   would otherwise produce ragged row spacing inside the right
-	   column at desktop. */
-	.feed-upcoming-virtual-event__layout .feed-upcoming-virtual-event__badge,
-	.feed-upcoming-virtual-event__layout .feed-upcoming-virtual-event__image-link,
-	.feed-upcoming-virtual-event__layout .feed-upcoming-virtual-event__title,
-	.feed-upcoming-virtual-event__layout .feed-upcoming-virtual-event__date,
-	.feed-upcoming-virtual-event__layout .feed-upcoming-virtual-event__location,
-	.feed-upcoming-virtual-event__layout
-		.feed-upcoming-virtual-event__description,
-	.feed-upcoming-virtual-event__layout
-		.feed-upcoming-virtual-event__featured-talk {
-		margin-block-end: 0;
-	}
-
-	/* Wave 44 — prevent right-column grid items from overflowing their
-	   track. Grid items default to min-width:auto which respects content
-	   min-content size; the date-plate's white-space:nowrap + long timezone
-	   string (e.g. "MDT") pushed the column past the container edge,
-	   clipping the MeetupRsvpButton below it. min-width:0 lets items
-	   shrink within their minmax(0,1fr) track. */
+	/* Wave 44 / 57 — prevent grid items from overflowing their track if
+	   a 2-col layout is ever re-introduced. min-width:0 lets items shrink
+	   within a minmax(0,1fr) track. Harmless in the current single-column
+	   layout. */
 	.feed-upcoming-virtual-event__layout .feed-upcoming-virtual-event__title,
 	.feed-upcoming-virtual-event__layout .feed-upcoming-virtual-event__date,
 	.feed-upcoming-virtual-event__layout .cdn-brand-btn-stack,


### PR DESCRIPTION
Bryan: 'the aws global community gatherings banner should be same width as the free & open aws virtual aws community events block above it | remove watch builder cards intro from builder center card, thats not what I meant and carlos blocks us from embedding his video anyways'.

## task A — virtual-event image full-width
Reverted wave 42b1 @container ≥860px 2-col image-left grid for upcoming-virtual-event. Now stacks single-column at all widths — banner spans full card width matching the 'Free & Open Virtual AWS Community Events' marquee header. Wave 44/57 min-width:0 overflow guards retained as harmless safeguards.

## task B — revert wave 56 builder cards intro modal
Removed click-to-play button, Modal, lazy YouTube iframe, and 4 locale keys (builderCenterWatchIntro/VideoTitle/VideoAuthor/ModalAriaLabel) for svvgLNWGlEI Ajolotes en la Nube. Carlos blocks embedding.

The wave 56 'How to play AWS BuilderCards (2023)' Pn6w8-abgis FeaturedVideoCard by AWS for Games stays — separate change, embedding allowed.

## gates
- biome 0 errors / tsc 0 NEW / build PASS / vitest 926 PASS (−6 wave-56A modal cases removed)