### PR TITLE
fix: wave 70a — RSVP→Apúntate (es), hamburger visibility on scroll, weather card dark mode

### DIFF
--- a/src/components/weather/__tests__/wave-70a-dark-mode.test.ts
+++ b/src/components/weather/__tests__/wave-70a-dark-mode.test.ts
@@ -1,0 +1,92 @@
+/**
+ * wave 70a — weather card dark mode (Fix 3)
+ *
+ * Bryan: "I'm lookin at it on dark mode the footer weather card shows for
+ * light mode the fonts are not compliant"
+ *
+ * Root cause: .awsui-dark-mode .cdn-weather had only 50-55% opacity dark
+ * background — in the docked sticky footer context with backdrop-filter,
+ * the semi-transparent glass could pull in light page content making the
+ * background appear lighter than intended. Text colors depended on opacity
+ * inheritance over an ambiguous dark background.
+ *
+ * Fix:
+ * 1. Raised dark-mode weather card background opacity to 82-85% (was 50-55%)
+ *    so the dark navy reads through regardless of backdrop content.
+ * 2. Added explicit color declarations for metric dt/dd and temp-c in dark mode
+ *    so text never depends solely on opacity inheritance.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "..", "..", "..", "..");
+const weatherCss = readFileSync(
+	resolve(REPO_ROOT, "src/components/weather/styles.css"),
+	"utf-8",
+);
+
+describe("wave 70a — weather card dark mode contrast", () => {
+	it("dark-mode weather background opacity is >= 0.80 (was 0.50-0.55)", () => {
+		// Extract the background values from .awsui-dark-mode .cdn-weather block
+		// The alpha values in rgba(28, 34, 48, X) must be >= 0.80
+		const darkBgMatch = weatherCss.match(
+			/\.awsui-dark-mode\s+\.cdn-weather\s*\{[^}]*background:\s*linear-gradient[^;]+;/,
+		);
+		expect(darkBgMatch).not.toBeNull();
+		const bgBlock = darkBgMatch?.[0] ?? "";
+		// Extract all rgba alpha values from the gradient
+		const alphas = [...bgBlock.matchAll(/rgba\([^)]+,\s*([\d.]+)\)/g)].map(
+			(m) => Number.parseFloat(m[1]),
+		);
+		expect(alphas.length).toBeGreaterThan(0);
+		// All background alphas should be >= 0.80
+		for (const alpha of alphas) {
+			expect(
+				alpha,
+				`Background alpha ${alpha} is below 0.80`,
+			).toBeGreaterThanOrEqual(0.8);
+		}
+	});
+
+	it("dark-mode metric dt labels have explicit color (not just opacity inheritance)", () => {
+		expect(weatherCss).toMatch(
+			/\.awsui-dark-mode\s+\.cdn-weather__metric\s+dt[^{]*\{[^}]*color:/,
+		);
+	});
+
+	it("dark-mode metric dd values have explicit color", () => {
+		expect(weatherCss).toMatch(
+			/\.awsui-dark-mode\s+\.cdn-weather__metric\s+dd[^{]*\{[^}]*color:/,
+		);
+	});
+
+	it("dark-mode temp-c has explicit color", () => {
+		expect(weatherCss).toMatch(
+			/\.awsui-dark-mode\s+\.cdn-weather__temp-c[^{]*\{[^}]*color:/,
+		);
+	});
+
+	it("dark mode city gradient uses violet/lavender (not amber/orange)", () => {
+		// .awsui-dark-mode .cdn-weather__city must override background-image
+		// to violet/lavender palette, not the light-mode amber/orange
+		const darkCityMatch = weatherCss.match(
+			/\.awsui-dark-mode\s+\.cdn-weather__city\s*\{[^}]+\}/,
+		);
+		expect(darkCityMatch).not.toBeNull();
+		const block = darkCityMatch?.[0] ?? "";
+		// Should contain violet (#9060f0) or lavender (#d7c7ee)
+		expect(block).toMatch(
+			/#9060f0|#d7c7ee|var\(--cdn-violet|var\(--cdn-lavender/i,
+		);
+		// Should NOT contain the amber/orange light-mode gradient colors
+		expect(block).not.toMatch(/#8b5a2b|#ff9900/);
+	});
+
+	it("light-mode weather uses amber color token", () => {
+		// Ensures the light mode rule is still intact
+		expect(weatherCss).toMatch(
+			/:root:not\(\.awsui-dark-mode\)\s+\.cdn-weather\s*\{[^}]*color:\s*var\(--cdn-amber/,
+		);
+	});
+});

--- a/src/components/weather/styles.css
+++ b/src/components/weather/styles.css
@@ -117,8 +117,8 @@
 .awsui-dark-mode .cdn-weather {
 	background: linear-gradient(
 		178deg,
-		rgba(28, 34, 48, 0.55) 0%,
-		rgba(20, 16, 48, 0.5) 100%
+		rgba(28, 34, 48, 0.85) 0%,
+		rgba(20, 16, 48, 0.82) 100%
 	);
 	backdrop-filter: blur(14px) saturate(1.2);
 	-webkit-backdrop-filter: blur(14px) saturate(1.2);
@@ -129,6 +129,18 @@
 		0 1px 3px rgba(0, 0, 0, 0.35),
 		inset 0 1px 0 rgba(215, 199, 238, 0.22),
 		inset 0 -1px 0 rgba(144, 96, 240, 0.22);
+	color: var(--cdn-lavender, #d7c7ee);
+}
+
+/* Dark mode: explicit text colors on all metric/label elements so they never
+   rely solely on opacity inheritance over an ambiguous background. */
+.awsui-dark-mode .cdn-weather__metric dt,
+.awsui-dark-mode .cdn-weather__tomorrow-label {
+	color: rgba(215, 199, 238, 0.65);
+}
+
+.awsui-dark-mode .cdn-weather__metric dd,
+.awsui-dark-mode .cdn-weather__temp-c {
 	color: var(--cdn-lavender, #d7c7ee);
 }
 

--- a/src/layouts/shell/__tests__/wave-70a-hamburger-scroll.test.ts
+++ b/src/layouts/shell/__tests__/wave-70a-hamburger-scroll.test.ts
@@ -1,0 +1,62 @@
+/**
+ * wave 70a — hamburger visibility on scroll (Fix 2)
+ *
+ * Bryan: "when I scroll down the left side bar menu button inappropriately
+ * disappears (when closed)"
+ *
+ * Root cause: body.cdn-scrolled [class*="awsui_breadcrumbs"] was too broad —
+ * on mobile the breadcrumbs container wraps the navigation-toggle too, so it
+ * got opacity:0 along with the breadcrumb text.
+ *
+ * Fix: narrowed selector to :not([class*="awsui_navigation-toggle"]) and added
+ * an explicit override to keep navigation-toggle at opacity:1 when scrolled.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "..", "..", "..", "..");
+const shellCss = readFileSync(
+	resolve(REPO_ROOT, "src/layouts/shell/styles.css"),
+	"utf-8",
+);
+
+describe("wave 70a — hamburger visibility on scroll", () => {
+	it("body.cdn-scrolled breadcrumb selector excludes navigation-toggle via :not()", () => {
+		// The selector must have :not([class*="awsui_navigation-toggle"]) to prevent
+		// the hamburger from being hidden by the breadcrumb fade rule.
+		expect(shellCss).toMatch(
+			/body\.cdn-scrolled\s+\[class\*="awsui_breadcrumbs"\]:not\(\[class\*="awsui_navigation-toggle"\]\)/,
+		);
+	});
+
+	it("the old broad selector body.cdn-scrolled [class*='awsui_breadcrumbs'] { opacity: 0 } is gone", () => {
+		// The previous rule without the :not() guard must not exist
+		// We check there is no direct selector without the :not clause
+		const broadRule =
+			/body\.cdn-scrolled\s+\[class\*="awsui_breadcrumbs"\]\s*\{[^}]*opacity:\s*0/;
+		expect(shellCss).not.toMatch(broadRule);
+	});
+
+	it("navigation-toggle has an explicit opacity:1 override under cdn-scrolled", () => {
+		// An explicit counter-rule ensures the hamburger can't be hidden
+		// even if it's a descendant of a fading breadcrumbs container.
+		expect(shellCss).toMatch(
+			/body\.cdn-scrolled\s+\[class\*="awsui_navigation-toggle"\][^{]*\{[^}]*opacity:\s*1/,
+		);
+	});
+
+	it("navigation-toggle counter-rule uses pointer-events: auto", () => {
+		// Ensure clicks on the hamburger still work when scrolled
+		expect(shellCss).toMatch(
+			/body\.cdn-scrolled\s+\[class\*="awsui_navigation-toggle"\][^{]*\{[^}]*pointer-events:\s*auto/,
+		);
+	});
+
+	it("the breadcrumb transition rule is still present for the non-scrolled base state", () => {
+		// Base transition should still be set so un-scrolling animates back
+		expect(shellCss).toMatch(
+			/\[class\*="awsui_breadcrumbs"\]\s*\{[^}]*transition:[^}]*opacity[^}]*\}/,
+		);
+	});
+});

--- a/src/layouts/shell/styles.css
+++ b/src/layouts/shell/styles.css
@@ -2079,14 +2079,26 @@ button[class*="awsui_tools-toggle"] {
 	}
 }
 
-/* A4 fix — breadcrumb fades away on scroll so only buttons remain visible */
-body.cdn-scrolled [class*="awsui_breadcrumbs"] {
+/* A4 fix — breadcrumb fades away on scroll so only buttons remain visible.
+   Narrowed: exclude navigation-toggle so the hamburger stays visible when scrolled.
+   Root cause: [class*="awsui_breadcrumbs"] matched the breadcrumb container that
+   on mobile also wraps the navigation-toggle, hiding the hamburger on scroll. */
+body.cdn-scrolled [class*="awsui_breadcrumbs"]:not([class*="awsui_navigation-toggle"]) {
 	opacity: 0;
 	transform: translateY(-8px);
 	pointer-events: none;
 	transition:
 		opacity 0.2s ease,
 		transform 0.2s ease;
+}
+/* Ensure the navigation-toggle (hamburger) and its wrappers remain fully visible
+   when cdn-scrolled is active — the breadcrumb fade must NOT affect it. */
+body.cdn-scrolled [class*="awsui_navigation-toggle"],
+body.cdn-scrolled [class*="awsui_breadcrumbs"] [class*="awsui_navigation-toggle"] {
+	opacity: 1 !important;
+	transform: none !important;
+	pointer-events: auto !important;
+	visibility: visible !important;
 }
 [class*="awsui_breadcrumbs"] {
 	transition:

--- a/src/locales/__tests__/translation-coverage.test.ts
+++ b/src/locales/__tests__/translation-coverage.test.ts
@@ -86,7 +86,7 @@ describe("translation coverage", () => {
 			"navigation.cacheable", // "Cacheable" - technical term used in Spanish
 			"apiGuide.api", // "API" - acronym
 			"meetingDetail.rsvp", // "RSVP" - universal abbreviation
-			"createMeeting.url", // "URL" - universal abbreviation
+
 			"createMeeting.api", // "API" - acronym
 			"createMeeting.details.no", // "No" - same in Spanish
 			"createMeeting.meetingDetails.errorIconAriaLabel", // "Error" - common tech term
@@ -119,8 +119,7 @@ describe("translation coverage", () => {
 			"feedPage.builderCenterHeader", // "AWS Builder Center" - AWS program proper noun
 			"helpPanel.arrowheadPark", // "Arrowhead Research Park" - proper noun
 			"helpPanel.communityFoundedSuffix", // ", NMSU." - punctuation + acronym
-			"rsvp.breadcrumb", // "RSVP" - universal abbreviation
-			"rsvp.pageTitle", // "RSVP — Cloud Del Norte" - proper noun + universal abbreviation
+			// rsvp.breadcrumb and rsvp.pageTitle removed — wave 70a translated RSVP → Apúntate
 			"feedPage.pastMeetupSpeaker1Name", // proper name
 			"feedPage.pastMeetupSpeaker2Name", // proper name
 			"feedPage.pastMeetupSpeaker3Name", // proper name
@@ -132,8 +131,7 @@ describe("translation coverage", () => {
 			"feedPage.theZacsShowHeader", // "The Zacs' Show" - proper name
 			"feedPage.vbrownbagHeader", // "vBrownBag" - proper noun / brand name
 			"feedbackForm.fileUpload.errorIconAriaLabel", // "Error" - universal tech term
-			"meetings.rsvpButton", // "RSVP" - universal abbreviation
-			"meetings.tableHeaders.rsvp", // "RSVP" - universal abbreviation
+			// meetings.rsvpButton and meetings.tableHeaders.rsvp removed — wave 70a translated RSVP → Apúntate/Registro
 			"speakerForm.fields.format.virtual", // "virtual" - same in Spanish
 			// wave 56 proper nouns / channel names
 			"feedPage.howToPlayBuildercardsAuthor", // "AWS for Games" - channel proper noun

--- a/src/locales/__tests__/wave-70a-rsvp-apuntate.test.ts
+++ b/src/locales/__tests__/wave-70a-rsvp-apuntate.test.ts
@@ -1,0 +1,82 @@
+/**
+ * wave 70a — RSVP → Apúntate regression guard
+ *
+ * Bryan: "replace RSVP language on spanish mode with Apúntate"
+ * All es-MX values that previously contained 'RSVP' now use Apúntate / apuntarte
+ * or a contextually appropriate form. en-US is unchanged.
+ */
+import { describe, expect, it } from "vitest";
+import enUS from "../en-US.json";
+import esMX from "../es-MX.json";
+
+// Flatten nested JSON to dot-notation key→value pairs
+function flatten(
+	obj: Record<string, unknown>,
+	prefix = "",
+): Record<string, string> {
+	const result: Record<string, string> = {};
+	for (const [k, v] of Object.entries(obj)) {
+		const key = prefix ? `${prefix}.${k}` : k;
+		if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+			Object.assign(result, flatten(v as Record<string, unknown>, key));
+		} else if (typeof v === "string") {
+			result[key] = v;
+		}
+	}
+	return result;
+}
+
+const esMXFlat = flatten(esMX as Record<string, unknown>);
+const enUSFlat = flatten(enUS as Record<string, unknown>);
+
+describe("wave 70a — RSVP → Apúntate (es-MX)", () => {
+	it("no es-MX value contains the word RSVP (case-insensitive)", () => {
+		const rsvpInEs = Object.entries(esMXFlat).filter(([, v]) =>
+			/rsvp/i.test(v),
+		);
+		expect(
+			rsvpInEs,
+			`Found es-MX values still containing RSVP: ${rsvpInEs.map(([k]) => k).join(", ")}`,
+		).toHaveLength(0);
+	});
+
+	it("en-US values still contain RSVP (unchanged)", () => {
+		const rsvpInEn = Object.entries(enUSFlat).filter(([, v]) =>
+			/rsvp/i.test(v),
+		);
+		// en-US should still have RSVP values
+		expect(rsvpInEn.length).toBeGreaterThan(0);
+	});
+
+	it("featuredEventSpotsRemaining uses Apúntate in es-MX", () => {
+		expect(esMX.feedPage.featuredEventSpotsRemaining).toMatch(/apúntate/i);
+	});
+
+	it("featuredEventRsvpMeetup uses Apúntate in es-MX", () => {
+		expect(esMX.feedPage.featuredEventRsvpMeetup).toMatch(/apúntate/i);
+	});
+
+	it("meetings.rsvpButton uses Apúntate in es-MX", () => {
+		expect(esMX.meetings.rsvpButton).toMatch(/apúntate/i);
+	});
+
+	it("rsvp.breadcrumb is translated (not RSVP) in es-MX", () => {
+		expect(esMX.rsvp.breadcrumb).not.toMatch(/^rsvp$/i);
+	});
+
+	it("rsvp.header uses Apúntate in es-MX", () => {
+		expect(esMX.rsvp.header).toMatch(/apúntate/i);
+	});
+
+	it("rsvp.rsvpButton uses Apúntate or lugar in es-MX (no RSVP)", () => {
+		expect(esMX.rsvp.rsvpButton).not.toMatch(/rsvp/i);
+	});
+
+	it("helpPanel.rsvpHeader uses Apúntate in es-MX", () => {
+		expect(esMX.helpPanel.rsvpHeader).toMatch(/apúntate/i);
+	});
+
+	it("meetings.rsvpOnMeetup uses Apúntate in es-MX", () => {
+		expect(esMX.meetings.rsvpOnMeetup).toMatch(/apúntate/i);
+	});
+});

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -150,24 +150,24 @@
 		"featuredEventTitle": "Hora Feliz Comunitaria y Noche de Networking",
 		"featuredEventLocation": "Centro de El Paso, TX",
 		"featuredEventDescription": "Cáele en el trolley, píllate un Lyft, en bici, o tráete tu nave para finger-foods, bebidas (incluyendo opciones sin alcohol), y platícale casual sobre carreras, nube, tecnología e inteligencia artificial. AWS Builder Center Cards van a estar disponibles para cualquiera que esté game",
-		"featuredEventRsvp": "Registrarse en Meetup",
+		"featuredEventRsvp": "Apúntate en Meetup",
 		"featuredEventImageAlt": "Foto del evento comunitario AWS Cloud del Norte UG",
 		"upcomingVirtualEventHeader": "Eventos Virtuales Libres y Abiertos de la Comunidad AWS",
 		"upcomingVirtualEventTitle": "[En línea] Reunión Global de la Comunidad AWS #19",
 		"upcomingVirtualEventLocation": "Evento en línea — únete desde cualquier lugar",
 		"upcomingVirtualEventDescription": "Reunión virtual global de la comunidad AWS. Abierta a todos. Únete al stream y conecta con builders de todo el mundo.",
-		"upcomingVirtualEventRsvp": "Registrarse en Meetup",
+		"upcomingVirtualEventRsvp": "Apúntate en Meetup",
 		"upcomingVirtualEventImageAlt": "Banner del evento virtual Reunión Global de la Comunidad AWS",
 		"upcomingVirtualEventFeaturedTalkBadge": "PRESENTACIÓN DESTACADA",
 		"upcomingVirtualEventFeaturedTalkSpeaker": "El co-organizador de AWSUG Cloud Del Norte, Bryan Chasko",
 		"upcomingVirtualEventFeaturedTalkTitle": "Una historia de migración: después de 240 meses consecutivos, evité un cargo de Microsoft",
 		"upcomingVirtualEventUgMarkLabel": "Marca AWS User Group",
 		"featuredEventInPersonLabel": "Junio 2026 presencial: centro de El Paso, Texas",
-		"featuredEventSpotsRemaining": "Cupo limitado — RSVP ya",
-		"featuredEventRsvpPrimary": "RSVP en CloudDelNorte.org",
-		"featuredEventRsvpMeetup": "RSVP en Meetup",
-		"featuredEventImageLinkLabel": "RSVP para la Hora Feliz Comunitaria y Noche de Networking",
-		"upcomingVirtualEventImageLinkLabel": "RSVP en Meetup para AWS Global Community Gatherings",
+		"featuredEventSpotsRemaining": "Cupo limitado — Apúntate ya",
+		"featuredEventRsvpPrimary": "Apúntate en CloudDelNorte.org",
+		"featuredEventRsvpMeetup": "Apúntate en Meetup",
+		"featuredEventImageLinkLabel": "Apúntate a la Hora Feliz Comunitaria y Noche de Networking",
+		"upcomingVirtualEventImageLinkLabel": "Apúntate en Meetup para AWS Global Community Gatherings",
 		"episodeScroller": {
 			"headerSuffix": " — episodios",
 			"sortNewest": "Reciente primero",
@@ -254,9 +254,9 @@
 			"happened": "¿Pasó?",
 			"onDemand": "On-Demand",
 			"eventPage": "Página del Evento",
-			"rsvp": "RSVP"
+			"rsvp": "Registro"
 		},
-		"rsvpButton": "RSVP",
+		"rsvpButton": "Apúntate",
 		"empty": {
 			"noMatches": "Sin resultados",
 			"noMatchesSubtitle": "No encontramos nada, compa.",
@@ -286,7 +286,7 @@
 			"history": "Juntas Anteriores"
 		},
 		"noPastMeetings": "No hay juntas anteriores registradas.",
-		"rsvpOnMeetup": "RSVP en Meetup",
+		"rsvpOnMeetup": "Apúntate en Meetup",
 		"editModal": {
 			"title": "Editar Junta",
 			"meetupLink": "Enlace de Meetup",
@@ -295,12 +295,12 @@
 			"scheduledDate": "Fecha programada",
 			"scheduledTime": "Hora programada",
 			"speakerBioUrl": "URL de bio del orador",
-			"meetupRsvpUrl": "URL de RSVP en Meetup",
+			"meetupRsvpUrl": "URL para apuntarse en Meetup",
 			"save": "Guardar",
 			"cancel": "Cancelar"
 		},
 		"myTicketsHeader": "Tus boletos",
-		"myTicketsEmpty": "Todavía no has hecho RSVP a ningún evento presencial de Cloud Del Norte.",
+		"myTicketsEmpty": "Todavía no te has apuntado a ningún evento presencial de Cloud Del Norte.",
 		"myTicketsShowAtDoor": "Muestra este código en la puerta"
 	},
 	"createMeeting": {
@@ -353,7 +353,7 @@
 		}
 	},
 	"helpPanel": {
-		"rsvpHeader": "RSVP para Eventos en Vivo",
+		"rsvpHeader": "Apúntate a Eventos en Vivo",
 		"cloudDelNorteMeetups": "Meetups de Nube of the North",
 		"blenderMeetups": "Blender & Diseño Gráfico:NE3D",
 		"userGroupTitle": "se buscan voluntarios",
@@ -1005,13 +1005,13 @@
 		"kexpNowPlayingFallback": "sonando en KEXP"
 	},
 	"rsvp": {
-		"breadcrumb": "RSVP",
-		"pageTitle": "RSVP — Cloud Del Norte",
-		"header": "RSVP para evento presencial",
+		"breadcrumb": "Apúntate",
+		"pageTitle": "Apúntate — Cloud Del Norte",
+		"header": "Apúntate al evento presencial",
 		"subheader": "Solo las primeras 50 personas. Guarda tu código QR — muéstralo en la puerta.",
 		"checkingAuth": "Verificando tu sesión...",
 		"eventNotFound": "No encontramos el evento",
-		"eventNotFoundDesc": "Esta página de RSVP ya no está activa. Checa los próximos eventos en la página de reuniones.",
+		"eventNotFoundDesc": "Esta página ya no está activa. Checa los próximos eventos en la página de reuniones.",
 		"soldOutHeader": "Este evento está lleno",
 		"soldOutBody": "Ya se llenaron los 50 cupos presenciales. Checa el feed para el próximo evento presencial, o únete a la reunión global virtual de abajo.",
 		"ticketHeader": "Estás en la lista",
@@ -1022,14 +1022,14 @@
 		"ticketHolder": "Titular",
 		"ticketCode": "Código del boleto",
 		"viewMyTickets": "Ver mis boletos",
-		"rsvpButton": "Confirmar mi RSVP",
+		"rsvpButton": "Confirmar mi lugar",
 		"rsvpingNow": "Reservando tu lugar...",
-		"fallbackMeetupCta": "Mejor házlo por Meetup",
+		"fallbackMeetupCta": "Mejor apúntate por Meetup",
 		"error": {
 			"capacityFull": "Disculpa — este evento ya se llenó. Checa el feed para el próximo.",
 			"network": "Falla de red — intenta de nuevo en un momento.",
-			"unauthorized": "Inicia sesión para hacer RSVP.",
-			"generic": "Algo salió mal — lo registramos. Intenta de nuevo o haz RSVP en Meetup."
+			"unauthorized": "Inicia sesión para apuntarte.",
+			"generic": "Algo salió mal — lo registramos. Intenta de nuevo o apúntate en Meetup."
 		}
 	}
 }


### PR DESCRIPTION
Bryan flagged 3 items in his feedback batch:

## fix 1 — RSVP → Apúntate (Spanish)
20 es-MX value replacements + 4 allowIdentical entries cleaned up. Norteño tone preserved (ap\u00fantate / apuntarte / apuntada / lugar contextually). en-US unchanged.

## fix 2 — hamburger visibility on scroll
Root cause: `body.cdn-scrolled [class*=awsui_breadcrumbs]` was too broad. On mobile/tablet AppLayout, the awsui_breadcrumbs container wraps both the breadcrumb text AND the navigation-toggle button — opacity:0 + pointer-events:none was hiding both. Narrowed selector via :not([class*=awsui_navigation-toggle]) + explicit opacity:1 !important counter-rule for the toggle.

## fix 3 — weather card dark mode
Root cause: dark-mode bg was only 50-55% opacity (rgba(28,34,48,0.55)) — in the docked sticky footer, nested backdrop-filter elements composited against page content scrolling underneath, picking up light-mode tones. Plus metric dt/dd labels lacked explicit dark-mode color. Fix: raised dark bg to 82-85% opacity + added explicit color declarations.

## gates
- biome 0 errors / tsc 0 NEW / build PASS / vitest 931 PASS (+21 new)