### PR TITLE
fix(csp): add Art19 CDN to build-csp-allowlist source of truth

### DIFF
--- a/infra/cloudfront-functions/csp-allowlist.json
+++ b/infra/cloudfront-functions/csp-allowlist.json
@@ -17,6 +17,7 @@
 		"https://cargocollective.com",
 		"https://cognito-idp.us-west-2.amazonaws.com",
 		"https://conceptoradial.com",
+		"https://content.production.cdn.art19.com",
 		"https://content.rss.com",
 		"https://d1le29qyzha1u4.cloudfront.net",
 		"https://d3ctxlq1ktw2nl.cloudfront.net",

--- a/scripts/build-csp-allowlist.mjs
+++ b/scripts/build-csp-allowlist.mjs
@@ -43,6 +43,7 @@ for (const urlStr of allUrls) {
 
 // Known redirect targets and CDN hosts that audio URLs resolve through
 const knownRedirects = [
+	"https://content.production.cdn.art19.com",
 	"https://18243.live.streamtheworld.com",
 	"https://kexp-podcast.streamguys1.com",
 	"https://dcs-cached.megaphone.fm",


### PR DESCRIPTION
## Why

PR #379 added `https://content.production.cdn.art19.com` directly to the **generated** `infra/cloudfront-functions/csp-allowlist.json`. But `scripts/deploy-csp-function.sh` Step 1 invokes `scripts/build-csp-allowlist.mjs`, which regenerates that JSON from `src/lib/streams.ts` plus a few hardcoded lists. The regeneration **wiped** the manual entry on the very first deploy.

I verified this by running the deploy script and inspecting the output:

```
── Step 1: Build allowlist from streams.ts ──
  connect-src: 60 origins
  media-src: 35 origins   ← Art19 CDN missing
```

The CloudFront Function published in that run did NOT include Art19. The persistent player would still hit a CSP violation.

## Fix

Add `https://content.production.cdn.art19.com` to the `knownRedirects` array in `scripts/build-csp-allowlist.mjs`. Entries in that list get added to both `connect-src` and `media-src`, matching the existing `rss.art19.com` pattern (XML feed via connect-src + audio enclosures via media-src).

After re-running the deploy script:

```
── Step 1: Build allowlist from streams.ts ──
  connect-src: 61 origins  ← +1
  media-src: 36 origins    ← +1
── Step 4: Publish function (DEVELOPMENT → LIVE) ──
  Published. Stage: LIVE
── Step 7: Invalidate cache ──
  Invalidation: I607TLRPS3QD3Z8N2JBBKP42CQ
```

## State

- LIVE CloudFront Function `cdn-csp-viewer-response` (distribution `ECC3LP1BL2CZS`) now includes Art19 CDN in both directives.
- Cache invalidated.
- Committed `csp-allowlist.json` now matches the LIVE state — connect-src gains the new entry; media-src was already added by PR #379.
- Future regenerations stay consistent.

## Diff

- `scripts/build-csp-allowlist.mjs` — +1 line in `knownRedirects`
- `infra/cloudfront-functions/csp-allowlist.json` — +1 line in connect-src

## Refs

- Builds on PR #379 (BabylonJS views import + initial CSP edit)