### PR TITLE
fix(i18n): typo Chihuaha -> Chihuahua in en-US.json

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -359,7 +359,7 @@
 		"cloudDelNorteMeetups": "Cloud Del Norte Meetups",
 		"blenderMeetups": "Blender & Graphic Design:NE3D",
 		"userGroupTitle": "volunteers wanted",
-		"communityDescription": "AWS UG Cloud Del Norte is a quest to network, experiment, and upskill together. We hold in-person, virtual, and hybrid meetups focusing on regional topics to rural New Mexico, West Texas, Northern Chihuaha, the Borderplex and beyond.",
+		"communityDescription": "AWS UG Cloud Del Norte is a quest to network, experiment, and upskill together. We hold in-person, virtual, and hybrid meetups focusing on regional topics to rural New Mexico, West Texas, Northern Chihuahua, the Borderplex and beyond.",
 		"organizersWantedHeader": "Organizers Wanted",
 		"spanishSpeakers": "Spanish-Speakers Sought",
 		"studentsStepUp": "Students Step On Up",


### PR DESCRIPTION
## Why

Spotted a misspelling in `src/locales/en-US.json` line 362 — `communityDescription` had "Northern Chihuaha" (missing a u). Every other instance in the repo (es-MX.json, README.md, LOCALIZATION.md, components/weather/cities.ts, .squad/agents/sofia/charter.md, etc.) spells it correctly as "Chihuahua".

## What changed

One character inserted. JSON still parses.