### PR TITLE
fix(player): wave 91 — restore audio playback (#182 follow-up)

### DIFF
--- a/src/components/persistent-player/index.tsx
+++ b/src/components/persistent-player/index.tsx
@@ -810,9 +810,15 @@ function PersistentPlayerBar({
 		if (!audio) return;
 		setReadyToLoad(true);
 		setConnecting(true);
-		audio.play().catch(() => {
-			setConnecting(false);
-			setBlocked(true);
+		// Defer to next frame so React can flush the src attribute before play()
+		requestAnimationFrame(() => {
+			const a = audioRef.current;
+			if (!a) return;
+			a.load();
+			a.play().catch(() => {
+				setConnecting(false);
+				setBlocked(true);
+			});
 		});
 	}, []);
 


### PR DESCRIPTION
## P0 Regression Fix

**Reported by:** Bryan (P0 — audio playback completely broken on live)

**Root cause:** Wave 88c (#182) introduced a `readyToLoad` / `preload="none"` performance gate that delayed setting the audio `src`. The `play()` callback fired before React flushed the `src` attribute to the DOM, so `audio.load()` + `audio.play()` operated on an empty source.

**Approach:** Surgical fix (Option B) — wrapped `audio.load()` + `audio.play()` in `requestAnimationFrame()` inside the play callback, ensuring React's commit phase flushes the `src` attribute before playback is attempted.

**Preserved:** The `readyToLoad` networkidle/preload-none perf optimization from wave 88c is fully intact. Weather `requestIdleCallback` fix (`src/components/weather/index.tsx`) is untouched.

**Tests:** 986 passing / 110 files. No new failures.

**Diff:** `src/components/persistent-player/index.tsx` — +9/-3 lines.