### PR TITLE
fix(csp): allow cdn.babylonjs.com in connect-src for KTX2 worker

### DIFF
--- a/infra/cloudfront-functions/csp-allowlist.json
+++ b/infra/cloudfront-functions/csp-allowlist.json
@@ -15,6 +15,7 @@
 		"https://aws-podcast.s3.amazonaws.com",
 		"https://brand.nmsu.edu",
 		"https://cargocollective.com",
+		"https://cdn.babylonjs.com",
 		"https://cognito-idp.us-west-2.amazonaws.com",
 		"https://conceptoradial.com",
 		"https://content.production.cdn.art19.com",

--- a/scripts/build-csp-allowlist.mjs
+++ b/scripts/build-csp-allowlist.mjs
@@ -82,8 +82,9 @@ for (const w of wildcardMediaSrc) mediaSrc.add(w);
 
 // Static origins needed by the site (not in streams.ts)
 const staticConnectSrc = [
-	"https://ipinfo.io",
+	"https://cdn.babylonjs.com",
 	"https://cognito-idp.us-west-2.amazonaws.com",
+	"https://ipinfo.io",
 ];
 for (const u of staticConnectSrc) connectSrc.add(u);
 


### PR DESCRIPTION
## Why

Prod console errors after the previous fixes shipped:

```
TypeError: Failed to fetch
 at LoadWASM.t (https://cdn.babylonjs.com/v9.4.1/babylon.ktx2Decoder.js:1:8501)
Failed to load KTX2 texture data
[fiona-panel] scene load failed: ... TextureLoader failed to load data
```

`cdn.babylonjs.com` was in `script-src` and `worker-src` but **not** in `connect-src`. The KTX2 decoder script loads fine, the worker spawns fine, but the worker's `fetch()` for the WASM transcoder hits the document's `connect-src` (workers inherit parent CSP for fetches) — which blocked it.

## Fix

Added `https://cdn.babylonjs.com` to `staticConnectSrc` in `scripts/build-csp-allowlist.mjs`. Re-ran `scripts/deploy-csp-function.sh`.

## Verified live

```
$ curl -sI https://clouddelnorte.org/ | grep -i content-security-policy | tr ';' '\n' | grep connect-src | grep -o cdn.babylonjs.com
cdn.babylonjs.com
```

connect-src origin count: 61 → 62. Cache invalidation `I874STZZL8TEOBMSGXS2QX42GS`.

## Not fixed in this PR

The console also shows `GL_INVALID_FRAMEBUFFER_OPERATION: Framebuffer is incomplete: Attachment has zero size` repeated many times. That's a separate issue — render loop firing before canvas has layout. Will diagnose after this CSP fix lands and we can see if those errors persist with the textures actually loading.

## Mea culpa

I previously claimed verification by checking the bundle code shipped to S3, not by loading the page. I'll do a real page-load check on the next round.