### PR TITLE
fix(tests): align rsvp mocks + port csp-function to vitest

### DIFF
--- a/src/lib/__tests__/rsvp.test.ts
+++ b/src/lib/__tests__/rsvp.test.ts
@@ -221,16 +221,17 @@ describe("spotsRemaining", () => {
 	it("returns the remaining count on a 200 response", async () => {
 		fetchMock.mockResolvedValueOnce(
 			jsonResponse(200, {
-				eventId: EVENT_ID,
-				capacity: 50,
-				taken: 0,
-				remaining: 50,
+				counts: { [EVENT_ID]: { remaining: 50, capacity: 50, taken: 0 } },
 			}),
 		);
 		await expect(spotsRemaining(EVENT_ID)).resolves.toBe(50);
 		// public endpoint — no Authorization header should have been sent.
-		const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-		expect(init).toBeUndefined();
+		const [url, init] = fetchMock.mock.calls[0] as [
+			string,
+			RequestInit | undefined,
+		];
+		expect(url).toBe("/data/rsvp-counts.json");
+		expect(init?.headers).toBeUndefined();
 	});
 
 	it("returns NaN on a 404 (unknown event)", async () => {
@@ -256,10 +257,7 @@ describe("spotsRemaining", () => {
 		sessionStorage.removeItem("cdn.idToken");
 		fetchMock.mockResolvedValueOnce(
 			jsonResponse(200, {
-				eventId: EVENT_ID,
-				capacity: 50,
-				taken: 5,
-				remaining: 45,
+				counts: { [EVENT_ID]: { remaining: 45, capacity: 50, taken: 5 } },
 			}),
 		);
 		await expect(spotsRemaining(EVENT_ID)).resolves.toBe(45);

--- a/src/pages/feed/components/__tests__/featured-event-scroll.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-event-scroll.test.tsx
@@ -72,10 +72,9 @@ describe("FeaturedEvent — wave 30a scroll-tearing regression", () => {
 		fetchMock = vi.fn().mockResolvedValue(
 			new Response(
 				JSON.stringify({
-					eventId: "happy-hour-2026-06-03",
-					capacity: 50,
-					taken: 0,
-					remaining: 50,
+					counts: {
+						"happy-hour-2026-06-03": { remaining: 50, capacity: 50, taken: 0 },
+					},
 				}),
 				{ status: 200, headers: { "Content-Type": "application/json" } },
 			),

--- a/src/pages/feed/components/__tests__/featured-event.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-event.test.tsx
@@ -25,10 +25,9 @@ beforeEach(() => {
 	fetchMock.mockResolvedValue(
 		new Response(
 			JSON.stringify({
-				eventId: "happy-hour-2026-06-03",
-				capacity: 50,
-				taken: 0,
-				remaining: 50,
+				counts: {
+					"happy-hour-2026-06-03": { remaining: 50, capacity: 50, taken: 0 },
+				},
 			}),
 			{ status: 200, headers: { "Content-Type": "application/json" } },
 		),

--- a/tests/unit/csp-function.test.mjs
+++ b/tests/unit/csp-function.test.mjs
@@ -5,8 +5,7 @@
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, it } from "node:test";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import vm from "node:vm";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -39,15 +38,15 @@ describe("csp-main.js CloudFront Function", () => {
 	it("sets content-security-policy header on response", () => {
 		const event = { response: { headers: {}, statusCode: 200 } };
 		const result = handler(event);
-		assert.ok(result.headers["content-security-policy"]);
-		assert.ok(result.headers["content-security-policy"].value.length > 0);
+		expect(result.headers["content-security-policy"]).toBeTruthy();
+		expect(result.headers["content-security-policy"].value.length).toBeGreaterThan(0);
 	});
 
 	it("includes default-src 'self'", () => {
 		const event = { response: { headers: {} } };
 		const result = handler(event);
 		const csp = result.headers["content-security-policy"].value;
-		assert.ok(csp.startsWith("default-src 'self'"));
+		expect(csp.startsWith("default-src 'self'")).toBe(true);
 	});
 
 	it("includes all CSP directives", () => {
@@ -57,7 +56,7 @@ describe("csp-main.js CloudFront Function", () => {
 		for (const d of ["script-src", "script-src-elem", "style-src", "connect-src",
 			"font-src", "img-src", "object-src", "frame-ancestors", "frame-src",
 			"media-src", "worker-src"]) {
-			assert.ok(csp.includes(d), `missing directive: ${d}`);
+			expect(csp).toContain(d);
 		}
 	});
 
@@ -67,21 +66,21 @@ describe("csp-main.js CloudFront Function", () => {
 		const csp = result.headers["content-security-policy"].value;
 		const allowlist = JSON.parse(allowlistJson);
 		for (const origin of allowlist["connect-src"]) {
-			assert.ok(csp.includes(origin), `connect-src missing: ${origin}`);
+			expect(csp).toContain(origin);
 		}
 	});
 
 	it("preserves existing response headers", () => {
 		const event = { response: { headers: { "x-custom": { value: "test" } } } };
 		const result = handler(event);
-		assert.equal(result.headers["x-custom"].value, "test");
-		assert.ok(result.headers["content-security-policy"]);
+		expect(result.headers["x-custom"].value).toBe("test");
+		expect(result.headers["content-security-policy"]).toBeTruthy();
 	});
 
 	it("includes worker-src with blob: and babylonjs", () => {
 		const event = { response: { headers: {} } };
 		const result = handler(event);
 		const csp = result.headers["content-security-policy"].value;
-		assert.ok(csp.includes("worker-src 'self' blob: https://cdn.babylonjs.com"));
+		expect(csp).toContain("worker-src 'self' blob: https://cdn.babylonjs.com");
 	});
 });


### PR DESCRIPTION
## Summary

Resolves all pre-existing vitest failures: 6 failed tests + 1 failed suite → 990 passing, 0 failed.

## Root causes

### 1. rsvp.ts mock shape drift (6 tests)

Commit 8f091657 (`perf(rsvp): replace per-pageview Lambda with static JSON snapshot`) refactored `spotsRemaining(eventId)` to read `/data/rsvp-counts.json` with shape:

```ts
{ counts: { [eventId]: { remaining, capacity, taken } } }
```

The tests were not updated and continued mocking the old flat shape `{ eventId, capacity, taken, remaining }`. The function returned NaN, and the FeaturedEvent component conditionally renders `.feed-featured-event__spots` only on a real number — so 4 featured-event tests also cascade-failed waiting for that element.

**Fix:** updated 3 mock fixtures (rsvp.test.ts, featured-event.test.tsx, featured-event-scroll.test.tsx) to use the snapshot shape. Also corrected an assertion in `returns the remaining count on a 200 response` that asserted `init` was undefined — the new code passes `{ cache: 'default' }` so we now check the URL and the absence of `headers` instead, preserving the original 'no Authorization header' intent.

### 2. csp-function.test.mjs uses node:test instead of vitest (1 failed suite)

Vitest 4 picks up the file via the `*.test.mjs` glob but cannot register suites authored with `node:test`. The other tests under `tests/unit/` are vitest. Ported `tests/unit/csp-function.test.mjs` to vitest (`describe/it/expect` from `vitest`, `assert.ok/equal` → `expect().toBeTruthy()/.toBe()/.toContain()`). Test coverage and behavior unchanged.

## Verification

```
npm test
Test Files  110 passed (110)
     Tests  990 passed (990)
```

## Out of scope

Pre-existing `act()` warnings in some component tests are unrelated and don't affect pass/fail. Filed separately if needed.