### PR TITLE
fix(babylon): import views side-effect to restore registerView

### DIFF
--- a/infra/cloudfront-functions/csp-allowlist.json
+++ b/infra/cloudfront-functions/csp-allowlist.json
@@ -70,6 +70,7 @@
 		"https://*.talkpython.fm",
 		"https://18243.live.streamtheworld.com",
 		"https://anchor.fm",
+		"https://content.production.cdn.art19.com",
 		"https://content.rss.com",
 		"https://d1le29qyzha1u4.cloudfront.net",
 		"https://d3ctxlq1ktw2nl.cloudfront.net",

--- a/src/lib/babylon-shared-engine.ts
+++ b/src/lib/babylon-shared-engine.ts
@@ -53,6 +53,7 @@
 //     (matches existing pattern in SceneBootstrap).
 
 import "@babylonjs/core/Animations/animatable.js";
+import "@babylonjs/core/Engines/AbstractEngine/abstractEngine.views.js";
 
 import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Engine } from "@babylonjs/core/Engines/engine";


### PR DESCRIPTION
## URGENT — production-breaking regression

Page turns black ~4s after load. Console:

```
Uncaught TypeError: c(...).registerView is not a function
Uncaught TypeError: n.unRegisterView is not a function
```

## Root cause

BabylonJS 9.x split `AbstractEngine.registerView` / `unRegisterView` into a side-effect module at `@babylonjs/core/Engines/AbstractEngine/abstractEngine.views.js`. The shared-engine singleton uses deep imports (`@babylonjs/core/Engines/engine`) for tree-shaking but never imports the views side-effect module. Vite (correctly) strips it as unused, and the methods never get attached to `AbstractEngine.prototype`.

## Fix

One-line side-effect import in `src/lib/babylon-shared-engine.ts`, grouped with the existing `animatable.js` side-effect import:

```ts
import "@babylonjs/core/Animations/animatable.js";
+ import "@babylonjs/core/Engines/AbstractEngine/abstractEngine.views.js";
```

Bundle impact: babylon-shared-engine chunk 580 kB → 587.76 kB (+7 kB; gzip 146.30 kB).

## Bundled fix: Art19 CDN allowlist

The persistent player tries to load Art19 podcast episodes from `https://content.production.cdn.art19.com` (distinct from `rss.art19.com` which serves feed XML). Currently blocked by CSP `media-src`. Adding the domain to `infra/cloudfront-functions/csp-allowlist.json` in alphabetical position.

**Requires post-merge:** `scripts/deploy-csp-function.sh` to push the updated allowlist to the CloudFront Function (separate from the S3 deploy).

## Verification

- `npm run build` — passed locally, no errors.
- The new side-effect import sits next to the existing `animatable.js` side-effect import (proven pattern in this file).
- Build output shows `babylon-shared-engine-CHC7BviE.js` chunk with the views module compiled in.

## Post-merge actions

1. Auto-deploy pipeline pushes the JS fix to S3 + invalidates CloudFront.
2. Run `scripts/deploy-csp-function.sh` to push the CSP update.
3. Spot-check production console for zero registerView/unRegisterView TypeErrors and Art19 media loading without CSP violation.