### PR TITLE
fix(ci): install openssl in deploy steps to unblock auto-deploy

### DIFF
--- a/.woodpecker/deploy.yml
+++ b/.woodpecker/deploy.yml
@@ -63,6 +63,13 @@ steps:
   # ─── CSP drift gate (runs before any deploy) ────────────────────────────────
   # Fails the pipeline if live CloudFront CSP drifts from infra/cloudfront-security-headers.json
   # or is missing required endpoints. Prevents FP-017-class failures.
+  #
+  # KNOWN GAP (failure: ignore protects the pipeline):
+  # The heraldstack-ci-deploy role lacks `cloudfront:GetResponseHeadersPolicy`,
+  # so verify-csp.sh cannot read the live awsug response-headers-policy and
+  # reports a cascading set of FAILs. The role is uncodified (see
+  # heraldstack/secure-access/cfn/secrets-store/ci-bryanchasko-role.yaml note),
+  # so the permission cannot be added from this repo. Tracked in #372.
 
   - name: verify-csp
     image: public.ecr.aws/aws-cli/aws-cli:latest
@@ -104,6 +111,8 @@ steps:
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
       - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      # openssl is not in public.ecr.aws/aws-cli/aws-cli (AL2023 base) — install on demand.
+      - yum install -y openssl 2>/dev/null || apk add --no-cache openssl 2>/dev/null || true
       - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
@@ -136,6 +145,8 @@ steps:
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
       - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      # openssl is not in public.ecr.aws/aws-cli/aws-cli (AL2023 base) — install on demand.
+      - yum install -y openssl 2>/dev/null || apk add --no-cache openssl 2>/dev/null || true
       - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
@@ -168,6 +179,8 @@ steps:
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
       - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      # openssl is not in public.ecr.aws/aws-cli/aws-cli (AL2023 base) — install on demand.
+      - yum install -y openssl 2>/dev/null || apk add --no-cache openssl 2>/dev/null || true
       - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
@@ -205,6 +218,8 @@ steps:
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
       - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      # openssl is not in public.ecr.aws/aws-cli/aws-cli (AL2023 base) — install on demand.
+      - yum install -y openssl 2>/dev/null || apk add --no-cache openssl 2>/dev/null || true
       - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
@@ -240,6 +255,8 @@ steps:
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
       - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      # openssl is not in public.ecr.aws/aws-cli/aws-cli (AL2023 base) — install on demand.
+      - yum install -y openssl 2>/dev/null || apk add --no-cache openssl 2>/dev/null || true
       - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
@@ -275,6 +292,8 @@ steps:
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
       - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      # openssl is not in public.ecr.aws/aws-cli/aws-cli (AL2023 base) — install on demand.
+      - yum install -y openssl 2>/dev/null || apk add --no-cache openssl 2>/dev/null || true
       - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
@@ -321,6 +340,8 @@ steps:
       CF_DIST_DEV: EEHVTUEQ97V0X
     commands:
       - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      # openssl is not in public.ecr.aws/aws-cli/aws-cli (AL2023 base) — install on demand.
+      - yum install -y openssl 2>/dev/null || apk add --no-cache openssl 2>/dev/null || true
       - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
@@ -363,6 +384,8 @@ steps:
       CF_DIST_MAIN: ECC3LP1BL2CZS
     commands:
       - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      # openssl is not in public.ecr.aws/aws-cli/aws-cli (AL2023 base) — install on demand.
+      - yum install -y openssl 2>/dev/null || apk add --no-cache openssl 2>/dev/null || true
       - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
@@ -409,6 +432,8 @@ steps:
       AWS_PROFILE: ci-deploy
     commands:
       - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      # openssl is not in public.ecr.aws/aws-cli/aws-cli (AL2023 base) — install on demand.
+      - yum install -y openssl 2>/dev/null || apk add --no-cache openssl 2>/dev/null || true
       - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |
@@ -450,6 +475,8 @@ steps:
       AWS_PROFILE: ci-deploy
     commands:
       - 'ls -la /workload.crt /workload.key || (echo "FATAL: /workload.crt or /workload.key not mounted. Check WOODPECKER_BACKEND_DOCKER_VOLUMES on the woodpecker-agent host."; exit 1)'
+      # openssl is not in public.ecr.aws/aws-cli/aws-cli (AL2023 base) — install on demand.
+      - yum install -y openssl 2>/dev/null || apk add --no-cache openssl 2>/dev/null || true
       - 'openssl x509 -in /workload.crt -noout -dates || (echo "FATAL: /workload.crt is not a valid X509 cert."; exit 1)'
       - mkdir -p /root/.aws
       - |


### PR DESCRIPTION
## Why

Pipeline #1719 confirmed Woodpecker auto-deploy is broken: every deploy step (`deploy`, `deploy-auth`, `deploy-awsug`, …) fails at the cert-sanity preflight with:

```
+ openssl x509 -in /workload.crt -noout -dates || (echo "FATAL...")
/bin/sh: line 20: openssl: command not found
FATAL: /workload.crt is not a valid X509 cert.
```

The base image (`public.ecr.aws/aws-cli/aws-cli:latest`, AL2023) does not bundle openssl. Bryan has been running `scripts/deploy-manual.sh` by hand to compensate.

## What changed

- Prepend `yum install -y openssl 2>/dev/null || apk add --no-cache openssl 2>/dev/null || true` before each of the 10 `openssl x509` cert-check call sites in `.woodpecker/deploy.yml`.
- Pattern matches the existing `verify-csp` step's jq install (defensive yum→apk→noop).
- Add a comment near `verify-csp` documenting the orthogonal IAM gap (`cloudfront:GetResponseHeadersPolicy` denied on uncodified `heraldstack-ci-deploy` role). That step already has `failure: ignore` so it does not block deploy. Tracked in #372.

## What this does NOT do

- Does **not** fix the `verify-csp` cascading FAILs (separate IAM concern, see #372).
- Does **not** touch `ci.yml`'s `verify-csp` step (same gap, same workaround).
- Does **not** address awsug-fiona e2e tests (separate PR).

## Verification

- YAML parses cleanly (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- The `yum install` pattern is identical to the one already proven working in `verify-csp` (pipeline #1719 log shows `yum install -y jq` succeeded on AL2023).
- Post-merge, watch pipeline status — success means deploy steps reached `aws s3 sync` for the first time since the regression.

## Refs

- Closes/unblocks the deploy half of the ticket; awsug-fiona is follow-up.
- Issue #372 (verify-csp IAM gap)