### PR TITLE
fix(auth): migrate CSP to CloudFront Function for login (#369)

### DIFF
--- a/infra/cloudfront-security-headers.auth.json
+++ b/infra/cloudfront-security-headers.auth.json
@@ -1,5 +1,6 @@
 {
 	"Name": "cdn-auth-security-headers",
+	"_comment": "CSP is delivered via CloudFront Function 'cdn-csp-viewer-response' (associated with distribution ECQ44FO9MBTCY as viewer-response). Same pattern as main (PR #366). The CSP key is intentionally absent from this file — see scripts/deploy-csp-function.sh.",
 	"SecurityHeadersConfig": {
 		"XSSProtection": {
 			"Override": true,
@@ -13,10 +14,6 @@
 		"ReferrerPolicy": {
 			"Override": true,
 			"ReferrerPolicy": "strict-origin-when-cross-origin"
-		},
-		"ContentSecurityPolicy": {
-			"Override": true,
-			"ContentSecurityPolicy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https://cognito-idp.us-west-2.amazonaws.com https://ipinfo.io https://api.zeno.fm https://api.kexp.org; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: https://www.gravatar.com; object-src 'none'; frame-ancestors 'none'; media-src 'none'"
 		},
 		"ContentTypeOptions": {
 			"Override": true


### PR DESCRIPTION
## Summary

Resolves the auth-CSP portion of #369. `auth.clouddelnorte.org/login` now serves CSP via the same `cdn-csp-viewer-response` CloudFront Function that PR #366 deployed for main, instead of the response-headers-policy that was blocking the persistent player + inline FOUC + BabylonJS atmosphere on the login page.

## Why a function instead of expanding the policy

A focused expansion of `infra/cloudfront-security-headers.auth.json` clocked in at 1131 chars and passed targeted CSP tests, but the full Playwright run flagged a violation on `https://media.rss.com/.../feed.xml` — one of ~60 connect-src origins the persistent player rotates through. Hitting them all blows past the 1783-char response-headers-policy ceiling, exactly the constraint that pushed main onto the function in #366. Same pattern, same allowlist, same source of truth.

## What changed

- `infra/cloudfront-security-headers.auth.json` — drops the `ContentSecurityPolicy` key with a `_comment` pointing at the function. HSTS, X-Frame-Options DENY, ReferrerPolicy, X-Content-Type-Options, X-XSS-Protection retained.

## What changed in AWS (already applied)

Account 211125425201 / profile `aerospaceug-admin`:

- Associated `cdn-csp-viewer-response` LIVE function with distribution `ECQ44FO9MBTCY` (DefaultCacheBehavior, viewer-response)
- Removed the `ContentSecurityPolicy` block from response-headers-policy `6e5c7c27-39d3-4a6e-8a89-58a70396c5ed` so CSP has a single source
- Invalidated `/*` on auth (`I3B79NYH0D0013NM7Q9A7WKDS5`)

## Verification

- `curl -sI https://auth.clouddelnorte.org/login/index.html` → full ~1500-char CSP including media.rss.com, anchor.fm, `*.podbean.com`, `*.megaphone.fm`, `*.streamguys1.com`, `*.streamtheworld.com`.
- `npx playwright test tests/e2e/csp-headers.spec.ts --grep awsug` → **3/3 pass** (the `awsug: no CSP violations on page load` test #369 listed as primary failure).
- `npx playwright test` (full suite) → **17 pass, 1 skip, 3 fail**. The 1 skip is Cognito PKCE (needs SSM creds, expected). The 3 failures are all `awsug-fiona.spec.ts` and were explicitly called out as out-of-scope in #369: they require auth context (storageState / public-path target / device-farm migration), not a CSP change.

## Known limitation

Requests to `/login/` (trailing slash, no `index.html`) hit CloudFront's CustomErrorResponse path (S3 403 → CF substitutes /login/index.html as 200), and CloudFront Functions don't run on that response shape — so that specific URL doesn't carry CSP. Real browser navigation in the redirect chain lands on `/login/index.html?return_to=...` (with explicit index.html), which does run the function. Worth a separate work item if direct `/login/` traffic ever needs CSP.

## Out of scope (separate issues to file)

- Parameterize `scripts/deploy-csp-function.sh` to accept main|auth|all so future allowlist updates flow to both distributions
- Woodpecker pipeline #1719 itself failed at `verify-csp` (IAM missing `cloudfront:GetResponseHeadersPolicy` on the heraldstack-ci-deploy role) and `deploy*` (`openssl: command not found` in the AL2023 deploy image). #370 fixed the YAML compile error but auto-deploy is still not restored.
- 3 `awsug-fiona` tests need an auth context or a non-gated target (per #369)