### PR TITLE
fix(ci): clean 3 ancillary pipeline failures (unzip + #376 + #377)

### DIFF
--- a/.woodpecker/deploy.yml
+++ b/.woodpecker/deploy.yml
@@ -489,21 +489,8 @@ steps:
         MSG=$$(printf '[CDN prod] %s\nlive: https://clouddelnorte.org/\ndiff: https://github.com/chasko-labs/cloud-del-norte-website/commit/%s' "$${CI_COMMIT_SHA:0:7}" "$$CI_COMMIT_SHA")
         aws sns publish --topic-arn arn:aws:sns:us-west-2:211125425201:cdn-deploy-alerts --message "$$MSG"
 
-  # ─── qdrant re-indexing (shared-knowledge) ──────────────────────────────────
-
-  - name: qdrant-reindex
-    image: python:3.12-alpine
-    failure: ignore
-    depends_on: [deploy, deploy-auth, deploy-awsug]
-    when:
-      - event: push
-        branch: main
-    environment:
-      QDRANT_URL: http://192.168.4.53:6333
-      OLLAMA_URL: http://192.168.4.53:11434
-      EMBED_MODEL: nomic-embed-text
-      COLLECTION: shared-knowledge
-    commands:
-      - apk add --no-cache git curl
-      - git clone --depth 1 https://github.com/BryanChasko/haunting-kiro-cli.git /tmp/haunting
-      - git diff HEAD~1 --name-only --diff-filter=ACMR | python3 /tmp/haunting/scripts/qdrant-index.py --repo "$CI_REPO_NAME" --commit "$CI_COMMIT_SHA"
+  # ─── qdrant re-indexing (REMOVED — see #376) ───────────────────────────────
+  # The qdrant-reindex step previously cloned BryanChasko/haunting-kiro-cli (PRIVATE)
+  # to run scripts/qdrant-index.py. Without a GITHUB_TOKEN secret wired in
+  # Woodpecker, the clone fails with "could not read Username for 'https://github.com'".
+  # Step removed to keep pipeline output clean. Restore once #376 wires credentials.

--- a/.woodpecker/device-farm.yml
+++ b/.woodpecker/device-farm.yml
@@ -27,6 +27,6 @@ steps:
       # The original step provisioned awscli, aws_signing_helper, pytest deps,
       # then ran `AWS_PROFILE=device-farm pytest tests/device-farm/`. See git
       # history for the full command sequence.
-      - echo "device-farm-test SKIPPED pending IAM fix in jitsi account (170473530355)"
-      - echo "Tracking issue:  https://github.com/chasko-labs/cloud-del-norte-website/issues/377"
-      - echo "Required change: add sts:SetSourceIdentity to device-farm-ssm-reader trust policy"
+      - 'echo "device-farm-test SKIPPED pending IAM fix in jitsi account (170473530355)"'
+      - 'echo "Tracking issue: https://github.com/chasko-labs/cloud-del-norte-website/issues/377"'
+      - 'echo "Required change: add sts:SetSourceIdentity to device-farm-ssm-reader trust policy"'

--- a/.woodpecker/device-farm.yml
+++ b/.woodpecker/device-farm.yml
@@ -1,9 +1,17 @@
 ---
 # woodpecker ci — device farm browser testing
-# auth chain:
+# auth chain (when restored):
 #   1. Roles Anywhere → kiro (946179428633) device-farm-ci role → Device Farm API
 #   2. device-farm-ci → sts:AssumeRole → jitsi (170473530355) device-farm-ssm-reader → SSM reads
 # workload cert: /workload.crt + /workload.key (mounted via agent volumes)
+#
+# CURRENTLY STUBBED (see #377):
+# Step 2 above fails because device-farm-ci lacks sts:SetSourceIdentity on
+# device-farm-ssm-reader. The trust policy lives in account 170473530355
+# (jitsi), not in this repo. Without SSM lookups, all 11 env vars are empty
+# and every test ERRORs at fixture setup. The real commands are preserved
+# in git history (commit before this stub) and should be restored once the
+# trust policy is fixed.
 cancel_previous: true
 
 when:
@@ -12,52 +20,13 @@ when:
 
 steps:
   - name: device-farm-test
-    image: python:3.12-slim
+    image: alpine:3.21
     failure: ignore
-    environment:
-      AWS_REGION: us-west-2
-      AWS_DEFAULT_REGION: us-west-2
-      TEST_URL: https://awsug.clouddelnorte.org
-      TEST_AUTH_URL: https://auth.clouddelnorte.org
-      TEST_API_URL: https://rwmypxz9z6.execute-api.us-west-2.amazonaws.com
-      TESTGRID_PROJECT_ARN: "arn:aws:devicefarm:us-west-2:946179428633:testgrid-project:0f1bfe22-0371-40c8-bcac-f96709363893"
     commands:
-      - apt-get update -qq && apt-get install -y -qq unzip curl jq > /dev/null
-      - curl -sSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.27.50.zip -o /tmp/awscli.zip
-      - unzip -q /tmp/awscli.zip -d /tmp && /tmp/aws/install && rm -rf /tmp/awscli.zip /tmp/aws
-      - curl -sL https://rolesanywhere.amazonaws.com/releases/1.7.0/X86_64/Linux/aws_signing_helper -o /usr/local/bin/aws_signing_helper && chmod +x /usr/local/bin/aws_signing_helper
-      - pip install -r tests/device-farm/requirements.txt -q
-
-      # Profile 1: kiro account (Device Farm API + cross-account assume)
-      - mkdir -p /root/.aws
-      - |
-        cat > /root/.aws/config <<EOF
-        [profile device-farm]
-        region = us-west-2
-        credential_process = /usr/local/bin/aws_signing_helper credential-process --trust-anchor-arn arn:aws:rolesanywhere:us-west-2:946179428633:trust-anchor/41cd58ba-3e23-42bf-a3da-728363c249bd --profile-arn arn:aws:rolesanywhere:us-west-2:946179428633:profile/2ff4503a-b937-4b30-baec-9cf51b4dc6ab --role-arn arn:aws:iam::946179428633:role/device-farm-ci --certificate /workload.crt --private-key /workload.key
-
-        [profile ssm-reader]
-        region = us-west-2
-        role_arn = arn:aws:iam::170473530355:role/device-farm-ssm-reader
-        source_profile = device-farm
-        EOF
-      - test -f /workload.crt && test -f /workload.key
-      - aws sts get-caller-identity --profile device-farm
-
-      # Fetch test credentials from SSM (jitsi account via cross-account assume)
-      - |
-        export DEVICE_FARM_GRID_URL=$(aws ssm get-parameter --name '/cloud-del-norte/test/grid-url' --profile ssm-reader --query 'Parameter.Value' --output text)
-        export TEST_USER_MEMBER_EMAIL=$(aws ssm get-parameter --name '/cloud-del-norte/test/member-only-user-email' --profile ssm-reader --query 'Parameter.Value' --output text)
-        export TEST_USER_MEMBER_PASSWORD=$(aws ssm get-parameter --name '/cloud-del-norte/test/member-only-user-password' --profile ssm-reader --with-decryption --query 'Parameter.Value' --output text)
-        export TEST_USER_ADMIN_EMAIL=$(aws ssm get-parameter --name '/cloud-del-norte/test/admin-user-email' --profile ssm-reader --query 'Parameter.Value' --output text)
-        export TEST_USER_ADMIN_PASSWORD=$(aws ssm get-parameter --name '/cloud-del-norte/test/admin-user-password' --profile ssm-reader --with-decryption --query 'Parameter.Value' --output text)
-        export TEST_USER_PENDING_EMAIL=$(aws ssm get-parameter --name '/cloud-del-norte/test/pending-user-email' --profile ssm-reader --query 'Parameter.Value' --output text)
-        export TEST_USER_PENDING_PASSWORD=$(aws ssm get-parameter --name '/cloud-del-norte/test/pending-user-password' --profile ssm-reader --with-decryption --query 'Parameter.Value' --output text)
-        export TEST_USER_BANNED_EMAIL=$(aws ssm get-parameter --name '/cloud-del-norte/test/banned-user-email' --profile ssm-reader --query 'Parameter.Value' --output text)
-        export TEST_USER_BANNED_PASSWORD=$(aws ssm get-parameter --name '/cloud-del-norte/test/banned-user-password' --profile ssm-reader --with-decryption --query 'Parameter.Value' --output text)
-        export COGNITO_USER_POOL_ID=$(aws ssm get-parameter --name '/cloud-del-norte/test/cognito-user-pool-id' --profile ssm-reader --query 'Parameter.Value' --output text)
-        export COGNITO_CLIENT_ID=$(aws ssm get-parameter --name '/cloud-del-norte/test/cognito-client-id' --profile ssm-reader --query 'Parameter.Value' --output text)
-
-      # Run Device Farm tests
-      - AWS_PROFILE=device-farm pytest tests/device-farm/ --junitxml=results.xml -v
-      - echo "Results saved to results.xml"
+      # TODO(#377): restore the real test runner once cross-account IAM is fixed.
+      # The original step provisioned awscli, aws_signing_helper, pytest deps,
+      # then ran `AWS_PROFILE=device-farm pytest tests/device-farm/`. See git
+      # history for the full command sequence.
+      - echo "device-farm-test SKIPPED pending IAM fix in jitsi account (170473530355)"
+      - echo "Tracking issue:  https://github.com/chasko-labs/cloud-del-norte-website/issues/377"
+      - echo "Required change: add sts:SetSourceIdentity to device-farm-ssm-reader trust policy"

--- a/.woodpecker/screenshot.yml
+++ b/.woodpecker/screenshot.yml
@@ -33,6 +33,8 @@ steps:
         region = us-west-2
         credential_process = /usr/local/bin/aws_signing_helper credential-process --trust-anchor-arn arn:aws:rolesanywhere:us-west-2:211125425201:trust-anchor/5e54afa4-d3d7-4e42-bae6-68f9d126c7d7 --profile-arn arn:aws:rolesanywhere:us-west-2:211125425201:profile/2177db77-a33c-4e5b-bcce-21b908659406 --role-arn arn:aws:iam::211125425201:role/heraldstack-ci-deploy --certificate /workload.crt --private-key /workload.key
         EOF
+      # mcr.microsoft.com/playwright:noble is debian-based but ships without unzip.
+      - which unzip || (apt-get update -qq && apt-get install -y -qq unzip > /dev/null)
       # install awscli if not present (playwright image is debian-based; pip is faster than apt)
       - which aws || (curl -sSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.27.50.zip -o /tmp/awscli.zip && unzip -q /tmp/awscli.zip -d /tmp && /tmp/aws/install && rm -rf /tmp/awscli.zip /tmp/aws)
       # install aws_signing_helper if not present — amd64 linux
@@ -74,6 +76,8 @@ steps:
         region = us-west-2
         credential_process = /usr/local/bin/aws_signing_helper credential-process --trust-anchor-arn arn:aws:rolesanywhere:us-west-2:211125425201:trust-anchor/5e54afa4-d3d7-4e42-bae6-68f9d126c7d7 --profile-arn arn:aws:rolesanywhere:us-west-2:211125425201:profile/2177db77-a33c-4e5b-bcce-21b908659406 --role-arn arn:aws:iam::211125425201:role/heraldstack-ci-deploy --certificate /workload.crt --private-key /workload.key
         EOF
+      # mcr.microsoft.com/playwright:noble is debian-based but ships without unzip.
+      - which unzip || (apt-get update -qq && apt-get install -y -qq unzip > /dev/null)
       # install awscli if not present
       - which aws || (curl -sSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.27.50.zip -o /tmp/awscli.zip && unzip -q /tmp/awscli.zip -d /tmp && /tmp/aws/install && rm -rf /tmp/awscli.zip /tmp/aws)
       # install aws_signing_helper if not present — amd64 linux


### PR DESCRIPTION
## Why

Pipeline #1727 confirmed auto-deploy is restored (#373), but three `failure: ignore` steps still exit non-zero, polluting pipeline logs:

- `capture-prod` (screenshot.yml) — exit 127
- `qdrant-reindex` (deploy.yml) — exit 128
- `device-farm-test` (device-farm.yml) — exit 1

Cleaning each per the user's success criterion: *all steps either success or skipped, no more failure exits.*

## Diagnosis + fix

### 1. capture-prod / capture-dev — `unzip: not found`

`mcr.microsoft.com/playwright:v1.55.1-noble` is debian-based but ships without unzip, so the awscli zip extract failed:

```
+ which aws || (curl -sSL ...awscli.zip ... && unzip -q /tmp/awscli.zip ...)
/bin/sh: 33: unzip: not found
```

**Fix:** prepend `which unzip || (apt-get update -qq && apt-get install -y -qq unzip > /dev/null)`. Idempotent guard via `which`.

### 2. qdrant-reindex — private repo clone with no credentials

```
+ git clone --depth 1 https://github.com/BryanChasko/haunting-kiro-cli.git /tmp/haunting
fatal: could not read Username for 'https://github.com': No such device or address
```

`BryanChasko/haunting-kiro-cli` is private. Woodpecker repo has no `GITHUB_TOKEN` secret; only `dev_cf_distribution_id` exists. No org-level secrets either.

**Fix:** removed the step. Tracking issue #376 covers wiring a fine-grained PAT and restoring credentialed clone.

### 3. device-farm-test — IAM trust policy gap

```
An error occurred (AccessDenied) when calling the AssumeRole operation:
User: arn:aws:sts::946179428633:assumed-role/device-farm-ci/...
is not authorized to perform: sts:SetSourceIdentity
on resource: arn:aws:iam::170473530355:role/device-farm-ssm-reader
```

`source_profile = device-farm` propagates RolesAnywhere source identity, requiring `sts:SetSourceIdentity` on the target trust policy. That policy lives in account `170473530355` (jitsi) — outside this repo. All 11 SSM lookups return empty, so all 91 pytest tests ERROR at fixture setup with `Invalid length for parameter ClientId` and `No host specified`.

**Fix:** stubbed step body with early-exit echoes documenting the gap and pointing at #377. Real commands preserved in git history for restoration after the trust policy is fixed.

## Verification

YAML lint:

```
OK: .woodpecker/screenshot.yml
OK: .woodpecker/deploy.yml
OK: .woodpecker/device-farm.yml
```

Post-merge expectation: pipeline #1729+ on main should show no `failure` exits — the deploy workflow's only remaining noisy step is `verify-csp` (#372 IAM gap, also `failure: ignore` — separate scope).

## Refs

- Closes the noise dimensions of the deploy pipeline
- Tracks: #376 (qdrant), #377 (device-farm IAM)
- Builds on: #373 (auto-deploy restoration)