### PR TITLE
fix(perf): wave 75 — content-visibility:auto on feed grid cells

### DIFF
--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -474,6 +474,8 @@
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
+	content-visibility: auto;
+	contain-intrinsic-size: 0 400px; /* estimated card height, prevents scroll-bar jump */
 }
 
 /* design-system baseline — cream surface for feed cards (light mode).
@@ -657,6 +659,8 @@
 	   (~100-130px of whitespace per card). Bryan validated in DevTools.
 	   Standard-tier cards keep their floor since they cycle content. */
 	min-height: 0;
+	content-visibility: auto;
+	contain-intrinsic-size: 0 400px; /* estimated card height, prevents scroll-bar jump */
 }
 
 /* wave 25b — extra breathing room between stacked event cards (featured,


### PR DESCRIPTION
Liora perf audit (wave 75) measured 66.7% scroll frames >33ms, worst 283ms. Compositor hygiene is clean (will-change=2, canvas=1 from waves 71-74). Remaining jank is main-thread layout for off-screen cards.

## fix
- content-visibility: auto on .feed-grid__cell + .feed-grid__cell--full
- contain-intrinsic-size: 0 400px (estimated height to prevent scrollbar jump)

Browser skips layout/paint for off-screen cards entirely. Expected: significant reduction in main-thread work during scroll.