### PR TITLE
fix(cards): wave 86a — remove artifact behind glassmorphic cards (#208)

### DIFF
--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -1211,7 +1211,7 @@
 
 	position: relative;
 	isolation: isolate;
-	border-left: 4px solid var(--cdn-violet, #9060f0);
+	border-left: none;
 	border-radius: var(--cdn-radius-md, 8px);
 	overflow: hidden;
 	/* wave 37a — perspective + preserve-3d + contain + translate3d +
@@ -1239,6 +1239,7 @@
 	/* layered ambient bloom — sits beneath the radial spotlight backplate
 	   (::before) and the cool sweep depth layer (::after). */
 	box-shadow:
+		inset 4px 0 0 0 var(--cdn-violet, #9060f0),
 		0 1px 2px rgba(48, 0, 106, 0.08),
 		0 8px 28px -8px var(--cdn-v2-ambient-bloom),
 		0 18px 48px -12px var(--cdn-v2-ambient-bloom),
@@ -1268,6 +1269,7 @@
 	--cdn-v2-title-tape: rgba(215, 199, 238, 0.42);
 
 	box-shadow:
+		inset 4px 0 0 0 var(--cdn-violet, #9060f0),
 		0 2px 6px rgba(0, 0, 0, 0.5),
 		0 10px 30px -8px var(--cdn-v2-ambient-bloom),
 		0 22px 56px -12px var(--cdn-v2-ambient-bloom),

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -744,6 +744,18 @@ html:not(.awsui-dark-mode) body {
 	box-shadow: var(--cdn-card-rim-light);
 }
 
+/* wave 86a fix (#208) — suppress awsui_root chrome inside .cdn-card to prevent
+   ghost-shell double-rendering. Specificity (0,3,0) beats both the global rule
+   above and Cloudscape's own scoped module selectors. */
+.cdn-card [class*="awsui_root_"][class*="awsui_variant-default_"],
+.cdn-card [class*="awsui_root_"][class*="awsui_variant-stacked_"] {
+	background: transparent;
+	background-image: none;
+	border: none;
+	border-radius: 0;
+	box-shadow: none;
+}
+
 /* Per-surface application of --cdn-card-gradient-light + --cdn-card-rim-light
    for non-Cloudscape card surfaces (e.g. .feed-mini-card__link) is colocated
    with each surface's own rule — see src/pages/feed/styles.css. */


### PR DESCRIPTION
## Summary

Cloudscape `awsui_root` container rendered a second opaque card shell behind the `cdn-glass` surface, creating a visible white/grey artifact at rounded corners and card edges.

**Fix:**
- `src/styles/tokens.css`: suppress `awsui_root` background/border/shadow inside `.cdn-card` at specificity (0,3,0)
- `src/pages/feed/styles.css`: replace `border-left` accent with `inset box-shadow` to avoid clipping at border-radius corners

Screenshot reference: https://cdn-del-norte-assets.s3.us-west-2.amazonaws.com/screenshots/wave86a-glassmorphic-artifact.png

Closes #208