### PR TITLE
fix(perf): wave 72 — deeper scroll perf (rAF, scoped ResizeObserver, GPU layer promotion)

### DIFF
--- a/src/components/footer/styles.css
+++ b/src/components/footer/styles.css
@@ -37,6 +37,10 @@
 	transition:
 		left 0.3s ease,
 		right 0.3s ease;
+	/* Wave 72: promote to dedicated GPU layer — avoids re-rasterizing
+	   backdrop-filter on every scroll frame */
+	will-change: transform;
+	transform: translateZ(0);
 }
 
 /* Wave 70c: spacer reserves vertical space so page content isn't hidden behind fixed footer */

--- a/src/layouts/shell/__tests__/wave-72-scroll-perf.test.tsx
+++ b/src/layouts/shell/__tests__/wave-72-scroll-perf.test.tsx
@@ -1,0 +1,52 @@
+// Wave 72 — scroll perf structural tests
+// Validates compositor layer promotion on fixed surfaces and
+// rAF-throttled scroll handlers.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "..", "..", "..", "..");
+
+const footerCss = readFileSync(
+	resolve(REPO_ROOT, "src/components/footer/styles.css"),
+	"utf-8",
+);
+
+const glassStreaksCss = readFileSync(
+	resolve(REPO_ROOT, "src/styles/cdn-glass-streaks.css"),
+	"utf-8",
+);
+
+const shellTsx = readFileSync(
+	resolve(REPO_ROOT, "src/layouts/shell/index.tsx"),
+	"utf-8",
+);
+
+describe("wave 72 — compositor layer promotion", () => {
+	it("footer has will-change: transform for GPU layer", () => {
+		expect(footerCss).toContain("will-change: transform");
+	});
+
+	it("footer has transform: translateZ(0) for layer creation", () => {
+		expect(footerCss).toContain("transform: translateZ(0)");
+	});
+
+	it("volunteer-btn has will-change: transform", () => {
+		const btnStart = glassStreaksCss.indexOf(".cdn-volunteer-btn {");
+		const btnBlock = glassStreaksCss.slice(btnStart, btnStart + 800);
+		expect(btnBlock).toContain("will-change: transform");
+	});
+});
+
+describe("wave 72 — scroll handler throttling", () => {
+	it("cdn-scrolled toggle uses requestAnimationFrame", () => {
+		const scrolledIdx = shellTsx.indexOf("cdn-scrolled");
+		const scrolledBlock = shellTsx.slice(scrolledIdx, scrolledIdx + 500);
+		expect(scrolledBlock).toContain("requestAnimationFrame");
+	});
+
+	it("volunteer pill ResizeObserver does NOT observe document.body", () => {
+		expect(shellTsx).not.toContain("ro.observe(document.body)");
+	});
+});

--- a/src/layouts/shell/index.tsx
+++ b/src/layouts/shell/index.tsx
@@ -387,14 +387,21 @@ function ShellContent({
 	// cdn-scrolled body class — drives the fixed-position mobile toggle pair.
 	// Threshold 80px gives one clear scroll gesture before the class fires;
 	// removes cleanly when back near top so the toggles return to normal flow.
+	// Wave 72: rAF-throttled to avoid per-event class toggle (layout thrash).
 	useEffect(() => {
 		if (typeof window === "undefined") return;
+		let rafId: number | null = null;
 		const onScroll = () => {
-			document.body.classList.toggle("cdn-scrolled", window.scrollY > 80);
+			if (rafId !== null) return;
+			rafId = requestAnimationFrame(() => {
+				rafId = null;
+				document.body.classList.toggle("cdn-scrolled", window.scrollY > 80);
+			});
 		};
 		window.addEventListener("scroll", onScroll, { passive: true });
 		return () => {
 			window.removeEventListener("scroll", onScroll);
+			if (rafId !== null) cancelAnimationFrame(rafId);
 			document.body.classList.remove("cdn-scrolled");
 		};
 	}, []);
@@ -406,6 +413,7 @@ function ShellContent({
 	// shift it via CSS custom property so the pill horizontally lines up
 	// with the active page name in the breadcrumb above. ResizeObserver
 	// catches viewport reflow + nav-drawer open/close.
+	// Wave 72: observe the breadcrumb container (not body) to avoid firing on scroll.
 	useEffect(() => {
 		if (typeof document === "undefined") return;
 
@@ -436,8 +444,16 @@ function ShellContent({
 		// initial pass after Cloudscape paint settles
 		const initialId = window.setTimeout(computeShift, 80);
 
+		// Wave 72: observe the breadcrumb container instead of body.
+		// Body's scrollHeight changes on scroll → fires RO on every frame.
+		// Breadcrumb container only resizes on viewport/nav-drawer changes.
+		const breadcrumbEl = document.querySelector<HTMLElement>(
+			'[class*="awsui_breadcrumbs_"]',
+		);
 		const ro = new ResizeObserver(computeShift);
-		ro.observe(document.body);
+		if (breadcrumbEl) {
+			ro.observe(breadcrumbEl);
+		}
 
 		window.addEventListener("resize", computeShift);
 

--- a/src/styles/cdn-glass-streaks.css
+++ b/src/styles/cdn-glass-streaks.css
@@ -1847,6 +1847,8 @@ body.cdn-stream-playing
 		box-shadow 0.2s ease,
 		border-color 0.2s ease;
 	user-select: none;
+	/* Wave 72: dedicated GPU layer — fixed element shouldn't re-rasterize on scroll */
+	will-change: transform;
 }
 
 .cdn-volunteer-btn::before {


### PR DESCRIPTION
Wave 71 cut worst frame 249.9ms → 83.4ms but 93.9% slow frames remained. Liora found 4 root causes via static analysis:

1. ResizeObserver on document.body fires every scroll frame (body scrollHeight changes)
2. cdn-scrolled body class toggled un-throttled per scroll event
3. Footer backdrop-filter blur re-rasterizes per frame without GPU layer promotion
4. Volunteer button position:fixed without will-change

## fixes
- shell: rAF gate on cdn-scrolled toggle (one per frame max)
- shell: ResizeObserver scoped from body to awsui_breadcrumbs_ container
- footer: will-change + translateZ(0) compositor layer
- volunteer-btn: will-change

## metrics target
worst frame 83.4ms → <50ms; % slow frames 93.9% → <50%

biome 0 / tsc 0 NEW / build PASS / vitest passes