### PR TITLE
fix(ci): device-farm YAML separator + manual event

### DIFF
--- a/.woodpecker/device-farm.yml
+++ b/.woodpecker/device-farm.yml
@@ -1,3 +1,4 @@
+---
 # woodpecker ci — device farm browser testing
 # auth chain:
 #   1. Roles Anywhere → kiro (946179428633) device-farm-ci role → Device Farm API
@@ -9,7 +10,7 @@ depends_on:
   - ci
 
 when:
-  - event: [push, pull_request]
+  - event: [push, pull_request, manual]
     branch: main
 
 steps:


### PR DESCRIPTION
Woodpecker was not recognizing device-farm.yml because it lacked the `---` YAML document separator. Also adds `manual` to the event list.