### PR TITLE
fix(ci): device-farm runs independently

### DIFF
--- a/.woodpecker/device-farm.yml
+++ b/.woodpecker/device-farm.yml
@@ -6,9 +6,6 @@
 # workload cert: /workload.crt + /workload.key (mounted via agent volumes)
 cancel_previous: true
 
-depends_on:
-  - ci
-
 when:
   - event: [push, pull_request, manual]
     branch: main


### PR DESCRIPTION
Removes `depends_on: - ci` so device-farm pipeline triggers on its own. It was never running because `ci` only triggers on src/** changes, and device-farm depended on ci succeeding first.