### PR TITLE
chore(biome): wave 87a — apply unsafe biome fixes (#260)

### DIFF
--- a/src/components/weather/__tests__/atmosphere-scene.test.tsx
+++ b/src/components/weather/__tests__/atmosphere-scene.test.tsx
@@ -33,7 +33,6 @@ vi.mock("@babylonjs/core", () => {
 	class ArcRotateCamera {
 		inputs = { clear: vi.fn() };
 		animations: unknown[] = [];
-		constructor() {}
 	}
 	// biome-ignore lint/complexity/noStaticOnlyClass: same
 	class HemisphericLight {
@@ -95,11 +94,8 @@ vi.mock("@babylonjs/core", () => {
 		HemisphericLight,
 		DirectionalLight,
 		Animation,
-		Color4: class Color4 {
-			constructor() {}
-		},
+		Color4: class Color4 {},
 		Color3: class Color3 {
-			constructor() {}
 			static White() {
 				return {};
 			}
@@ -108,7 +104,6 @@ vi.mock("@babylonjs/core", () => {
 			static Zero() {
 				return {};
 			}
-			constructor() {}
 		},
 		MeshBuilder: {
 			CreateSphere: vi.fn((name: string) => mockMesh(name)),

--- a/src/components/weather/__tests__/weather-stable-key.test.tsx
+++ b/src/components/weather/__tests__/weather-stable-key.test.tsx
@@ -1,8 +1,3 @@
-// Wave 66 — Weather component stable-key test.
-// AtmosphereScene must NOT remount when city cycles — only receive new props.
-// If the key changes on city, a new canvas would be created destroying/re-creating
-// the WebGL context on every city advance.
-import { render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Babylon stub ─────────────────────────────────────────────────────────────
@@ -63,28 +58,27 @@ vi.mock("../../lib/babylon-budget", () => ({
 class IntersectionObserverMock {
 	observe = vi.fn();
 	disconnect = vi.fn();
-	constructor(_cb: unknown) {}
 }
 
 // ── Spy on AtmosphereScene to track mount count ───────────────────────────────
 // We directly test the key stability by tracking how many canvas elements
 // are created across prop changes. A stable-key component reuses the same
 // canvas node; an unstable-key component creates a new one.
-let mountCount = 0;
+let _mountCount = 0;
 
 vi.mock("./atmosphere-scene", async (importOriginal) => {
 	const mod = await importOriginal<typeof import("../atmosphere-scene")>();
 	return {
 		...mod,
 		default: (props: import("../atmosphere-scene").AtmosphereSceneProps) => {
-			mountCount++;
+			_mountCount++;
 			return mod.default(props);
 		},
 	};
 });
 
 beforeEach(() => {
-	mountCount = 0;
+	_mountCount = 0;
 	vi.stubGlobal("IntersectionObserver", IntersectionObserverMock);
 });
 

--- a/src/pages/admin/index.html
+++ b/src/pages/admin/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/pages/auth/callback/index.html
+++ b/src/pages/auth/callback/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/pages/costs/index.html
+++ b/src/pages/costs/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/pages/create-meeting/index.html
+++ b/src/pages/create-meeting/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/pages/dune-test/index.html
+++ b/src/pages/dune-test/index.html
@@ -66,9 +66,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/pages/feed/components/__tests__/wave-48bc.test.tsx
+++ b/src/pages/feed/components/__tests__/wave-48bc.test.tsx
@@ -6,7 +6,7 @@
 //   B.2 — AndresYoutubeLive fanfare (brand star, sigil, ayl-header-row)
 //   C   — FeaturedVideoCard desktop right-column alignment (align-items: start in CSS)
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../../contexts/locale-context";
 import AndresYoutubeLive from "../andres-youtube-live";
@@ -43,14 +43,14 @@ const SAMPLE_POSTS: FeedPost[] = [
 
 // IntersectionObserver stub for lazy-embed tests
 type IOCallback = (entries: IntersectionObserverEntry[]) => void;
-let lastIOCb: IOCallback | null = null;
+let _lastIOCb: IOCallback | null = null;
 
 beforeEach(() => {
-	lastIOCb = null;
+	_lastIOCb = null;
 	class IOMock {
 		disconnect = vi.fn();
 		constructor(cb: IOCallback) {
-			lastIOCb = cb;
+			_lastIOCb = cb;
 		}
 		observe() {}
 	}

--- a/src/pages/feed/components/youtube-carousel.tsx
+++ b/src/pages/feed/components/youtube-carousel.tsx
@@ -5,7 +5,6 @@ import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import { lazy, useEffect, useState } from "react";
 import BabylonGate from "../../../components/babylon-gate";
-import { SkeletonFrame } from "../../../components/skeleton";
 import { useTranslation } from "../../../hooks/useTranslation";
 import { YouTubeSpinPlaceholder } from "./youtube-spin-placeholder";
 

--- a/src/pages/feed/index.html
+++ b/src/pages/feed/index.html
@@ -36,9 +36,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/pages/home/index.html
+++ b/src/pages/home/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/pages/learning/api/index.html
+++ b/src/pages/learning/api/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/pages/maintenance-calendar/index.html
+++ b/src/pages/maintenance-calendar/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/pages/meeting-public/index.html
+++ b/src/pages/meeting-public/index.html
@@ -18,9 +18,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/pages/meetings/index.html
+++ b/src/pages/meetings/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/pages/plans/index.html
+++ b/src/pages/plans/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/pages/roadmap/index.html
+++ b/src/pages/roadmap/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/pages/theme/index.html
+++ b/src/pages/theme/index.html
@@ -19,9 +19,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/sites/auth/forgot-password/index.html
+++ b/src/sites/auth/forgot-password/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/sites/auth/login/__tests__/app.test.tsx
+++ b/src/sites/auth/login/__tests__/app.test.tsx
@@ -84,7 +84,7 @@ describe("login → redirectWithTokens: needsVerificationSetup stash", () => {
 		sessionStorage.removeItem("cdn.needsVerificationSetup");
 		if (returnTo) sessionStorage.setItem("cdn.returnTo", returnTo);
 		window.location.assign(
-			"/verification-setup/index.html" + window.location.search,
+			`/verification-setup/index.html${window.location.search}`,
 		);
 
 		expect(sessionStorage.getItem("cdn.returnTo")).toBe(

--- a/src/sites/auth/login/app.tsx
+++ b/src/sites/auth/login/app.tsx
@@ -59,7 +59,7 @@ function LoginForm() {
 	const [email, setEmail] = useState(
 		() => localStorage.getItem("cdn.passkey_email") ?? "",
 	);
-	const passkeyAutoRef = useRef(false);
+	const _passkeyAutoRef = useRef(false);
 	const [password, setPassword] = useState("");
 	const [showPassword, setShowPassword] = useState(false);
 	const [emailError, setEmailError] = useState("");

--- a/src/sites/auth/login/index.html
+++ b/src/sites/auth/login/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/sites/auth/passkeys/index.html
+++ b/src/sites/auth/passkeys/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/sites/auth/signup/index.html
+++ b/src/sites/auth/signup/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/sites/auth/verification-setup/index.html
+++ b/src/sites/auth/verification-setup/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/sites/auth/verify/index.html
+++ b/src/sites/auth/verify/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/sites/awsug/admin/index.html
+++ b/src/sites/awsug/admin/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/sites/awsug/auth/callback/index.html
+++ b/src/sites/awsug/auth/callback/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/sites/awsug/auth/redeem/index.html
+++ b/src/sites/awsug/auth/redeem/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/sites/awsug/create-meeting/index.html
+++ b/src/sites/awsug/create-meeting/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/sites/awsug/index.html
+++ b/src/sites/awsug/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/sites/awsug/meetings/index.html
+++ b/src/sites/awsug/meetings/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');

--- a/src/sites/awsug/rsvp/index.html
+++ b/src/sites/awsug/rsvp/index.html
@@ -20,9 +20,9 @@
         var t;
         try {
           t = localStorage.getItem('awsaerospace-theme');
-        } catch (e) { /* localStorage unavailable; safe fall-through */ }
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
         if (t !== 'dark' && t !== 'light') {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
         if (t === 'dark') {
           document.documentElement.classList.add('awsui-dark-mode');


### PR DESCRIPTION
## Wave 87a — Biome Unsafe Fixes (Partial Batch)

**Diff stats (src/ only):** 33 files changed, 64 insertions(+), 76 deletions(-)

### Rule-category breakdown — LANDED (JS/TS/HTML, 33 files)

| Rule | Files | Change |
|------|-------|--------|
| `style/useTemplate` | 27 × index.html | `window.matchMedia && …` → `window.matchMedia?.(…)`; `catch (e)` → `catch (_e)` |
| `correctness/noUnusedVariables` | login/app.tsx, wave-48bc.test.tsx, weather-stable-key.test.tsx | unused vars prefixed with `_` |
| `complexity/noUselessConstructor` | atmosphere-scene.test.tsx | removed empty `constructor(){}` from mocks |
| `correctness/noUnusedImports` | weather-stable-key.test.tsx, wave-48bc.test.tsx, youtube-carousel.tsx | removed unused `render`, `screen`, `SkeletonFrame` imports |
| `style/useOptionalChain` | login/__tests__/app.test.tsx | string concat → template literal |

### DROPPED (CSS, 10 files reverted)

| Rule | Reason dropped |
|------|---------------|
| `style/noDescendingSpecificity` | Reordering Cloudscape override selectors changes cascade resolution — visual semantic risk |
| CSS formatter `!important` removal | biome stripped `!important` from 179 Cloudscape token overrides — these MUST keep `!important` to override Cloudscape component-internal scoped CSS; silent removal breaks light/dark mode theming |

### Additional individual reverts (JS/TS)
- `projection.test.ts` — `?.!` conversion triggers `noNonNullAssertedOptionalChain` at CI
- `wave-71-perf-contrast.test.ts` — `versionMatch?.[1]` produces `string|undefined` breaking `parseInt`

### Gates
- ✅ `npx biome ci --diagnostic-level=error src/` — 406 files clean
- ✅ `npm run build` — tsc + 3 vite bundles green
- ✅ `npm test -- --run` — 979/979 tests passing

**Scope:** Partial batch — JS/TS/HTML unsafe fixes landed; CSS batch deferred to follow-up.

Ref #260 (partial — CSS unsafe fixes remain open)