### PR TITLE
fix(css): 3D canvas visible via variable override

### DIFF
--- a/src/styles/cdn-atmospheric.css
+++ b/src/styles/cdn-atmospheric.css
@@ -147,13 +147,13 @@
 	/* Light mode */
 	.cdn-viz-active:not(.awsui-dark-mode) [class*="awsui_layout-main"]:not(#\9),
 	.cdn-viz-active:not(.awsui-dark-mode) main[class*="awsui_layout"]:not(#\9) {
-		background-color: rgba(237, 229, 212, 0.55);
+		background-color: var(--cdn-glass-bg-content);
 	}
 
 	/* Dark mode */
 	.cdn-viz-active.awsui-dark-mode [class*="awsui_layout-main"]:not(#\9),
 	.cdn-viz-active.awsui-dark-mode main[class*="awsui_layout"]:not(#\9) {
-		background-color: rgba(10, 12, 20, 0.55);
+		background-color: var(--cdn-glass-bg-content);
 	}
 }
 

--- a/src/styles/cdn-glass-streaks.css
+++ b/src/styles/cdn-glass-streaks.css
@@ -126,6 +126,14 @@
 	--cdn-glass-streak: var(--cdn-streak-h-dark);
 }
 
+/* When 3D canvas is active, reduce content area opacity so canvas shows through */
+.cdn-viz-active:not(.awsui-dark-mode) {
+	--cdn-glass-bg-content: rgba(237, 229, 212, 0.55);
+}
+.cdn-viz-active.awsui-dark-mode {
+	--cdn-glass-bg-content: rgba(10, 12, 32, 0.55);
+}
+
 /* ==========================================================================
    .cdn-glass — primary plate primitive
 


### PR DESCRIPTION
Overrides --cdn-glass-bg-content from 0.92 to 0.55 when cdn-viz-active is present. The previous fix was beaten by higher-specificity rules using the variable. Now the variable itself changes when the canvas is active.