### PR TITLE
fix(player): un-hide recovered streams, fix reachability probe

### DIFF
--- a/src/components/footer/styles.css
+++ b/src/components/footer/styles.css
@@ -585,10 +585,33 @@ body.cdn-nav-open.cdn-tools-open .cdn-footer {
 /* Weather in footer — constrained so it doesn't dominate */
 .cdn-footer-weather {
 	max-width: 280px;
-	max-height: 56px;
 	overflow: hidden;
 	flex: 1 1 auto;
 	min-width: 140px;
+}
+
+/* Compact single-row layout when weather card is inside footer */
+.cdn-footer-weather .cdn-weather {
+	flex-direction: row;
+	align-items: center;
+	gap: 8px;
+	margin: 0;
+	padding: 4px 12px;
+	max-width: none;
+}
+.cdn-footer-weather .cdn-weather__now {
+	flex-direction: row;
+	align-items: center;
+	gap: 8px;
+}
+.cdn-footer-weather .cdn-weather__tomorrow,
+.cdn-footer-weather .cdn-weather__dots,
+.cdn-footer-weather .cdn-weather__metrics {
+	display: none;
+}
+.cdn-footer-weather .cdn-weather__temp {
+	flex-direction: row;
+	gap: 6px;
 }
 
 /* Version pushed to end */

--- a/src/layouts/shell/styles.css
+++ b/src/layouts/shell/styles.css
@@ -1707,7 +1707,7 @@ nav[class*="awsui_navigation_"]:not(
 	font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 	font-size: 11px;
 	opacity: 0.65;
-	color: rgba(245, 233, 208, 0.7);
+	color: rgba(139, 90, 43, 0.6);
 	pointer-events: none;
 	user-select: none;
 	background: rgba(255, 255, 255, 0.06);

--- a/src/lib/__tests__/streams-reachability.test.ts
+++ b/src/lib/__tests__/streams-reachability.test.ts
@@ -29,11 +29,16 @@ describe("checkReachability", () => {
 		expect(fetch).not.toHaveBeenCalled();
 	});
 
-	it("returns fail for corsBlocked streams without fetching", async () => {
-		const stream = { ...BASE, corsBlocked: true } as StreamDef;
+	it("does not fast-fail corsBlocked streams — probes the audio URL anyway", async () => {
+		// corsBlocked only means the RSS feed is CORS-blocked; the audio URL is
+		// still reachable. The reachability probe must test the audio URL
+		// regardless. The persistent-player handles corsBlocked at runtime by
+		// skipping the RSS fetch.
+		vi.mocked(fetch).mockResolvedValueOnce({ type: "opaque" } as Response);
+		const stream = { ...BASE, key: "reach-cors", corsBlocked: true } as StreamDef;
 		const result = await checkReachability(stream);
-		expect(result).toBe("fail");
-		expect(fetch).not.toHaveBeenCalled();
+		expect(result).toBe("ok");
+		expect(fetch).toHaveBeenCalledTimes(1);
 	});
 
 	it("returns ok when fetch resolves with type !== error", async () => {

--- a/src/lib/__tests__/streams.test.ts
+++ b/src/lib/__tests__/streams.test.ts
@@ -62,10 +62,10 @@ describe("STREAMS — Wave 22 fixes", () => {
 		expect(onda?.curated).toBe(true);
 	});
 
-	it("radio_udg_lagos is hidden (dead Zeno mount)", () => {
+	it("radio_udg_lagos is no longer hidden (Zeno mount re-verified 2026-05-26)", () => {
 		const lagos = STREAMS.find((s) => s.key === "radio_udg_lagos");
 		expect(lagos).toBeDefined();
-		expect(lagos?.hidden).toBe(true);
+		expect(lagos?.hidden).toBeUndefined();
 	});
 
 	it("radio_udg_lagos has fallbackUrls for auto-recovery", () => {
@@ -74,18 +74,18 @@ describe("STREAMS — Wave 22 fixes", () => {
 		expect(lagos?.fallbackUrls?.length ?? 0).toBeGreaterThan(0);
 	});
 
-	it("visible Mexican stations are ibero_909, concepto_radial, and radio_unam_961", () => {
+	it("visible Mexican stations include ibero_909, concepto_radial, radio_unam_961, radio_udg_lagos, and onda_aws", () => {
 		const visibleMx = STREAMS.filter(
 			(s) => s.location.country === "México" && !s.hidden,
 		);
-		// radio_udg_lagos is hidden; onda_aws is distributed/global with México country
-		// ibero_909, concepto_radial, radio_unam_961, onda_aws (all visible)
+		// All five MX-tagged streams are visible after the 2026-05-26 audit
+		// (radio_udg_lagos un-hidden, Zeno mount alive again)
 		const keys = visibleMx.map((s) => s.key).sort();
 		expect(keys).toContain("ibero_909");
 		expect(keys).toContain("concepto_radial");
 		expect(keys).toContain("radio_unam_961");
+		expect(keys).toContain("radio_udg_lagos");
 		expect(keys).toContain("onda_aws");
-		expect(keys).not.toContain("radio_udg_lagos");
 	});
 
 	it("ibero_909 and concepto_radial remain (not removed)", () => {

--- a/src/lib/streams-reachability.ts
+++ b/src/lib/streams-reachability.ts
@@ -19,8 +19,6 @@ export async function checkReachability(
 ): Promise<ReachResult> {
 	// Curated stations are trusted — no probe needed
 	if (stream.curated) return "skip-curated";
-	// CORS-blocked feeds will always fail a browser fetch — mark dead immediately
-	if (stream.corsBlocked) return "fail";
 
 	const cached = cache.get(stream.key);
 	if (cached && Date.now() - cached.ts < CACHE_TTL_MS) return cached.result;

--- a/src/lib/streams.ts
+++ b/src/lib/streams.ts
@@ -549,13 +549,12 @@ export const STREAMS: StreamDef[] = [
 	},
 	{
 		key: "radio_udg_lagos",
-		// hidden: true — Zeno mount 8hage4z92hhvv returns HTTP 401 (mount expired/revoked).
-		// Wave 22 probe: alternate Zeno mounts (UNAM 0xrt7ehm9k8uv, OPUS ydtzts4h4kuuv)
-		// also return 401. No working replacement found within 5 probe attempts.
-		// ibero_909 + concepto_radial remain as the active Mexican stations.
-		// fallbackUrls preserves the dead mount so if Zeno re-issues the key
-		// the station auto-recovers when hidden is removed.
-		hidden: true,
+		// Zeno mount 8hage4z92hhvv re-verified working 2026-05-26 — curl returned
+		// 302 → 200 audio/mpeg, mount is alive again after the prior 401 outage.
+		// Wave 22 had probed alternate Zeno mounts (UNAM 0xrt7ehm9k8uv, OPUS
+		// ydtzts4h4kuuv) which also returned 401 at the time; this canonical
+		// mount has since recovered. fallbackUrls preserves the same URL so the
+		// player retries it as a fallback if a future hiccup occurs.
 		// Zeno.fm CDN — base URL auto-redirects with JWT token per connection
 		url: "https://stream.zeno.fm/8hage4z92hhvv",
 		label: "radio udg lagos 104.7", // "lagos" disambiguates from main Guadalajara station
@@ -771,10 +770,10 @@ export const STREAMS: StreamDef[] = [
 		// aws-podcast.s3.amazonaws.com; S3 bucket policy may restrict direct access
 		// but browser fetch() with Origin header may succeed. Episode audio
 		// resolves from the RSS enclosure once the RSS fetch succeeds.
-		// Note: go-aws.com DNS was SERVFAIL as of 2026-05-03 — episode audio
-		// will fail until that resolves. hidden: true removes from shuffle until fixed.
+		// Note: go-aws.com DNS previously SERVFAIL (2026-05-03) — re-verified
+		// resolved 2026-05-26, curl returns 200 audio/mpeg via the redirect
+		// chain. Un-hidden as the audio path is alive again.
 		key: "aws_developers_podcast",
-		hidden: true,
 		type: "podcast",
 		url: "https://op3.dev/e/dts.podtrac.com/redirect.mp3/developers.podcast.go-aws.com/media/176.mp3",
 		rssFeedUrl:
@@ -846,9 +845,11 @@ export const STREAMS: StreamDef[] = [
 	},
 	{
 		key: "rust_in_production",
+		curated: true, // Bryan's known-good list: letscast.fm audio CDN reliable
 		// letscast.fm feed emits no Access-Control-Allow-Origin header — CORS-blocked
 		// in the browser. Build-time fetch-feeds.mjs populates podcast-episodes.json
 		// server-side (no CORS restriction). Runtime parseMeta is skipped.
+		// corsBlocked only affects RSS title refresh; the audio URL plays fine.
 		corsBlocked: true,
 		type: "podcast",
 		url: "https://letscast.fm/media/public/938e6879-4aff-480d-8772-d0e0967725c5.mp3",


### PR DESCRIPTION
## Summary

Full stream URL audit from AIBOX (curl HEAD/GET, 2026-05-26). All 21 streams alive.

### Changes

**Recovered streams (un-hidden):**
- `radio_udg_lagos` — Zeno mount working again (302→200 audio/mpeg via JWT redirect)
- `aws_developers_podcast` — go-aws.com DNS resolved (was SERVFAIL, now 200)

**Bug fix — reachability probe:**
- Removed `if (stream.corsBlocked) return "fail"` from `streams-reachability.ts`
- `corsBlocked` only means the RSS feed is CORS-blocked (title refresh), NOT the audio URL
- This was causing `rust_in_production` to always be skipped by the reachability probe
- Added `curated: true` to `rust_in_production` as additional protection

### What was tested
- curl HEAD/GET every stream URL from AIBOX — all 21 return 200 with audio content-type
- KEXP specifically: 200 audio/aac, Access-Control-Allow-Origin: *
- Unit tests pass (25/25 streams-related tests green)
- Device Farm PR #360 verification: Fiona frame, scroll, dark mode all pass

### Impact
Users hitting the player will no longer cycle through hidden/unreachable stations before landing on a podcast. The two recovered radio stations expand the live radio rotation.