### PR TITLE
fix(auth): wave 73b — disable auto-passkey trigger (P0 — event signups today)

### DIFF
--- a/src/sites/auth/login/app.tsx
+++ b/src/sites/auth/login/app.tsx
@@ -190,13 +190,10 @@ function LoginForm() {
 		}
 	}
 
-	// Auto-trigger passkey if user has one registered
-	if (!passkeyAutoRef.current && localStorage.getItem("cdn.passkey_email")) {
-		passkeyAutoRef.current = true;
-		setTimeout(() => {
-			void handlePasskeyLogin();
-		}, 600);
-	}
+	// Auto-trigger passkey disabled — Cognito user pool WebAuthn configuration
+	// is incomplete (CredentialRequestOptions missing from challenge response).
+	// Users can still click "Sign in with passkey" manually if they want to try.
+	// Re-enable once Cognito WebAuthn is properly configured.
 
 	async function handleCredentialsSubmit(e: React.FormEvent) {
 		e.preventDefault();


### PR DESCRIPTION
P0: users see 'passkey challenge missing CredentialRequestOptions' on login page load. Auto-passkey trigger fires before they can type password. Email/password auth works fine — error was just blocking UX. Disabled auto-trigger; manual passkey button stays.