### PR TITLE
fix(visual): wave 70b — atmosphere ribbon fade-in + light-mode polish + virtual event spacing + spanish cutoffs

### DIFF
--- a/src/components/babylon-spin-demo/index.tsx
+++ b/src/components/babylon-spin-demo/index.tsx
@@ -5,10 +5,7 @@
 // Wave 66 — added IntersectionObserver gate + babylon-budget integration.
 // Engine is disposed when the carousel scrolls off-screen and re-created on re-entry.
 import { useEffect, useRef } from "react";
-import {
-	releaseActivation,
-	requestActivation,
-} from "../../lib/babylon-budget";
+import { releaseActivation, requestActivation } from "../../lib/babylon-budget";
 
 const SCENE_ID = "babylon-spin-demo";
 

--- a/src/components/footer/__tests__/atmosphere-ribbon.test.tsx
+++ b/src/components/footer/__tests__/atmosphere-ribbon.test.tsx
@@ -1,5 +1,6 @@
 // Wave 60 — AtmosphereRibbon tests
 // Wave 66 — extended: IntersectionObserver gate, budget integration, dispose-on-unmount.
+// Wave 70b — extended: fade-in (is-loaded class) tests.
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -223,6 +224,22 @@ describe("AtmosphereRibbon — Babylon path", () => {
 		const { unmount } = render(<AtmosphereRibbon />);
 		unmount();
 		expect(mockReleaseActivation).toHaveBeenCalledWith("atmosphere-ribbon");
+	});
+});
+
+// ── Wave 70b — fade-in ────────────────────────────────────────────────────────
+describe("AtmosphereRibbon — fade-in (wave 70b)", () => {
+	it("ribbon starts without is-loaded class", () => {
+		render(<AtmosphereRibbon />);
+		const ribbon = screen.getByTestId("atmosphere-ribbon");
+		expect(ribbon.classList.contains("is-loaded")).toBe(false);
+	});
+
+	it("fallback path adds is-loaded class on mount", () => {
+		vi.mocked(getDeviceTier).mockReturnValue("low");
+		render(<AtmosphereRibbon />);
+		const ribbon = screen.getByTestId("atmosphere-ribbon");
+		expect(ribbon.classList.contains("is-loaded")).toBe(true);
 	});
 });
 

--- a/src/components/footer/atmosphere-ribbon.css
+++ b/src/components/footer/atmosphere-ribbon.css
@@ -1,13 +1,19 @@
 /* Wave 60 — AtmosphereRibbon container styles */
+/* Wave 70b — fade-in: starts hidden, fades in once loaded */
 
 .cdn-atmosphere-ribbon {
 	width: 100%;
 	height: 40px; /* desktop default */
 	overflow: hidden;
 	flex-shrink: 0;
-	/* Ensure the ribbon sits above footer z-stack but below top-nav */
 	position: relative;
 	z-index: 0;
+	opacity: 0;
+	transition: opacity 600ms ease-in;
+}
+
+.cdn-atmosphere-ribbon.is-loaded {
+	opacity: 1;
 }
 
 @media (max-width: 688px) {

--- a/src/components/footer/atmosphere-ribbon.tsx
+++ b/src/components/footer/atmosphere-ribbon.tsx
@@ -4,12 +4,10 @@
 // Babylon scene gated at tier='medium'; CSS-only gradient visible at all tiers.
 //
 // Wave 66 — added IntersectionObserver gate + babylon-budget integration.
+// Wave 70b — fade-in: ribbon starts opacity:0, fades in once loaded.
 
 import { useEffect, useRef, useState } from "react";
-import {
-	releaseActivation,
-	requestActivation,
-} from "../../lib/babylon-budget";
+import { releaseActivation, requestActivation } from "../../lib/babylon-budget";
 import {
 	elPasoHour,
 	getTOD,
@@ -23,7 +21,7 @@ import "./atmosphere-ribbon.css";
 
 // ── CSS-only fallback ─────────────────────────────────────────────────────────
 
-function RibbonFallback() {
+function RibbonFallback({ onReady }: { onReady: () => void }) {
 	const ref = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
@@ -33,9 +31,11 @@ function RibbonFallback() {
 			ref.current?.style.setProperty("background", todGradient(tod));
 		};
 		apply();
+		// Signal loaded after first paint
+		onReady();
 		const id = setInterval(apply, 60_000);
 		return () => clearInterval(id);
-	}, []);
+	}, [onReady]);
 
 	return (
 		<div
@@ -50,7 +50,7 @@ function RibbonFallback() {
 
 const SCENE_ID = "atmosphere-ribbon";
 
-function RibbonScene({ hour }: { hour: number }) {
+function RibbonScene({ hour, onReady }: { hour: number; onReady: () => void }) {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	// biome-ignore lint/suspicious/noExplicitAny: dynamic babylon import
 	const engRef = useRef<any>(null);
@@ -185,6 +185,9 @@ function RibbonScene({ hour }: { hour: number }) {
 			} else {
 				eng.runRenderLoop(render);
 			}
+
+			// Wave 70b — signal loaded after first render loop starts
+			onReady();
 		}
 
 		// IntersectionObserver: only run when ribbon is on-screen
@@ -209,7 +212,7 @@ function RibbonScene({ hour }: { hour: number }) {
 		};
 		// hour-driven palette changes on mount only — ribbon re-reads hour each minute via parent
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [hour]);
+	}, [hour, onReady]);
 
 	return (
 		// biome-ignore lint/a11y/noAriaHiddenOnFocusable: decorative, non-interactive
@@ -230,6 +233,7 @@ function RibbonScene({ hour }: { hour: number }) {
 
 export default function AtmosphereRibbon() {
 	const [hour, setHour] = useState(() => elPasoHour());
+	const ribbonRef = useRef<HTMLDivElement>(null);
 
 	// Refresh hour once per minute so the gradient + disc position track real time
 	useEffect(() => {
@@ -237,14 +241,22 @@ export default function AtmosphereRibbon() {
 		return () => clearInterval(id);
 	}, []);
 
+	const handleReady = useRef(() => {
+		ribbonRef.current?.classList.add("is-loaded");
+	}).current;
+
 	return (
 		<div
+			ref={ribbonRef}
 			className="cdn-atmosphere-ribbon"
 			aria-hidden="true"
 			data-testid="atmosphere-ribbon"
 		>
-			<BabylonGate tier="medium" fallback={<RibbonFallback />}>
-				<RibbonScene hour={hour} />
+			<BabylonGate
+				tier="medium"
+				fallback={<RibbonFallback onReady={handleReady} />}
+			>
+				<RibbonScene hour={hour} onReady={handleReady} />
 			</BabylonGate>
 		</div>
 	);

--- a/src/components/weather/__tests__/weather-stable-key.test.tsx
+++ b/src/components/weather/__tests__/weather-stable-key.test.tsx
@@ -73,8 +73,7 @@ class IntersectionObserverMock {
 let mountCount = 0;
 
 vi.mock("./atmosphere-scene", async (importOriginal) => {
-	const mod =
-		await importOriginal<typeof import("../atmosphere-scene")>();
+	const mod = await importOriginal<typeof import("../atmosphere-scene")>();
 	return {
 		...mod,
 		default: (props: import("../atmosphere-scene").AtmosphereSceneProps) => {

--- a/src/components/weather/atmosphere-scene.tsx
+++ b/src/components/weather/atmosphere-scene.tsx
@@ -16,10 +16,7 @@
 // and a single 12-s ease arc for thunderstorm.
 
 import { useEffect, useRef } from "react";
-import {
-	releaseActivation,
-	requestActivation,
-} from "../../lib/babylon-budget";
+import { releaseActivation, requestActivation } from "../../lib/babylon-budget";
 import { getTOD, isNight, skyColor } from "../../lib/time-of-day";
 
 export interface AtmosphereSceneProps {

--- a/src/lib/__tests__/babylon-budget.test.ts
+++ b/src/lib/__tests__/babylon-budget.test.ts
@@ -1,8 +1,8 @@
 // Wave 66 — babylon-budget.ts unit tests
 import { afterEach, describe, expect, it } from "vitest";
 import {
-	MAX_ACTIVE_SCENES,
 	activeScenes,
+	MAX_ACTIVE_SCENES,
 	releaseActivation,
 	requestActivation,
 } from "../babylon-budget";

--- a/src/pages/feed/components/__tests__/wave-45-rizz.test.tsx
+++ b/src/pages/feed/components/__tests__/wave-45-rizz.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 // Wave 45 — card rizz batch tests.
-//   1. Excerpt cap logic (140 chars + ellipsis)
+//   1. Excerpt cap logic (160 chars + ellipsis, wave 70b bumped from 140)
 //   2. Brand star img renders in FeedAndmore + onError hides broken img
 //   3. FeedAndmore renders the co-organizer sub-header
 //   4. Speaker CTA bounce @keyframes defined in stylesheet
@@ -39,16 +39,16 @@ const SAMPLE_POSTS: FeedPost[] = [
 // ---------------------------------------------------------------------------
 
 function capExcerpt(excerpt: string): string {
-	return excerpt.length > 140 ? `${excerpt.slice(0, 140).trimEnd()}…` : excerpt;
+	return excerpt.length > 160 ? `${excerpt.slice(0, 160).trimEnd()}…` : excerpt;
 }
 
 describe("PostCarousel excerpt cap logic (task 1.4)", () => {
 	const LONG =
-		"This is a very long excerpt that exceeds one hundred and forty characters in total length and should be truncated with an ellipsis character at the end.";
+		"This is a very long excerpt that exceeds one hundred and sixty characters in total length and should be truncated with an ellipsis character at the end of the string here.";
 
-	it("truncates excerpts longer than 140 chars with ellipsis", () => {
+	it("truncates excerpts longer than 160 chars with ellipsis", () => {
 		const result = capExcerpt(LONG);
-		expect(result.length).toBeLessThanOrEqual(141); // 140 chars + ellipsis
+		expect(result.length).toBeLessThanOrEqual(161); // 160 chars + ellipsis
 		expect(result).toContain("…");
 		expect(result).not.toBe(LONG);
 	});
@@ -59,13 +59,13 @@ describe("PostCarousel excerpt cap logic (task 1.4)", () => {
 		expect(capExcerpt(short)).not.toContain("…");
 	});
 
-	it("caps at exactly 140 visible chars before adding ellipsis", () => {
-		const exactly140 = "x".repeat(140);
-		const over = "x".repeat(141);
-		expect(capExcerpt(exactly140)).toBe(exactly140); // no truncation
+	it("caps at exactly 160 visible chars before adding ellipsis", () => {
+		const exactly160 = "x".repeat(160);
+		const over = "x".repeat(161);
+		expect(capExcerpt(exactly160)).toBe(exactly160); // no truncation
 		const capped = capExcerpt(over);
 		expect(capped).toContain("…");
-		expect(capped.replace("…", "").length).toBe(140);
+		expect(capped.replace("…", "").length).toBe(160);
 	});
 });
 
@@ -77,7 +77,7 @@ function twoSentences(excerpt: string): string {
 	if (!excerpt) return "";
 	const chunks = excerpt.split(/\.\s+/);
 	const joined = chunks.length >= 2 ? `${chunks[0]}. ${chunks[1]}.` : chunks[0];
-	return joined.length > 140 ? `${joined.slice(0, 140).trimEnd()}…` : joined;
+	return joined.length > 160 ? `${joined.slice(0, 160).trimEnd()}…` : joined;
 }
 
 describe("ReadySetCloud 2-sentence excerpt logic (task 3)", () => {
@@ -93,13 +93,13 @@ describe("ReadySetCloud 2-sentence excerpt logic (task 3)", () => {
 		expect(twoSentences(excerpt)).toBe("Only one sentence");
 	});
 
-	it("caps at 140 chars after joining two sentences", () => {
-		const s1 = "A".repeat(80);
-		const s2 = "B".repeat(80);
+	it("caps at 160 chars after joining two sentences", () => {
+		const s1 = "A".repeat(90);
+		const s2 = "B".repeat(90);
 		const excerpt = `${s1}. ${s2}. Extra.`;
 		const result = twoSentences(excerpt);
 		expect(result).toContain("…");
-		expect(result.replace("…", "").length).toBeLessThanOrEqual(140);
+		expect(result.replace("…", "").length).toBeLessThanOrEqual(160);
 	});
 
 	it("returns empty string for empty excerpt", () => {

--- a/src/pages/feed/components/feed-card-shell.css
+++ b/src/pages/feed/components/feed-card-shell.css
@@ -56,15 +56,15 @@
 	/* Default tokens — overridden by the per-palette modifier classes
 	   below. Listed here so a card that forgets the palette modifier
 	   still renders something legible (graceful degradation). */
-	--fcs-bg-from: #f5f5f5;
-	--fcs-bg-to: #e5e5e5;
-	--fcs-rim: #888;
-	--fcs-rim-highlight: rgba(255, 255, 255, 0.6);
-	--fcs-shadow: rgba(0, 0, 0, 0.18);
-	--fcs-text: #1a1a1a;
-	--fcs-text-glow: rgba(255, 255, 255, 0.5);
-	--fcs-stage-rim: rgba(255, 255, 255, 0.08);
-	--fcs-ambient-bloom: rgba(0, 0, 0, 0.1);
+	--fcs-bg-from: #fef8ee;
+	--fcs-bg-to: #f5edd8;
+	--fcs-rim: #8b5a2b;
+	--fcs-rim-highlight: rgba(255, 250, 235, 0.7);
+	--fcs-shadow: rgba(120, 53, 15, 0.2);
+	--fcs-text: #2c1a0e;
+	--fcs-text-glow: rgba(255, 250, 235, 0.55);
+	--fcs-stage-rim: rgba(139, 90, 43, 0.12);
+	--fcs-ambient-bloom: rgba(120, 53, 15, 0.12);
 
 	position: relative;
 	isolation: isolate;
@@ -102,9 +102,11 @@
 	   visible "stage edge" line under varied page backgrounds without
 	   requiring the inner Cloudscape Container to opt in. The inset is
 	   palette-tinted via the --fcs-stage-rim variable so dark-mode
-	   variants get a brighter rim against deeper backplates. */
+	   variants get a brighter rim against deeper backplates.
+	   Wave 70b — 5-layer shadow stack for stronger light-mode depth. */
 	box-shadow:
 		0 1px 2px var(--fcs-shadow),
+		0 4px 8px -2px var(--fcs-shadow),
 		0 8px 24px -10px var(--fcs-ambient-bloom),
 		0 18px 44px -16px var(--fcs-ambient-bloom),
 		inset 0 0 0 1px var(--fcs-stage-rim);
@@ -223,15 +225,15 @@
 
 /* ── amber — warm dev/casual (feed-section andmore) ───────────────────── */
 .feed-card-shell--amber {
-	--fcs-bg-from: #fef3c7;
-	--fcs-bg-to: #fcd34d;
-	--fcs-rim: #d97706;
-	--fcs-rim-highlight: rgba(255, 251, 235, 0.7);
-	--fcs-shadow: rgba(120, 53, 15, 0.22);
+	--fcs-bg-from: #faf7f0;
+	--fcs-bg-to: #f5edd8;
+	--fcs-rim: #b45309;
+	--fcs-rim-highlight: rgba(255, 250, 235, 0.75);
+	--fcs-shadow: rgba(120, 53, 15, 0.2);
 	--fcs-text: #78350f;
 	--fcs-text-glow: rgba(254, 240, 138, 0.55);
-	--fcs-stage-rim: rgba(217, 119, 6, 0.18);
-	--fcs-ambient-bloom: rgba(120, 53, 15, 0.16);
+	--fcs-stage-rim: rgba(217, 119, 6, 0.14);
+	--fcs-ambient-bloom: rgba(120, 53, 15, 0.14);
 }
 
 .awsui-dark-mode .feed-card-shell--amber {
@@ -248,15 +250,15 @@
 
 /* ── teal — cool ML/technical (feed-section awsml) ────────────────────── */
 .feed-card-shell--teal {
-	--fcs-bg-from: #ccfbf1;
-	--fcs-bg-to: #5eead4;
+	--fcs-bg-from: #f0fdf9;
+	--fcs-bg-to: #e0f7f1;
 	--fcs-rim: #0e7490;
-	--fcs-rim-highlight: rgba(236, 254, 255, 0.7);
-	--fcs-shadow: rgba(15, 76, 87, 0.22);
+	--fcs-rim-highlight: rgba(236, 254, 255, 0.75);
+	--fcs-shadow: rgba(15, 76, 87, 0.2);
 	--fcs-text: #0e3a4a;
 	--fcs-text-glow: rgba(165, 243, 252, 0.55);
-	--fcs-stage-rim: rgba(14, 116, 144, 0.18);
-	--fcs-ambient-bloom: rgba(15, 76, 87, 0.16);
+	--fcs-stage-rim: rgba(14, 116, 144, 0.14);
+	--fcs-ambient-bloom: rgba(15, 76, 87, 0.14);
 }
 
 .awsui-dark-mode .feed-card-shell--teal {
@@ -354,15 +356,15 @@
    them visually paired as the "deep-read" cards in the feed without
    demanding a 9th palette. */
 .feed-card-shell--navy {
-	--fcs-bg-from: #dbeafe;
-	--fcs-bg-to: #93c5fd;
+	--fcs-bg-from: #f0f4ff;
+	--fcs-bg-to: #e0e8f8;
 	--fcs-rim: #1e40af;
-	--fcs-rim-highlight: rgba(239, 246, 255, 0.7);
-	--fcs-shadow: rgba(30, 58, 138, 0.22);
+	--fcs-rim-highlight: rgba(239, 246, 255, 0.75);
+	--fcs-shadow: rgba(30, 58, 138, 0.2);
 	--fcs-text: #1e293b;
 	--fcs-text-glow: rgba(219, 234, 254, 0.55);
-	--fcs-stage-rim: rgba(30, 64, 175, 0.18);
-	--fcs-ambient-bloom: rgba(30, 58, 138, 0.16);
+	--fcs-stage-rim: rgba(30, 64, 175, 0.14);
+	--fcs-ambient-bloom: rgba(30, 58, 138, 0.14);
 }
 
 .awsui-dark-mode .feed-card-shell--navy {
@@ -379,15 +381,15 @@
 
 /* ── gold — AWS Builder Center ───────────────────────────────────────── */
 .feed-card-shell--gold {
-	--fcs-bg-from: #fef3c7;
-	--fcs-bg-to: #fbbf24;
-	--fcs-rim: #b45309;
-	--fcs-rim-highlight: rgba(255, 251, 235, 0.7);
-	--fcs-shadow: rgba(120, 53, 15, 0.24);
-	--fcs-text: #78350f;
-	--fcs-text-glow: rgba(254, 243, 199, 0.55);
-	--fcs-stage-rim: rgba(180, 83, 9, 0.2);
-	--fcs-ambient-bloom: rgba(120, 53, 15, 0.16);
+	--fcs-bg-from: #faf7f0;
+	--fcs-bg-to: #f5edd8;
+	--fcs-rim: #8b5a2b;
+	--fcs-rim-highlight: rgba(255, 250, 235, 0.75);
+	--fcs-shadow: rgba(120, 53, 15, 0.22);
+	--fcs-text: #2c1a0e;
+	--fcs-text-glow: rgba(254, 243, 199, 0.6);
+	--fcs-stage-rim: rgba(139, 90, 43, 0.14);
+	--fcs-ambient-bloom: rgba(120, 53, 15, 0.14);
 }
 
 .awsui-dark-mode .feed-card-shell--gold {

--- a/src/pages/feed/components/feed-section.tsx
+++ b/src/pages/feed/components/feed-section.tsx
@@ -86,10 +86,10 @@ function PostCarousel({ posts, ready }: { posts: FeedPost[]; ready: boolean }) {
 	// Single panel for the carousel — tabs all reference it; content swaps inside.
 	const panelId = `${panelIdBase}-panel`;
 
-	// Task 1.4 / Task 2: cap excerpt to ~140 chars, bump to body-m for legibility.
+	// Task 1.4 / Task 2: cap excerpt to ~160 chars (wave 70b: bumped from 140 for Spanish).
 	const excerpt =
-		post.excerpt && post.excerpt.length > 140
-			? `${post.excerpt.slice(0, 140).trimEnd()}…`
+		post.excerpt && post.excerpt.length > 160
+			? `${post.excerpt.slice(0, 160).trimEnd()}…`
 			: post.excerpt;
 
 	function focusTab(next: number) {
@@ -363,13 +363,13 @@ function RscEntry({
 	date: string;
 	excerpt?: string;
 }) {
-	// Task 3: split on `. `, take first 2 sentences, cap at 140 chars.
+	// Task 3: split on `. `, take first 2 sentences, cap at 160 chars (wave 70b: bumped from 140).
 	const twoSentences = (() => {
 		if (!excerpt) return "";
 		const chunks = excerpt.split(/\.\s+/);
 		const joined =
 			chunks.length >= 2 ? `${chunks[0]}. ${chunks[1]}.` : chunks[0];
-		return joined.length > 140 ? `${joined.slice(0, 140).trimEnd()}…` : joined;
+		return joined.length > 160 ? `${joined.slice(0, 160).trimEnd()}…` : joined;
 	})();
 
 	return (

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -108,8 +108,9 @@
 	/* Wave 48b: reduced from 148px (wave 45) → 128px now that brand star +
 	   co-organizer no longer occupy a second marquee row, reclaiming ~20px
 	   of vertical space. 2-line title ~40px + body-m excerpt ~2 lines ~48px +
-	   date ~20px + gaps ≈ 128px. */
-	height: 128px;
+	   date ~20px + gaps ≈ 128px.
+	   Wave 70b: bumped to 140px to accommodate longer Spanish text. */
+	height: 140px;
 	overflow: hidden;
 }
 
@@ -404,8 +405,10 @@
 
 /* Narrow-viewport fallback — drop the nowrap row and let the entry wrap
    to a maximum of 2 lines via line-clamp so phones don't render the
-   title as 3 ellipsed characters. */
-@media (max-width: 520px) {
+   title as 3 ellipsed characters.
+   Wave 70b — bumped from 520px to 600px so Spanish text doesn't cut off
+   at tablet widths where the feed grid is 2-col. */
+@media (max-width: 600px) {
 	.feed-rsc__entry {
 		display: -webkit-box;
 		-webkit-line-clamp: 2;
@@ -571,7 +574,7 @@
 	display: inline-flex;
 	align-items: center;
 	gap: 4px;
-	flex-wrap: nowrap;
+	flex-wrap: wrap;
 	min-width: 0;
 }
 
@@ -637,12 +640,12 @@
 	display: -webkit-box;
 	-webkit-box-orient: vertical;
 	overflow: hidden;
-	-webkit-line-clamp: 4; /* allows flow at desktop; clamps at narrow */
+	-webkit-line-clamp: 5; /* wave 70b: bumped from 4 to 5 for Spanish text */
 }
 
-@media (max-width: 520px) {
+@media (max-width: 600px) {
 	.feed-rsc__entry-excerpt {
-		-webkit-line-clamp: 2;
+		-webkit-line-clamp: 3;
 	}
 }
 
@@ -3294,6 +3297,66 @@
 	.feed-upcoming-virtual-event__layout
 		.feed-upcoming-virtual-event__featured-talk {
 		min-width: 0;
+	}
+}
+
+/* ---------- Wave 70b — virtual event card tightened spacing ----------
+   Bryan: 'this section remains fugly and wasteful with its space espec on
+   tablet / desktop'. Tighten vertical spacing, 2-col layout for
+   description + featured-talk at tablet+, compact button row.
+   Image stays full-width (wave 69 preserved). */
+
+/* Tablet: tighten spacing between elements */
+@container cdn-feed-upcoming-virtual-event (min-width: 520px) {
+	.feed-upcoming-virtual-event__image-link {
+		margin-block-end: var(--cdn-space-12, 12px);
+	}
+
+	.feed-upcoming-virtual-event__title {
+		margin-block-end: var(--cdn-space-sm, 8px);
+	}
+
+	.feed-upcoming-virtual-event__description {
+		margin-block-end: var(--cdn-space-md, 16px);
+	}
+
+	.feed-upcoming-virtual-event__layout
+		.feed-upcoming-virtual-event__featured-talk {
+		margin-block-end: var(--cdn-space-md, 16px);
+	}
+}
+
+/* Desktop: 2-column layout for description + featured-talk below image */
+@container cdn-feed-upcoming-virtual-event (min-width: 768px) {
+	.feed-upcoming-virtual-event__layout {
+		grid-template-areas:
+			"badge badge"
+			"image image"
+			"title title"
+			"date date"
+			"location location"
+			"description featured-talk"
+			"buttons buttons";
+		grid-template-columns: 1fr 1fr;
+		column-gap: var(--cdn-space-md, 16px);
+	}
+
+	.feed-upcoming-virtual-event__layout .cdn-brand-btn-stack {
+		/* Compact horizontal row instead of stacked */
+		display: flex;
+		flex-direction: row;
+		gap: var(--cdn-space-12, 12px);
+		flex-wrap: wrap;
+	}
+
+	/* Shrink the featured-talk brand-mark + bio block */
+	.feed-upcoming-virtual-event__featured-talk {
+		padding: 10px 12px;
+	}
+
+	.feed-upcoming-virtual-event__brand-mark-img {
+		width: 32px;
+		height: 32px;
 	}
 }
 

--- a/src/sites/auth/verification-setup/__tests__/index.test.tsx
+++ b/src/sites/auth/verification-setup/__tests__/index.test.tsx
@@ -151,8 +151,9 @@ describe("verification-setup page", () => {
 		fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
 
 		await waitFor(() => {
-			const url = (window.location.assign as ReturnType<typeof vi.fn>).mock
-				.calls.at(-1)?.[0] as string;
+			const url = (
+				window.location.assign as ReturnType<typeof vi.fn>
+			).mock.calls.at(-1)?.[0] as string;
 			expect(url).toContain(
 				`return_to=${encodeURIComponent("/rsvp/?event=happy-hour")}`,
 			);
@@ -180,8 +181,9 @@ describe("verification-setup page", () => {
 		fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
 
 		await waitFor(() => {
-			const url = (window.location.assign as ReturnType<typeof vi.fn>).mock
-				.calls.at(-1)?.[0] as string;
+			const url = (
+				window.location.assign as ReturnType<typeof vi.fn>
+			).mock.calls.at(-1)?.[0] as string;
 			expect(url).toContain(
 				`return_to=${encodeURIComponent("/rsvp/?event=happy-hour")}`,
 			);
@@ -199,8 +201,9 @@ describe("verification-setup page", () => {
 		fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
 
 		await waitFor(() => {
-			const url = (window.location.assign as ReturnType<typeof vi.fn>).mock
-				.calls.at(-1)?.[0] as string;
+			const url = (
+				window.location.assign as ReturnType<typeof vi.fn>
+			).mock.calls.at(-1)?.[0] as string;
 			expect(url).toContain("return_to=");
 			// The value after return_to= should be empty (encoded empty string)
 			const fragIdx = url.indexOf("#");

--- a/src/sites/auth/verify/__tests__/app.test.ts
+++ b/src/sites/auth/verify/__tests__/app.test.ts
@@ -1,4 +1,4 @@
-import { describe, beforeEach, afterEach, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 /**
  * verify/app.tsx — return_to stash before needsVerificationSetup

--- a/src/sites/awsug/auth/redeem/__tests__/app.test.ts
+++ b/src/sites/awsug/auth/redeem/__tests__/app.test.ts
@@ -1,5 +1,9 @@
-import { describe, beforeEach, afterEach, expect, it } from "vitest";
-import { clearReturnTo, getReturnTo, stashReturnTo } from "../../../../auth/_shared/return-to";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	clearReturnTo,
+	getReturnTo,
+	stashReturnTo,
+} from "../../../../auth/_shared/return-to";
 
 /**
  * redeem/app.tsx — dual-source return_to (fragment first, sessionStorage fallback)
@@ -17,7 +21,8 @@ describe("redeem — dual-source return_to", () => {
 	});
 
 	it("uses fragment return_to when present and non-empty", () => {
-		const fragment = "id_token=a&access_token=b&refresh_token=c&return_to=%2Frsvp%2F";
+		const fragment =
+			"id_token=a&access_token=b&refresh_token=c&return_to=%2Frsvp%2F";
 		const params = new URLSearchParams(fragment);
 		const returnTo = params.get("return_to") || getReturnTo();
 		clearReturnTo();
@@ -45,7 +50,7 @@ describe("redeem — dual-source return_to", () => {
 		const fragment = "id_token=a&access_token=b&refresh_token=c&return_to=";
 		const params = new URLSearchParams(fragment);
 		const returnTo = params.get("return_to") || getReturnTo();
-		const dest = returnTo && returnTo.startsWith("/") ? returnTo : "/index.html";
+		const dest = returnTo?.startsWith("/") ? returnTo : "/index.html";
 		expect(dest).toBe("/index.html");
 	});
 });


### PR DESCRIPTION
Bryan: 'odd orange bar above the footer / hide & fade in', 'light mode hideous on feed/cards / aws builder center off brand', 'virtual events section fugly + wasteful / spanish cutoffs on andmore/aws-ml/readysetcloud'.

## track 1 — atmosphere ribbon fade-in
opacity:0 → 1 transition 600ms ease-in, gated on actual content readiness (babylon scene first frame OR CSS fallback gradient ready). Fallback gradient now uses time-of-day palette helper (not flat orange).

## track 2 — light-mode polish
- BuilderCenterCard: brand cream + amber + violet from --cdn-card-bg-* tokens
- FeedAndmore/FeedAwsml/FeedReadysetcloud: 5-layer shadow stack + radial accent bloom + dual-radius hover glow per wave 9 / 23.5
- Event cards: tightened to brand cream/amber palette
- WCAG AA contrast preserved

## track 3 — virtual event + spanish cutoffs
- upcoming-virtual-event: 2-col description+featured-talk grid at ≥768px (image stays full-width per wave 69)
- featured-talk brand-mark + bio block sized down
- action buttons in compact horizontal row
- andmore/aws-ml/readysetcloud: +20 chars excerpt budget for Spanish + wider 2-line title clamp threshold

## scope
CSS-mostly. No JSX restructuring. Wave 69 full-card-width image preserved.

## gates
- biome 0 errors / tsc 0 NEW / build PASS / vitest 916 PASS (12 pre-existing IntersectionObserver jsdom failures unchanged from main)