### PR TITLE
fix(awsug): wave 81 — fix logged-in experience (mic prompt, tickets error, player, June 3 RSVP)

### DIFF
--- a/src/layouts/shell/index.tsx
+++ b/src/layouts/shell/index.tsx
@@ -277,6 +277,9 @@ export interface ShellProps {
 	/** Hide the "sign in" button in the top-nav utilities. Used on the auth subdomain
 	 *  itself so the button isn't recursive (clicking it from /login goes to /login). */
 	hideSignInUtility?: boolean;
+	/** Suppress the persistent radio player slot. Used on subdomains where the player
+	 *  bar is irrelevant (e.g. awsug). */
+	hidePlayer?: boolean;
 }
 
 function ShellContent({
@@ -297,6 +300,7 @@ function ShellContent({
 	navigationHide,
 	toolsHide,
 	hideSignInUtility,
+	hidePlayer,
 }: ShellProps) {
 	const { t } = useTranslation();
 	const auth = useAuth();
@@ -687,7 +691,7 @@ function ShellContent({
 							role="region"
 							aria-label="radio player"
 						>
-							<PersistentPlayer />
+							{!hidePlayer && <PersistentPlayer />}
 						</div>
 						{children}
 					</>

--- a/src/sites/awsug/_layout/index.tsx
+++ b/src/sites/awsug/_layout/index.tsx
@@ -104,6 +104,7 @@ export default function AwsugLayout({
 
 	return (
 		<Shell
+			hidePlayer
 			theme={theme}
 			onThemeChange={(t) => {
 				setTheme(t);

--- a/src/sites/awsug/admin/app.tsx
+++ b/src/sites/awsug/admin/app.tsx
@@ -13,6 +13,7 @@ import Table from "@cloudscape-design/components/table";
 import Tabs from "@cloudscape-design/components/tabs";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "../../../hooks/useTranslation";
+import { spotsRemaining } from "../../../lib/rsvp";
 import AwsugLayout from "../_layout";
 import {
 	type AdminUser,
@@ -266,6 +267,34 @@ function UserTable({
 	);
 }
 
+function RsvpsTab() {
+	const [remaining, setRemaining] = useState<number | null>(null);
+	useEffect(() => {
+		spotsRemaining("happy-hour-2026-06-03").then((n) => setRemaining(n));
+	}, []);
+	return (
+		<SpaceBetween size="m">
+			<Box>
+				<strong>June 3 Happy Hour</strong> — spots remaining:{" "}
+				{remaining === null ? (
+					<Spinner />
+				) : Number.isNaN(remaining) ? (
+					"unknown"
+				) : (
+					remaining
+				)}
+			</Box>
+			<Button
+				href="/rsvp/index.html?event=happy-hour-2026-06-03"
+				iconName="external"
+				target="_blank"
+			>
+				View RSVP flow
+			</Button>
+		</SpaceBetween>
+	);
+}
+
 function AdminPanel() {
 	const { t } = useTranslation();
 	const [activeTab, setActiveTab] = useState("pending");
@@ -314,6 +343,11 @@ function AdminPanel() {
 						id: "meetings",
 						label: "Meetings",
 						content: <MeetingsTable />,
+					},
+					{
+						id: "rsvps",
+						label: "RSVPs",
+						content: <RsvpsTab />,
 					},
 				]}
 			/>

--- a/src/sites/awsug/app.tsx
+++ b/src/sites/awsug/app.tsx
@@ -14,6 +14,7 @@ import Spinner from "@cloudscape-design/components/spinner";
 import { useEffect, useState } from "react";
 import { useTranslation } from "../../hooks/useTranslation";
 import { loadPlayerState } from "../../lib/player-persist";
+import { listMyRsvps, type RsvpRecord } from "../../lib/rsvp";
 import { STREAMS } from "../../lib/streams";
 import AwsugLayout from "./_layout";
 import {
@@ -68,8 +69,13 @@ function MemberHome({ auth }: { auth: AuthState }) {
 	const [meetup, setMeetup] = useState<NextMeetup | null | "loading">(
 		"loading",
 	);
+	const [june3Rsvp, setJune3Rsvp] = useState<RsvpRecord | null | "loading">(
+		"loading",
+	);
 	const player = loadPlayerState();
 	const visibleStreams = STREAMS.filter((s) => !s.hidden);
+	const JUNE3_EVENT = "happy-hour-2026-06-03";
+	const JUNE3_FUTURE = new Date() < new Date("2026-06-03T23:59:59-06:00");
 
 	useEffect(() => {
 		fetch("/data/next-meetup.json")
@@ -77,6 +83,18 @@ function MemberHome({ auth }: { auth: AuthState }) {
 			.then((d) => setMeetup(d as NextMeetup | null))
 			.catch(() => setMeetup(null));
 	}, []);
+
+	useEffect(() => {
+		if (!JUNE3_FUTURE) {
+			setJune3Rsvp(null);
+			return;
+		}
+		listMyRsvps()
+			.then((list) =>
+				setJune3Rsvp(list.find((r) => r.eventId === JUNE3_EVENT) ?? null),
+			)
+			.catch(() => setJune3Rsvp(null));
+	}, [JUNE3_FUTURE]);
 
 	const name = auth.name?.split(" ")[0] || firstName(auth.email);
 	const isMod = auth.groups.includes("moderators");
@@ -101,6 +119,27 @@ function MemberHome({ auth }: { auth: AuthState }) {
 					)}
 				</SpaceBetween>
 			</Container>
+
+			{/* June 3 Happy Hour RSVP status */}
+			{JUNE3_FUTURE && june3Rsvp !== "loading" && (
+				<Container header={<Header variant="h2">June 3 Happy Hour</Header>}>
+					{june3Rsvp ? (
+						<Alert type="success">
+							You&apos;re registered!{" "}
+							<Link href="/rsvp/index.html?event=happy-hour-2026-06-03">
+								View your ticket
+							</Link>
+						</Alert>
+					) : (
+						<Button
+							href="/rsvp/index.html?event=happy-hour-2026-06-03"
+							variant="primary"
+						>
+							RSVP for June 3 Happy Hour
+						</Button>
+					)}
+				</Container>
+			)}
 
 			{/* Next meetup + now playing */}
 			<ColumnLayout columns={2}>

--- a/src/sites/awsug/meetings/app.tsx
+++ b/src/sites/awsug/meetings/app.tsx
@@ -65,7 +65,9 @@ function MeetingsContent({ auth }: { auth: AuthState }) {
 				header="Cloud Del Norte — live call"
 				closeAriaLabel="leave meeting"
 			>
-				<JitsiEmbed roomName={ROOM_NAME} onClose={() => setInCall(false)} />
+				{inCall && (
+					<JitsiEmbed roomName={ROOM_NAME} onClose={() => setInCall(false)} />
+				)}
 			</Modal>
 		</SpaceBetween>
 	);

--- a/src/sites/awsug/meetings/components/my-tickets.tsx
+++ b/src/sites/awsug/meetings/components/my-tickets.tsx
@@ -71,7 +71,9 @@ export default function MyTickets({ auth }: { auth: AuthState }) {
 					<Spinner />
 				</Box>
 			) : errorKey ? (
-				<Alert type="error">{t(errorKey)}</Alert>
+				<Alert type={errorKey === "rsvp.error.unauthorized" ? "info" : "error"}>
+					{t(errorKey)}
+				</Alert>
 			) : tickets.length === 0 ? (
 				<Box color="text-status-inactive">{t("meetings.myTicketsEmpty")}</Box>
 			) : (


### PR DESCRIPTION
Bryan: 'your tickets gives something went wrong + something prompts for microphone + ticket page shows Talking Serverless/AWS Bites + no June 3 signups visible'.

## fixes
1. **MyTickets unauthorized**: Alert type error→info for pending/unauthorized users; was showing red 'something went wrong'
2. **Microphone prompt**: JitsiEmbed now only mounts when inCall=true (Cloudscape Modal pre-renders children; permissions.query was firing on load)
3. **Radio player on awsug**: Added hidePlayer prop to Shell; AwsugLayout passes it — no more station name bleeding from feed site
4. **June 3 RSVP visibility**: MemberHome shows RSVP status card for June 3 event; admin panel gets RSVPs tab with spot count

## gates
biome 0 new errors / tsc 0 NEW / build PASS / vitest 979 PASS