### PR TITLE
fix(player): wave 93 — hide KEXP album art when image fails to load

### DIFF
--- a/src/components/persistent-player/__tests__/kexp-album-art.test.ts
+++ b/src/components/persistent-player/__tests__/kexp-album-art.test.ts
@@ -31,6 +31,18 @@ function shouldRenderKexpArt(stationKey: string, art: KexpArt | null): boolean {
 	return stationKey === "kexp" && Boolean(art?.albumArtUrl);
 }
 
+// wave 93 — album-art also gates on whether the <img> errored on the current
+// URL. When the cover-art-archive returns a 404 / the network fails / the
+// resource is blocked, we hide the thumbnail entirely so the broken-image
+// placeholder icon never shows.
+function shouldRenderKexpArtWithErrorGate(
+	stationKey: string,
+	art: KexpArt | null,
+	kexpArtError: boolean,
+): boolean {
+	return shouldRenderKexpArt(stationKey, art) && !kexpArtError;
+}
+
 describe("KEXP album-art KEXP-only render guard", () => {
 	const sampleArt: KexpArt = {
 		song: "I Can't Wait",
@@ -65,6 +77,35 @@ describe("KEXP album-art KEXP-only render guard", () => {
 	it("does NOT render when station is empty / podcast", () => {
 		expect(shouldRenderKexpArt("", sampleArt)).toBe(false);
 		expect(shouldRenderKexpArt("rust_in_production", sampleArt)).toBe(false);
+	});
+});
+
+describe("KEXP album-art image-error fallback (Wave 93)", () => {
+	const sampleArt: KexpArt = {
+		song: "Strings Of Steel",
+		artist: "Cibo Matto",
+		albumArtUrl: "https://archive.example/cover.jpg",
+	};
+
+	it("renders when image has not errored", () => {
+		expect(shouldRenderKexpArtWithErrorGate("kexp", sampleArt, false)).toBe(
+			true,
+		);
+	});
+
+	it("does NOT render when image has errored on current URL", () => {
+		expect(shouldRenderKexpArtWithErrorGate("kexp", sampleArt, true)).toBe(
+			false,
+		);
+	});
+
+	it("still does NOT render when station != kexp regardless of error flag", () => {
+		expect(shouldRenderKexpArtWithErrorGate("krux", sampleArt, false)).toBe(
+			false,
+		);
+		expect(shouldRenderKexpArtWithErrorGate("krux", sampleArt, true)).toBe(
+			false,
+		);
 	});
 });
 

--- a/src/components/persistent-player/index.tsx
+++ b/src/components/persistent-player/index.tsx
@@ -151,6 +151,18 @@ function PersistentPlayerBar({
 	// this state only holds the artwork URL + a refs-tracked "current track"
 	// signature used to skip stale-data re-renders.
 	const [kexpArt, setKexpArt] = useState<KexpNowPlaying | null>(null);
+	// wave 93 — hide the album art entirely when the image fails to load
+	// (cover-art-archive returns a 404 / network error / blocked URL). Without
+	// this gate, Chromium / Firefox render the broken-image placeholder icon
+	// instead of falling back to no-image. Reset on each new track URL.
+	const [kexpArtError, setKexpArtError] = useState(false);
+	// Reset the kexpArtError flag whenever the album-art URL changes so each
+	// new track gets a fresh load attempt. Without this, a single 404 would
+	// hide the thumbnail for the rest of the listening session.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: only the URL drives the reset
+	useEffect(() => {
+		setKexpArtError(false);
+	}, [kexpArt?.albumArtUrl]);
 	// stable signature of the last KEXP track we accepted — lets the polling
 	// effect short-circuit re-renders when KEXP returns the same row twice
 	// (DJ on a long airbreak after one song, slow rotations). Stored as ref so
@@ -1016,7 +1028,7 @@ function PersistentPlayerBar({
 			    The aria-live wrapper announces track changes for screen
 			    readers; alt text on the inner <img> carries the
 			    "song — artist" line for sighted users. */}
-			{state.stationKey === "kexp" && kexpArt?.albumArtUrl ? (
+			{state.stationKey === "kexp" && kexpArt?.albumArtUrl && !kexpArtError ? (
 				<span className="cdn-pp__kexp-art-wrap" aria-live="polite">
 					<img
 						className="cdn-pp__kexp-art"
@@ -1030,6 +1042,7 @@ function PersistentPlayerBar({
 						decoding="async"
 						width={40}
 						height={40}
+						onError={() => setKexpArtError(true)}
 					/>
 				</span>
 			) : null}


### PR DESCRIPTION
Closes user report: KEXP thumbnails are showing broken-image placeholder icons instead of falling back to no-image.

## Root cause

KEXP `/plays` returns 3rd-party cover-art-archive URLs. They 404 / network-fail / get blocked routinely. The `<img>` element rendered them with no `onError` handler, so Chromium / Firefox showed the broken-image placeholder icon. Worse than no thumbnail.

## Fix

- New `kexpArtError` state flag on the persistent-player component.
- `<img onError>` flips the flag on load failure.
- Render guard becomes `station=kexp && albumArtUrl && !kexpArtError` — entire wrap hides on error, no broken icon.
- A `useEffect` resets the flag whenever `kexpArt?.albumArtUrl` changes, so each new track gets a fresh attempt. A single 404 doesn't blacklist the surface for the session.

## Tests

3 new vitest cases on `kexp-album-art.test.ts`:
- renders when not errored
- hidden when errored on current URL
- station gate still wins regardless of error flag

992/992 tests passing. biome ci clean. build green.