### PR TITLE
fix(babylon): defer zero-size view + lose WebGL context on disposal

### DIFF
--- a/src/lib/babylon-shared-engine.ts
+++ b/src/lib/babylon-shared-engine.ts
@@ -71,6 +71,10 @@ interface RegisteredView {
 let _engine: Engine | null = null;
 let _workingCanvas: HTMLCanvasElement | null = null;
 const _views = new Map<HTMLCanvasElement, RegisteredView>();
+// Pending registrations keyed by canvas while we wait for it to gain layout.
+// Registering a zero-size canvas causes the engine to render into a 0×0
+// framebuffer, producing a flood of GL_INVALID_FRAMEBUFFER_OPERATION errors.
+const _deferredObservers = new Map<HTMLCanvasElement, ResizeObserver>();
 let _docVisHandlerInstalled = false;
 
 function _masterTick(): void {
@@ -145,6 +149,28 @@ export function registerSceneView(
 	customRender: () => void,
 ): void {
 	const engine = _ensureEngine();
+
+	// Defer registration when the canvas has zero dimensions. Common when a
+	// parent drawer/panel hasn't opened yet (mobile nav, gated card, etc.).
+	// Registering a zero-size view spams GL_INVALID_FRAMEBUFFER_OPERATION on
+	// every render-loop tick. Wait for the canvas to gain layout, then
+	// register normally. Idempotent: if already deferred or already
+	// registered, the second call is a no-op.
+	if (_views.has(canvas) || _deferredObservers.has(canvas)) return;
+	if (canvas.clientWidth === 0 || canvas.clientHeight === 0) {
+		const obs = new ResizeObserver(() => {
+			if (canvas.clientWidth > 0 && canvas.clientHeight > 0) {
+				obs.disconnect();
+				_deferredObservers.delete(canvas);
+				engine.registerView(canvas, camera);
+				_views.set(canvas, { customRender, paused: false });
+			}
+		});
+		obs.observe(canvas);
+		_deferredObservers.set(canvas, obs);
+		return;
+	}
+
 	engine.registerView(canvas, camera);
 	_views.set(canvas, { customRender, paused: false });
 }
@@ -156,12 +182,29 @@ export function registerSceneView(
  * working canvas are fully disposed.
  */
 export function unregisterSceneView(canvas: HTMLCanvasElement): void {
+	// Cancel any pending deferred registration for this canvas. Safe to call
+	// even when the canvas was never deferred — .get/.delete are no-ops.
+	const pendingObs = _deferredObservers.get(canvas);
+	if (pendingObs) {
+		pendingObs.disconnect();
+		_deferredObservers.delete(canvas);
+	}
+
 	if (!_engine) return;
 	_engine.unRegisterView(canvas);
 	_views.delete(canvas);
 
 	if (_views.size === 0) {
 		_engine.stopRenderLoop();
+		// Explicitly release the WebGL context so Chrome reclaims it
+		// immediately rather than waiting for GC. Prevents context-limit
+		// pressure across mount/unmount cycles when fiona-embed (separate
+		// engine) also wants a context.
+		if (_workingCanvas) {
+			const gl = (_workingCanvas.getContext("webgl2") ||
+				_workingCanvas.getContext("webgl")) as WebGLRenderingContext | null;
+			gl?.getExtension("WEBGL_lose_context")?.loseContext?.();
+		}
 		_engine.dispose();
 		_engine = null;
 		if (_workingCanvas) {

--- a/src/lib/device-capabilities.ts
+++ b/src/lib/device-capabilities.ts
@@ -15,6 +15,10 @@ export function isSoftwareWebGL(): boolean {
 		const renderer = ext
 			? String(gl.getParameter(ext.UNMASKED_RENDERER_WEBGL))
 			: "";
+		// Explicitly release the probe's WebGL context so Chrome reclaims it
+		// immediately rather than waiting for GC. The probe is called early
+		// in page load and can otherwise occupy a context slot for seconds.
+		gl.getExtension("WEBGL_lose_context")?.loseContext?.();
 		return /SwiftShader|llvmpipe|Software|Microsoft Basic Render/i.test(
 			renderer,
 		);

--- a/src/lib/render-capability.ts
+++ b/src/lib/render-capability.ts
@@ -31,6 +31,10 @@ export function detectRenderCapability(): RenderCapability {
 				!/SwiftShader|llvmpipe|software|Microsoft Basic Render Driver/i.test(
 					rendererString,
 				);
+			// Explicitly release the probe's WebGL context so Chrome reclaims it
+			// immediately rather than waiting for GC. The probe is called early
+			// in page load and can otherwise occupy a context slot for seconds.
+			gl.getExtension("WEBGL_lose_context")?.loseContext?.();
 		} else {
 			rendererString = "no-webgl";
 		}


### PR DESCRIPTION
## Why

Prod console showed hundreds of repeated:

```
[.WebGL-0x11400513e00] GL_INVALID_FRAMEBUFFER_OPERATION: glClear: Framebuffer is incomplete: Attachment has zero size.
```

Different context ID than fiona-embed's BJS log — the spam was coming from the **shared engine** (`src/lib/babylon-shared-engine.ts`), not fiona-embed. Caused by views being registered against zero-size canvases (parent panel hadn't opened yet) and the shared engine running its render loop against the 0×0 framebuffer every tick.

## Three coordinated fixes

### 1. `babylon-shared-engine.ts` — defer zero-size registrations

`registerSceneView` now checks `canvas.clientWidth/clientHeight === 0` and, if so, observes the canvas with a ResizeObserver. When the canvas gains layout, the observer disconnects and `engine.registerView` runs. New module-level `_deferredObservers: Map<HTMLCanvasElement, ResizeObserver>`. Idempotent — duplicate calls during the deferred window are no-ops.

`unregisterSceneView` cancels any pending observer at the top, so an early-unmount before the canvas ever sized doesn't leak observers.

### 2. `babylon-shared-engine.ts` — lose WebGL context on disposal

When the last view is unregistered and the engine is about to be disposed, explicitly call `WEBGL_lose_context.loseContext()` on the working canvas's GL context. Chrome reclaims the slot immediately rather than waiting for GC. Matters when fiona-embed (separate engine) wants a context — Chrome's context limit is ~16 and tight under memory pressure.

### 3. `device-capabilities.ts` + `render-capability.ts` — lose context after probing

Both helpers create a probe canvas, call `getContext('webgl')`, read `UNMASKED_RENDERER_WEBGL`, then drop the canvas. Without explicit loseContext, that probe-context lingers as Chrome waits for GC. Now both call `loseContext` immediately after capturing the renderer string.

## Defensive pattern

All three loseContext call sites use **double optional chaining**: `?.loseContext?.()`. The first `?.` handles a null returned by `getExtension` (extension unavailable); the second `?.` handles an object returned by mock test code that doesn't actually have the loseContext method. Without the second `?.`, the existing `render-capability.test.ts` and `device-capabilities.test.ts` mocks would throw on the new call.

## Tests

- 990/990 vitest pass (full suite)
- 30/30 pass on the two directly-affected test files
- `npm run build` clean (only the pre-existing chunk-size warning)

## Will this kill the spam?

The user's spam was `Framebuffer is incomplete: Attachment has zero size` from a context with ID like `0x11400513e00` — that's the shared engine. Deferring registration until the canvas has layout means the engine's render loop only ever ticks against sized framebuffers. The errors should stop. I'll headless-verify after merge.

## Refs

Builds on PRs #379, #381, #383, #384.