### PR TITLE
fix(auth): wave 87c — apply-to-join CTA corner clip resolved

### DIFF
--- a/src/sites/auth/login/app.tsx
+++ b/src/sites/auth/login/app.tsx
@@ -432,7 +432,12 @@ function LoginForm() {
 
 	return (
 		<div className="cdn-auth-form-inner">
-			<Box variant="small" textAlign="right" margin={{ bottom: "s" }}>
+			<Box
+				variant="small"
+				textAlign="right"
+				margin={{ bottom: "s" }}
+				padding={{ right: "xl" }}
+			>
 				{t("auth.login.noAccount")}{" "}
 				<Link
 					href={`/signup/index.html${typeof window !== "undefined" && window.location.search ? window.location.search : ""}`}


### PR DESCRIPTION
## Wave 87c — Apply-to-Join CTA Corner Clip Fix

### Root Cause
`.cdn-auth-card::after` pseudo-element (z-index:1, 36×36px positioned at top:10px right:12px) rendered on top of the right-aligned "Apply to join" CTA link, clipping 23×19px of text. The stamp has z-index:1 while the CTA text container has z-index:auto, causing the stamp to stack above.

### Fix
Added `padding={{ right: "xl" }}` (~24px in Cloudscape tokens) to the CTA parent `<Box>` so text content clears the stamp bounding box entirely.

**File:** `src/sites/auth/login/app.tsx` (1 file, +6 −1)

### Before
- Mobile light: stamp overlaps "Apply to join" text by 23px horizontally
- Desktop light: same overlap visible at standard viewport

### After
- CTA text fully visible, clears stamp zone with xl padding

### Gates
- ✅ `npx biome ci --diagnostic-level=error src/` — 406 files clean
- ✅ `npm run build` — green (1.93s)
- ✅ `npm test -- --run` — 979/979 passing
- ✅ lint-staged pre-commit hook passed