### PR TITLE
chore(husky): wave 85 — add biome ci full-tree gate to pre-commit (matches deploy.yml)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,7 @@
+#!/usr/bin/env sh
+set -e
+# 1. auto-fix staged files (lint-staged + biome check --write)
 npx lint-staged
+# 2. full-tree verify matches .woodpecker/deploy.yml gate
+#    (catches violations in unstaged files that would fail deploy)
+npx biome ci --diagnostic-level=error src/


### PR DESCRIPTION
**Motivation:** Wave 84c revealed that lint-staged alone cannot catch lint violations in files already committed but not in the current staged set. A developer could commit clean staged files while pre-existing violations in the tree go undetected, allowing broken code to reach the deploy pipeline and fail CI remotely — wasting deploy cycles and delaying feedback.

**Change:** The .husky/pre-commit hook now runs a two-step gate under `set -e`: (1) `npx lint-staged` for auto-fixable formatting on staged files, followed by (2) `npx biome ci --diagnostic-level=error src/` as a full-tree sweep that mirrors the exact check in deploy.yml. Any non-zero exit from either step aborts the commit immediately.

**Verification:** A synthetic violation (eval() call triggering security/noGlobalEval — non-auto-fixable) was committed to the tree, then a subsequent commit of a different staged file was attempted. lint-staged passed (no matching staged .ts), but biome ci caught the violation in the full-tree scan and exited 1, aborting the commit. This confirms the hook now blocks the exact scenario that caused the wave 84c deploy failure.