### PR TITLE
fix(css): reveal 3D canvas through main layout

### DIFF
--- a/src/styles/cdn-atmospheric.css
+++ b/src/styles/cdn-atmospheric.css
@@ -147,13 +147,13 @@
 	/* Light mode */
 	.cdn-viz-active:not(.awsui-dark-mode) [class*="awsui_layout-main"]:not(#\9),
 	.cdn-viz-active:not(.awsui-dark-mode) main[class*="awsui_layout"]:not(#\9) {
-		background-color: rgba(237, 229, 212, 0.94);
+		background-color: rgba(237, 229, 212, 0.55);
 	}
 
 	/* Dark mode */
 	.cdn-viz-active.awsui-dark-mode [class*="awsui_layout-main"]:not(#\9),
 	.cdn-viz-active.awsui-dark-mode main[class*="awsui_layout"]:not(#\9) {
-		background-color: rgba(10, 12, 20, 0.94);
+		background-color: rgba(10, 12, 20, 0.55);
 	}
 }
 


### PR DESCRIPTION
## Problem
The WebGL canvas (3D animated background) at z-index:-2 was invisible because cdn-atmospheric.css set background-color: rgba(237, 229, 212, 0.94) on the main layout — 94% opaque cream completely blocked the canvas.

## Fix
Reduced main content area opacity from 0.94 to 0.55 in both light and dark modes. The canvas now shows through as an animated background while text remains readable over the semi-transparent overlay.

## Diagnosis
Used Playwright DOM analysis to trace the computed background-color on main back to cdn-atmospheric.css line 150.