### PR TITLE
fix(ci): unbreak Woodpecker pipeline (YAML plain-scalar colon)

### DIFF
--- a/.woodpecker/deploy.yml
+++ b/.woodpecker/deploy.yml
@@ -103,8 +103,8 @@ steps:
       CF_DIST_AWSUG: E2QLAWFVIT1AR8
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
-      - ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)
-      - openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)
+      - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
         cat > /root/.aws/config <<EOF
@@ -135,8 +135,8 @@ steps:
       CF_DIST_AWSUG: E2QLAWFVIT1AR8
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
-      - ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)
-      - openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)
+      - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
         cat > /root/.aws/config <<EOF
@@ -167,8 +167,8 @@ steps:
       CF_DIST_AWSUG: E2QLAWFVIT1AR8
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
-      - ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)
-      - openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)
+      - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
         cat > /root/.aws/config <<EOF
@@ -204,8 +204,8 @@ steps:
       CF_DIST_AWSUG: E2QLAWFVIT1AR8
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
-      - ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)
-      - openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)
+      - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
         cat > /root/.aws/config <<EOF
@@ -239,8 +239,8 @@ steps:
       CF_DIST_AWSUG: E2QLAWFVIT1AR8
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
-      - ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)
-      - openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)
+      - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
         cat > /root/.aws/config <<EOF
@@ -274,8 +274,8 @@ steps:
       CF_DIST_AWSUG: E2QLAWFVIT1AR8
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
-      - ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)
-      - openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)
+      - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
         cat > /root/.aws/config <<EOF
@@ -320,8 +320,8 @@ steps:
       S3_BUCKET_DEV: dev.clouddelnorte.org
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
-      - ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)
-      - openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)
+      - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
         cat > /root/.aws/config <<EOF
@@ -362,8 +362,8 @@ steps:
       S3_BUCKET_MAIN: clouddelnorte.org
       CF_DIST_MAIN: ECC3LP1BL2CZS
     commands:
-      - ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)
-      - openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)
+      - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
         cat > /root/.aws/config <<EOF
@@ -408,8 +408,8 @@ steps:
       AWS_DEFAULT_REGION: us-west-2
       AWS_PROFILE: ci-deploy
     commands:
-      - ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)
-      - openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)
+      - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
         cat > /root/.aws/config <<EOF
@@ -449,8 +449,8 @@ steps:
       AWS_DEFAULT_REGION: us-west-2
       AWS_PROFILE: ci-deploy
     commands:
-      - ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)
-      - openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)
+      - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
         cat > /root/.aws/config <<EOF


### PR DESCRIPTION
## Summary

Resolves a YAML parse error that has silently broken **every** Woodpecker pipeline run for this repo since at least pipeline #1703. Bryan has been deploying manually via `scripts/deploy-manual.sh` for over a week as a workaround.

## Root cause

Every pipeline run errored at the **compile stage** (before any workflow could be scheduled) with:

```
cannot unmarshal 'map[ls -la /workload.crt /workload.key || (echo
"FATAL:/workload.crt or /workload.key not mounted. Check
WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host.";
exit 1)]' of type map[string]interface {} into a string value
```

YAML 1.2 plain-scalar rules forbid `: ` (colon-space) inside an unquoted scalar. The double quotes inside the line (around `"FATAL: ..."`) are **shell** quotes, not YAML quotes — YAML sees the whole list item as one plain scalar containing `FATAL: /workload.crt...`. Strict parsers (`go-yaml.v3`, used by Woodpecker) refuse and try to interpret the line as a key/value map. The whole pipeline never compiles → status=error, no workflow runs, no deploys happen.

This is a **silent failure** in the user-visible sense: the Woodpecker UI shows pipelines listed, but the production site never updates because no deploy step ever runs. The pre-flight `ls -la /workload.crt` lines themselves never executed — the compiler rejected the YAML before scheduling.

## Fix

Wrap each of the 20 affected `ls` / `openssl` preflight commands in YAML single quotes. Single-quoted scalars permit `: ` and any character except a literal `'`; none of the 20 lines contain one. Minimal churn (20 insertions / 20 deletions), no behavioral change to the underlying shell commands.

## Verification

```
python3 -c 'import yaml; yaml.safe_load(open(".woodpecker/deploy.yml"))'
# (no error, no output = parse OK)
```

The actual compiler will be re-exercised when this PR is merged and Woodpecker processes the resulting push to main. Expected outcome: the pipeline status flips from `error` to `success` (or at worst `failure` on a real step, no longer the compile error).

## Why this surfaced now

The same YAML pattern has been in this file for many commits, but Woodpecker (or its YAML library) bumped to a stricter parser at some point and this file has been broken since. The fix is forward-compatible with both old lenient and new strict parsers.