### PR TITLE
fix(player): hide broken album art until loaded

### DIFF
--- a/src/components/persistent-player/index.tsx
+++ b/src/components/persistent-player/index.tsx
@@ -1043,6 +1043,7 @@ function PersistentPlayerBar({
 						decoding="async"
 						width={40}
 						height={40}
+						onLoad={(e) => { (e.target as HTMLElement).dataset.loaded = '1'; }}
 						onError={() => setKexpArtError(true)}
 					/>
 				</span>

--- a/src/components/persistent-player/styles.css
+++ b/src/components/persistent-player/styles.css
@@ -786,6 +786,12 @@ body.cdn-podcast-playing .cdn-pp__btn--resume {
 	   cream parchment palette; full saturation in dark mode where the navy
 	   bg can carry vivid cover art */
 	filter: saturate(0.95);
+	opacity: 0;
+	transition: opacity 0.15s;
+}
+
+.cdn-pp__kexp-art[data-loaded] {
+	opacity: 1;
 }
 
 .awsui-dark-mode .cdn-pp__kexp-art {


### PR DESCRIPTION
Album art img starts opacity:0, fades in only on successful load. No more broken image icon flash.