### PR TITLE
feat(auth): wave 92 — 1-tap email-me-a-sign-in-link from wrong-password error

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -847,6 +847,10 @@
 			"signUpLink": "Apply to join",
 			"invalidCredentials": "Email or password is incorrect",
 			"genericError": "Something went wrong. Try again.",
+			"magicLinkHeader": "Forgot your password?",
+			"magicLinkDescription": "We'll email you a one-time code so you can reset your password and get in.",
+			"magicLinkCta": "Email me a sign-in link",
+			"magicLinkEmailRequired": "Type your email above first, then click this button.",
 			"mfaSetup": {
 				"alertHeader": "Get an authenticator app",
 				"hostageHeader": "Do not close this tab",
@@ -923,6 +927,8 @@
 			"newPasswordHint": "12+ characters — upper, lower, digit",
 			"resetButton": "Reset password",
 			"backToSignIn": "Back to sign in",
+			"codeSentHeader": "Check your email",
+			"codeSentBody": "We sent a 6-digit code to {email}. Enter it below along with your new password.",
 			"genericError": "Something went wrong. Try again."
 		},
 		"verificationSetup": {

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -847,6 +847,10 @@
 			"signUpLink": "Solicita unirte",
 			"invalidCredentials": "Correo o contraseña incorrectos",
 			"genericError": "Algo salió mal. Intenta de nuevo.",
+			"magicLinkHeader": "¿Olvidaste tu contraseña?",
+			"magicLinkDescription": "Te mandamos un código de un solo uso pa' que reinicies la contraseña y entres.",
+			"magicLinkCta": "Mándame liga pa' entrar",
+			"magicLinkEmailRequired": "Escribe tu correo arriba primero, luego pica el botón.",
 			"mfaSetup": {
 				"alertHeader": "Consigue una app autenticadora",
 				"hostageHeader": "No cierres esta pestaña",
@@ -923,6 +927,8 @@
 			"newPasswordHint": "12+ caracteres — mayúsculas, minúsculas, número",
 			"resetButton": "Restablecer",
 			"backToSignIn": "Volver al inicio de sesión",
+			"codeSentHeader": "Revisa tu correo",
+			"codeSentBody": "Te mandamos un código de 6 dígitos a {email}. Escíbelo aquí con tu nueva contraseña.",
 			"genericError": "Algo salió mal. Intenta de nuevo."
 		},
 		"verificationSetup": {

--- a/src/sites/auth/forgot-password/app.tsx
+++ b/src/sites/auth/forgot-password/app.tsx
@@ -26,8 +26,20 @@ function ForgotPasswordForm() {
 	const { t } = useTranslation();
 	document.title = `${t("auth.forgotPassword.title")} — ${t("auth.siteTitle")}`;
 
-	const [phase, setPhase] = useState<Phase>("request");
-	const [email, setEmail] = useState("");
+	// Read email + sent flags from URL — supports the wave 92 1-tap path:
+	// login page sends ForgotPassword, then redirects here with ?email=X&sent=1
+	// to skip the request phase entirely.
+	const initialParams =
+		typeof window !== "undefined"
+			? new URLSearchParams(window.location.search)
+			: new URLSearchParams();
+	const initialEmail = initialParams.get("email")?.trim() ?? "";
+	const arrivedFromOneTap = initialParams.get("sent") === "1";
+
+	const [phase, setPhase] = useState<Phase>(
+		initialEmail && arrivedFromOneTap ? "reset" : "request",
+	);
+	const [email, setEmail] = useState(initialEmail);
 	const [code, setCode] = useState("");
 	const [newPassword, setNewPassword] = useState("");
 	const [showPassword, setShowPassword] = useState(false);
@@ -163,7 +175,19 @@ function ForgotPasswordForm() {
 						errorText={formError || undefined}
 					>
 						<SpaceBetween size="m">
-							<Box>We sent a reset code to {email}</Box>
+							{arrivedFromOneTap ? (
+								<Alert
+									type="success"
+									header={t("auth.forgotPassword.codeSentHeader")}
+								>
+									{t("auth.forgotPassword.codeSentBody").replace(
+										"{email}",
+										email,
+									)}
+								</Alert>
+							) : (
+								<Box>We sent a reset code to {email}</Box>
+							)}
 							<FormField
 								label={t("auth.forgotPassword.codeLabel")}
 								errorText={codeError || undefined}

--- a/src/sites/auth/login/__tests__/app.test.tsx
+++ b/src/sites/auth/login/__tests__/app.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import * as cognito from "../../../../lib/cognito";
 
 vi.mock("../../../_layout", () => ({
 	default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -22,6 +23,7 @@ vi.mock("../../../../lib/cognito", () => ({
 	associateSoftwareToken: vi.fn(),
 	base64urlToBuffer: vi.fn(),
 	completePasskeyAuth: vi.fn(),
+	forgotPassword: vi.fn(),
 	initiatePasskeyAuth: vi.fn(),
 	respondToMfaChallenge: vi.fn(),
 	signInWithPassword: vi.fn(),
@@ -94,5 +96,114 @@ describe("login → redirectWithTokens: needsVerificationSetup stash", () => {
 			"/verification-setup/index.html?return_to=%2Frsvp%2F%3Fevent%3Dhappy-hour",
 		);
 		sessionStorage.clear();
+	});
+});
+
+describe("login → wave 92 1-tap forgot-password CTA", () => {
+	it("shows magic-link CTA when wrong-password error fires", async () => {
+		vi.mocked(cognito.signInWithPassword).mockRejectedValueOnce(
+			new cognito.AuthError("wrong password", "NotAuthorizedException"),
+		);
+		Object.defineProperty(window, "location", {
+			value: { ...window.location, search: "", assign: vi.fn() },
+			writable: true,
+		});
+		localStorage.clear();
+
+		render(<App />);
+
+		const emailInput = screen.getByPlaceholderText(
+			"auth.login.emailPlaceholder",
+		);
+		fireEvent.change(emailInput, { target: { value: "user@example.com" } });
+		const passwordInputs = screen.getAllByDisplayValue("");
+		const pw = passwordInputs.find(
+			(el) => (el as HTMLInputElement).type === "password",
+		) as HTMLInputElement;
+		fireEvent.change(pw, { target: { value: "wrong-pw" } });
+
+		const signInBtn = screen.getByText("auth.login.signInButton");
+		fireEvent.click(signInBtn);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("magic-link-cta")).toBeTruthy();
+		});
+		expect(screen.getByText("auth.login.magicLinkDescription")).toBeTruthy();
+	});
+
+	it("clicking magic-link CTA calls forgotPassword and redirects with email + sent params", async () => {
+		const forgotMock = vi.mocked(cognito.forgotPassword);
+		forgotMock.mockResolvedValueOnce(undefined);
+		vi.mocked(cognito.signInWithPassword).mockRejectedValueOnce(
+			new cognito.AuthError("wrong password", "NotAuthorizedException"),
+		);
+		const assign = vi.fn();
+		Object.defineProperty(window, "location", {
+			value: { ...window.location, search: "", assign },
+			writable: true,
+		});
+		localStorage.clear();
+
+		render(<App />);
+
+		const emailInput = screen.getByPlaceholderText(
+			"auth.login.emailPlaceholder",
+		);
+		fireEvent.change(emailInput, { target: { value: "user@example.com" } });
+		const passwordInputs = screen.getAllByDisplayValue("");
+		const pw = passwordInputs.find(
+			(el) => (el as HTMLInputElement).type === "password",
+		) as HTMLInputElement;
+		fireEvent.change(pw, { target: { value: "wrong-pw" } });
+		fireEvent.click(screen.getByText("auth.login.signInButton"));
+
+		const cta = await screen.findByTestId("magic-link-cta");
+		fireEvent.click(cta);
+
+		await waitFor(() => {
+			expect(forgotMock).toHaveBeenCalledWith("user@example.com");
+		});
+		await waitFor(() => {
+			expect(assign).toHaveBeenCalledWith(
+				"/forgot-password/index.html?email=user%40example.com&sent=1",
+			);
+		});
+	});
+
+	it("clicking magic-link CTA still redirects when ForgotPassword Cognito call errors", async () => {
+		const forgotMock = vi.mocked(cognito.forgotPassword);
+		forgotMock.mockRejectedValueOnce(
+			new cognito.AuthError("limit reached", "LimitExceededException"),
+		);
+		vi.mocked(cognito.signInWithPassword).mockRejectedValueOnce(
+			new cognito.AuthError("wrong password", "NotAuthorizedException"),
+		);
+		const assign = vi.fn();
+		Object.defineProperty(window, "location", {
+			value: { ...window.location, search: "", assign },
+			writable: true,
+		});
+		localStorage.clear();
+
+		render(<App />);
+		fireEvent.change(
+			screen.getByPlaceholderText("auth.login.emailPlaceholder"),
+			{ target: { value: "user@example.com" } },
+		);
+		const passwordInputs = screen.getAllByDisplayValue("");
+		const pw = passwordInputs.find(
+			(el) => (el as HTMLInputElement).type === "password",
+		) as HTMLInputElement;
+		fireEvent.change(pw, { target: { value: "wrong-pw" } });
+		fireEvent.click(screen.getByText("auth.login.signInButton"));
+
+		const cta = await screen.findByTestId("magic-link-cta");
+		fireEvent.click(cta);
+
+		await waitFor(() => {
+			expect(assign).toHaveBeenCalledWith(
+				"/forgot-password/index.html?email=user%40example.com&sent=1",
+			);
+		});
 	});
 });

--- a/src/sites/auth/login/app.tsx
+++ b/src/sites/auth/login/app.tsx
@@ -21,6 +21,7 @@ import {
 	associateSoftwareToken,
 	base64urlToBuffer,
 	completePasskeyAuth,
+	forgotPassword,
 	initiatePasskeyAuth,
 	respondToMfaChallenge,
 	signInWithPassword,
@@ -73,6 +74,8 @@ function LoginForm() {
 	const [totpSecret, setTotpSecret] = useState("");
 	const [challengeName, setChallengeName] = useState("");
 	const [cancelModalVisible, setCancelModalVisible] = useState(false);
+	const [magicLinkLoading, setMagicLinkLoading] = useState(false);
+	const [magicLinkError, setMagicLinkError] = useState("");
 
 	document.title = `${t("auth.login.title")} — ${t("auth.siteTitle")}`;
 
@@ -200,6 +203,7 @@ function LoginForm() {
 		if (!validate()) return;
 		setLoading(true);
 		setFormError("");
+		setMagicLinkError("");
 		try {
 			sessionStorage.setItem("cdn.mfaUsername", email);
 			const result = await signInWithPassword(email, password);
@@ -220,6 +224,34 @@ function LoginForm() {
 				setFormError(t("auth.login.genericError"));
 			}
 			setLoading(false);
+		}
+	}
+
+	async function handleSendMagicLink() {
+		setMagicLinkError("");
+		if (!email.trim()) {
+			setMagicLinkError(t("auth.login.magicLinkEmailRequired"));
+			return;
+		}
+		setMagicLinkLoading(true);
+		try {
+			// Always advance to the reset page even if Cognito errors —
+			// matches forgot-password's existing pattern of not revealing
+			// whether the email exists.
+			try {
+				await forgotPassword(email.trim());
+			} catch {
+				// swallow; advance regardless
+			}
+			const params = new URLSearchParams({
+				email: email.trim(),
+				sent: "1",
+			});
+			window.location.assign(
+				`/forgot-password/index.html?${params.toString()}`,
+			);
+		} finally {
+			setMagicLinkLoading(false);
 		}
 	}
 
@@ -494,6 +526,35 @@ function LoginForm() {
 					</SpaceBetween>
 				</Form>
 			</form>
+			{formError === t("auth.login.invalidCredentials") && (
+				<Box margin={{ top: "m" }}>
+					<Alert
+						type="info"
+						header={t("auth.login.magicLinkHeader")}
+						action={
+							<Button
+								variant="primary"
+								loading={magicLinkLoading}
+								onClick={() => {
+									void handleSendMagicLink();
+								}}
+								data-testid="magic-link-cta"
+							>
+								{t("auth.login.magicLinkCta")}
+							</Button>
+						}
+					>
+						<SpaceBetween size="xs">
+							<Box variant="p">{t("auth.login.magicLinkDescription")}</Box>
+							{magicLinkError && (
+								<Box variant="small" color="text-status-error">
+									{magicLinkError}
+								</Box>
+							)}
+						</SpaceBetween>
+					</Alert>
+				</Box>
+			)}
 			<Box margin={{ top: "m" }} textAlign="center">
 				<SpaceBetween size="xs">
 					<Link href="/forgot-password/index.html">


### PR DESCRIPTION
Closes user pain reported tonight: "when I sign in and it tells me i have the wrong password I need more forgiving options."

When the login form shows the wrong-password error, surface an info Alert with a primary 'Email me a sign-in link' CTA. Click triggers Cognito ForgotPassword on the email already in the form, silently (matches existing forgot-password 'do not reveal email existence' pattern), then redirects to `/forgot-password/?email=X&sent=1`.

The forgot-password page reads `?email=` and `?sent=1` to pre-fill email and skip the request phase entirely — user lands directly on the reset step with a 'Check your email at {email}' banner.

Functionally equivalent to a magic-link flow from the user's seat: 1 click on the error → 1 email click → set new password → in.

## Why not a real passwordless magic-link?

The real passwordless flow (Cognito Custom Auth Flow with DefineAuthChallenge / CreateAuthChallenge / VerifyAuthChallengeResponse Lambda triggers + SES + DDB challenge tokens + magic-link consumer page) is a 4-5 wave cross-repo initiative. This PR ships the immediate pain relief tonight while that remains queued.

## Tests

- 3 new vitest cases on `src/sites/auth/login/__tests__/app.test.tsx`:
  - magic-link CTA renders on wrong-password error
  - clicking CTA fires `forgotPassword` and redirects with email + sent params
  - clicking CTA still redirects when Cognito errors (e.g. LimitExceededException)
- All 989 vitest tests pass locally
- biome ci clean, build green

## i18n

6 new keys in en-US.json + es-MX.json (norteño tone for Spanish):
- auth.login.magicLinkHeader / Description / Cta / EmailRequired
- auth.forgotPassword.codeSentHeader / Body

Refs #189