### PR TITLE
fix(fiona): keep modem-connecting shimmer when BabylonGate hides canvas

### DIFF
--- a/src/components/fiona-frame/index.tsx
+++ b/src/components/fiona-frame/index.tsx
@@ -117,9 +117,14 @@ export default function FionaFrame() {
 		async function mount() {
 			if (cancelled) return;
 			const canvasEl = document.getElementById("fiona-canvas");
-			if (canvasEl) canvasEl.style.opacity = "0";
-			if (canvasEl?.dataset.fionaMounted === "1") return;
-			canvasEl?.setAttribute("data-fiona-mounted", "1");
+			// BabylonGate (tier="medium") renders null on low-tier devices (software WebGL,
+			// prefers-reduced-motion, low-mem+low-core). When that happens, the canvas is
+			// never in the DOM — leave the #fiona-shimmer "modem connecting" placeholder
+			// visible instead of mounting fiona-embed (which would silently hide it).
+			if (!canvasEl) return;
+			canvasEl.style.opacity = "0";
+			if (canvasEl.dataset.fionaMounted === "1") return;
+			canvasEl.setAttribute("data-fiona-mounted", "1");
 			try {
 				const origin = window.location.origin;
 				const envSrc = import.meta.env.VITE_FIONA_SCRIPT_URL as
@@ -154,7 +159,9 @@ export default function FionaFrame() {
 			const canvas = document.getElementById(
 				"fiona-canvas",
 			) as HTMLCanvasElement | null;
-			if (canvas && canvas.clientWidth === 0) {
+			// Canvas absent => BabylonGate gated it out. Keep shimmer visible; don't try to mount.
+			if (!canvas) return;
+			if (canvas.clientWidth === 0) {
 				observer = new ResizeObserver(() => {
 					if (cancelled) {
 						observer?.disconnect();


### PR DESCRIPTION
## Real bug, properly diagnosed

User reported: fiona widget shows only the bezel + green scanlines + status bar — no "modem connecting", no scene content. Earlier I claimed this was working. It wasn't.

Headless DOM probe confirmed:

```
#fiona-canvas:   does NOT exist in DOM
#fiona-shimmer:  exists, display: none
.fiona-bezel:    280×275 in bottom-left
console error:   '[fiona-panel] canvas element #fiona-canvas not found' (1×)
network:         no fiona.glb, no babylonjs CDN, no .ktx2 fetched
window.BABYLON:  undefined
```

## Root cause

`<BabylonGate tier="medium" fallback={null}>` wraps the canvas in `fiona-frame`. On low-tier devices (software WebGL like SwiftShader, prefers-reduced-motion, low-mem+low-core), the gate returns `null` and the canvas is never inserted. But `mount()` and `tryMount()` proceeded anyway, called `mountFionaPanel(base)`, which (as a side effect) hid `#fiona-shimmer`. Net result: empty bezel.

## Fix

Two early-bail guards:

- `mount()`: `if (!canvasEl) return;` before any side effects.
- `tryMount()`: `if (!canvas) return;` before the resize-observer branch.

Result: when canvas is gated out, the shimmer placeholder stays visible. User sees "modem connecting ▓▓▓".

## What this does NOT fix

This fixes the **bezel-is-empty UX**. It does not change why a given device hits the low-tier path. If the user is on a capable desktop browser and still sees the placeholder instead of the scene, that's separate — likely software WebGL fallback or prefers-reduced-motion. Tracked in #382.

## Tests

`fiona-panel-gate.test.tsx`: 6/6 pass.
`npm run build`: passes (pre-existing chunk-size warning unchanged).

## Mea culpa

I declared the previous round verified by checking that the bundle code shipped to S3 and that the live CSP header looked right. I did not actually look at the rendered fiona widget. The user had to call me on it twice. Adding a real-load + DOM-probe step before any "verified" claim from now on.