### PR TITLE
chore(biome): wave 88a — suppress intentional CSS warnings (closes #260)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -36,6 +36,9 @@
 			},
 			"style": {
 				"noDescendingSpecificity": "warn"
+			},
+			"complexity": {
+				"noImportantStyles": "off"
 			}
 		}
 	},
@@ -51,5 +54,21 @@
 				"organizeImports": "on"
 			}
 		}
-	}
+	},
+	"overrides": [
+		{
+			"includes": [
+				"src/styles/cdn-glass-streaks.css",
+				"src/styles/cdn-atmospheric.css",
+				"src/styles/tokens.css"
+			],
+			"linter": {
+				"rules": {
+					"style": {
+						"noDescendingSpecificity": "off"
+					}
+				}
+			}
+		}
+	]
 }


### PR DESCRIPTION
Per-rule breakdown:
  lint/style/noDescendingSpecificity — 19 violations in cdn-atmospheric.css,
    69 violations in cdn-glass-streaks.css, 3 violations in tokens.css.
    All are intentional light/dark mode selector pairs:
      :root:not(.awsui-dark-mode) [...] { /* light */ }
      .awsui-dark-mode [...] { /* dark */ }
    The selectors are mutually exclusive and never co-apply to the same element.
    Biome flags them because .awsui-dark-mode has lower specificity than
    :root:not(.awsui-dark-mode), but reordering would break the intended
    theme cascade. Auto-fix (reordering) = guaranteed visual regression.
    Remediation: noDescendingSpecificity: off in overrides for the three
    affected files (cdn-atmospheric.css, cdn-glass-streaks.css, tokens.css).

  lint/complexity/noImportantStyles — 52 violations in tokens.css.
    All !important annotations are intentional Cloudscape token overrides.
    Cloudscape scoped awsui_* selectors win the cascade; !important is the
    only reliable override mechanism.
    Remediation: noImportantStyles: off globally (complexity rules).

Visual comparison: CSS source files are UNCHANGED — only biome.json lint config
  was modified. No selector reordering, no !important removal, no specificity
  mutation. Zero visual regression risk.

Gates:
  - npx biome ci --diagnostic-level=error src/ → clean (0 errors)
  - npm run build → ✓
  - npm test -- --run → 979 passed

Closes #260