### PR TITLE
fix(ci): add cancel_previous to all pipelines

### DIFF
--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -4,6 +4,8 @@
 # runs on pull_request, push to main, and manual trigger
 # does NOT deploy — see deploy.yml for deploy pipeline
 
+cancel_previous: true
+
 when:
   - event: [pull_request, push, manual]
     branch: main

--- a/.woodpecker/deploy.yml
+++ b/.woodpecker/deploy.yml
@@ -15,6 +15,8 @@
 # clouddelnorte.org rebrand. Renaming requires S3 bucket recreation + DNS/CF
 # origin update. Track in a separate issue.
 
+cancel_previous: true
+
 when:
   - event: [push, manual]
     branch: [main, dev, "feature/*", "fix/*", "feat/*"]

--- a/.woodpecker/device-farm.yml
+++ b/.woodpecker/device-farm.yml
@@ -1,5 +1,7 @@
 # woodpecker ci — device farm browser testing
 # auth: IAM Roles Anywhere (same workload cert as deploy steps)
+cancel_previous: true
+
 depends_on:
   - ci
 

--- a/.woodpecker/screenshot.yml
+++ b/.woodpecker/screenshot.yml
@@ -6,6 +6,8 @@
 # debug log uploaded unconditionally; check <sha>/capture.log to distinguish
 # script failures from auth failures
 
+cancel_previous: true
+
 when:
   - event: [push, manual]
     branch: [dev, main]


### PR DESCRIPTION
Adds `cancel_previous: true` to all 4 Woodpecker pipeline configs. When a new push arrives, any running pipeline for the same branch is cancelled automatically.

## Changes
- `.woodpecker/ci.yml`
- `.woodpecker/deploy.yml`
- `.woodpecker/device-farm.yml`
- `.woodpecker/screenshot.yml`

## Context
Resolves the 2026-05-25 CDN CI session freeze caused by 3 duplicate pipelines competing for SQLite write locks.