### PR TITLE
perf(networkidle): wave 88c — defer weather fetch + gate audio src (#182)

### DIFF
--- a/src/components/persistent-player/index.tsx
+++ b/src/components/persistent-player/index.tsx
@@ -138,7 +138,9 @@ function PersistentPlayerBar({
 	const audioRef = useRef<HTMLAudioElement>(null);
 	const [blocked, setBlocked] = useState(false);
 	const [playing, setPlaying] = useState(false);
+	const playingRef = useRef(false);
 	const [connecting, setConnecting] = useState(false);
+	const [readyToLoad, setReadyToLoad] = useState(autoplay);
 	const [nowPlaying, setNowPlaying] = useState<string | null>(null);
 	const [rssAudioUrl, setRssAudioUrl] = useState<string | null>(null);
 	const [streamHealth, setStreamHealth] = useState<StreamHealth>("ok");
@@ -319,6 +321,8 @@ function PersistentPlayerBar({
 		setConnecting(false);
 		retryCountRef.current = 0;
 		hasConnectedRef.current = false;
+		// gate audio src: preserve when playing (station skip mid-play), reset when idle
+		if (!playingRef.current) setReadyToLoad(false);
 		// wave 28c: reset podcast-specific retry budget + clear pending backoff timer
 		podcastRetryHistoryRef.current = [];
 		if (podcastRetryTimerRef.current !== null) {
@@ -347,6 +351,7 @@ function PersistentPlayerBar({
 			if (!detail?.url) return;
 			setRssAudioUrl(detail.url);
 			if (detail.title) setNowPlaying(detail.title);
+			setReadyToLoad(true);
 			// best-effort autoplay — same pattern as the play() callback below.
 			// failure (e.g. browser blocks autoplay) sets the blocked state via
 			// the existing audio.play() catch chain.
@@ -578,6 +583,7 @@ function PersistentPlayerBar({
 			document.body.classList.add("cdn-stream-playing");
 			if (isPodcast) document.body.classList.add("cdn-podcast-playing");
 			setPlaying(true);
+			playingRef.current = true;
 			setConnecting(false);
 			onPlayStateChangeRef.current?.(true);
 		};
@@ -585,6 +591,7 @@ function PersistentPlayerBar({
 			document.body.classList.remove("cdn-stream-playing");
 			document.body.classList.remove("cdn-podcast-playing");
 			setPlaying(false);
+			playingRef.current = false;
 			onPlayStateChangeRef.current?.(false);
 		};
 		audio.addEventListener("playing", onPlay);
@@ -801,6 +808,7 @@ function PersistentPlayerBar({
 	const play = useCallback(() => {
 		const audio = audioRef.current;
 		if (!audio) return;
+		setReadyToLoad(true);
 		setConnecting(true);
 		audio.play().catch(() => {
 			setConnecting(false);
@@ -971,7 +979,7 @@ function PersistentPlayerBar({
 			<audio
 				key={isPodcast ? "podcast" : "radio"}
 				ref={audioRef}
-				src={rssAudioUrl ?? state.stationUrl}
+				src={readyToLoad ? (rssAudioUrl ?? state.stationUrl) : undefined}
 				preload="none"
 				crossOrigin={isPodcast ? undefined : "anonymous"}
 				onPlay={handlePlay}

--- a/src/components/weather/index.tsx
+++ b/src/components/weather/index.tsx
@@ -140,24 +140,38 @@ export default function Weather() {
 		}
 		setData(null);
 		let cancelled = false;
-		void Promise.allSettled([
-			fetch(forecastUrl(city)).then((r) =>
-				r.ok ? (r.json() as Promise<Forecast>) : null,
-			),
-			fetch(aqiUrl(city)).then((r) =>
-				r.ok ? (r.json() as Promise<AirQuality>) : null,
-			),
-		]).then((results) => {
-			if (cancelled) return;
-			const forecast =
-				results[0].status === "fulfilled" ? results[0].value : null;
-			const air = results[1].status === "fulfilled" ? results[1].value : null;
-			const fresh: CachedWeather = { ts: Date.now(), forecast, air };
-			saveCache(city, fresh);
-			setData(fresh);
-		});
+		const doFetch = () => {
+			void Promise.allSettled([
+				fetch(forecastUrl(city)).then((r) =>
+					r.ok ? (r.json() as Promise<Forecast>) : null,
+				),
+				fetch(aqiUrl(city)).then((r) =>
+					r.ok ? (r.json() as Promise<AirQuality>) : null,
+				),
+			]).then((results) => {
+				if (cancelled) return;
+				const forecast =
+					results[0].status === "fulfilled" ? results[0].value : null;
+				const air = results[1].status === "fulfilled" ? results[1].value : null;
+				const fresh: CachedWeather = { ts: Date.now(), forecast, air };
+				saveCache(city, fresh);
+				setData(fresh);
+			});
+		};
+		// useEffect only runs in the browser — window is always defined here
+		let timerId: number | undefined;
+		let idleCbId: number | undefined;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const win = window as any;
+		if ("requestIdleCallback" in window) {
+			idleCbId = requestIdleCallback(doFetch, { timeout: 2000 });
+		} else {
+			timerId = win.setTimeout(doFetch, 1500);
+		}
 		return () => {
 			cancelled = true;
+			if (idleCbId !== undefined) cancelIdleCallback(idleCbId);
+			if (timerId !== undefined) win.clearTimeout(timerId);
 		};
 	}, [city]);
 


### PR DESCRIPTION
Root causes fixed:
1. /home/ mobile networkidle ≈20s: weather/index.tsx fired open-meteo.com +
   air-quality-api.open-meteo.com fetches immediately on mount, keeping the
   network active 3-8s after first paint.
2. /roadmap/ desktop networkidle never settled: persistent-player/index.tsx
   rendered <audio src={...}> on mount; Chromium issued a range request on
   the podcast MP3 stream that never completed.

Fixes applied:
1. weather/index.tsx — cold-start fetch path now deferred via
   requestIdleCallback({timeout:2000}) when available, setTimeout(1500) fallback.
   Cache-hit path is unchanged (returns early as before).
2. persistent-player/index.tsx — added readyToLoad state (init: autoplay).
   Audio src is undefined until readyToLoad=true. readyToLoad set true on:
   play() callback, episode-swap event. Reset false on station-change when
   the player is not currently playing (skip while idle does not preload).

Projected networkidle post-fix: <3s on both /home/ mobile and /roadmap/ desktop.

Diagnostic source: /tmp/wave88c-after-trace.md

Gates:
  - biome ci --diagnostic-level=error src/ ✓ clean
  - npm run build ✓ exit 0 (built in 21.55s)
  - npm test -- --run ✓ 979/979 passing

Closes #182