### PR TITLE
chore(lint): biome unsafe auto-fix (refs #261)

### DIFF
--- a/src/components/babylon-spin-demo/index.tsx
+++ b/src/components/babylon-spin-demo/index.tsx
@@ -25,7 +25,7 @@ export default function BabylonSpinDemo({
 
 		let disposed = false;
 		// biome-ignore lint/suspicious/noExplicitAny: dynamic babylon import
-		let eng: any = null;
+		let _eng: any = null;
 		let ro: ResizeObserver | null = null;
 		let io: IntersectionObserver | null = null;
 
@@ -41,7 +41,7 @@ export default function BabylonSpinDemo({
 			if (canvas) {
 				unregisterSceneView(canvas);
 			}
-			eng = null;
+			_eng = null;
 		}
 
 		async function startEngine() {
@@ -52,7 +52,7 @@ export default function BabylonSpinDemo({
 			if (disposed) return;
 
 			const sharedEngine = getOrCreateSharedEngine();
-			eng = sharedEngine;
+			_eng = sharedEngine;
 			const scene = new B.Scene(sharedEngine);
 			currentScene = scene;
 			scene.clearColor = new B.Color4(0, 0, 0, 0);

--- a/src/components/weather/__tests__/atmosphere-scene.test.tsx
+++ b/src/components/weather/__tests__/atmosphere-scene.test.tsx
@@ -149,7 +149,7 @@ vi.mock("../../../lib/babylon-shared-engine", () => ({
 
 // ── IntersectionObserver stub ─────────────────────────────────────────────────
 type IOCallback = (entries: { isIntersecting: boolean }[]) => void;
-let lastIOCallback: IOCallback | null = null;
+let _lastIOCallback: IOCallback | null = null;
 let lastIOObserve: ReturnType<typeof vi.fn> | null = null;
 let lastIODisconnect: ReturnType<typeof vi.fn> | null = null;
 
@@ -157,7 +157,7 @@ class IntersectionObserverMock {
 	observe: ReturnType<typeof vi.fn>;
 	disconnect: ReturnType<typeof vi.fn>;
 	constructor(cb: IOCallback) {
-		lastIOCallback = cb;
+		_lastIOCallback = cb;
 		this.observe = vi.fn();
 		this.disconnect = vi.fn();
 		lastIOObserve = this.observe;
@@ -186,7 +186,7 @@ beforeEach(() => {
 	mockUnregister.mockClear();
 	const g = globalThis as unknown as { __babylonMeshes: { name: string }[] };
 	if (g.__babylonMeshes) g.__babylonMeshes.length = 0;
-	lastIOCallback = null;
+	_lastIOCallback = null;
 	lastIOObserve = null;
 	lastIODisconnect = null;
 	vi.stubGlobal("IntersectionObserver", IntersectionObserverMock);

--- a/src/lib/babylon-shared-engine.ts
+++ b/src/lib/babylon-shared-engine.ts
@@ -79,7 +79,7 @@ let _docVisHandlerInstalled = false;
 
 function _masterTick(): void {
 	const engine = _engine;
-	if (!engine || !engine.activeView) return;
+	if (!engine?.activeView) return;
 	const target = engine.activeView.target as HTMLCanvasElement;
 	const view = _views.get(target);
 	if (!view || view.paused) return;


### PR DESCRIPTION
Ran `npx biome check --write --unsafe --max-diagnostics=600 src/`.

## Scope
3 source files auto-fixed:
- `src/components/babylon-spin-demo/index.tsx` — unused-var prefix (`eng` → `_eng`)
- `src/components/weather/__tests__/atmosphere-scene.test.tsx` — unused-var prefix (`lastIOCallback` → `_lastIOCallback`)
- `src/lib/babylon-shared-engine.ts` — optional-chain (`!engine || !engine.activeView` → `!engine?.activeView`)

## Reverted
- `src/utils/__tests__/wave-71-perf-contrast.test.ts` — biome converted `versionMatch![1]` to `versionMatch?.[1]`, which TypeScript rejected (`string | undefined` not assignable to `Number.parseInt`).
- `src/pages/maintenance-calendar/utils/__tests__/projection.test.ts` — biome converted `result!.projectedDate!` to `result?.projectedDate!`, which biome itself then flagged as `noNonNullAssertedOptionalChain` (mixed pattern is forbidden).

## Verification
- `npm test`: 990/990 tests passed (110 files)
- `npm run build`: green

Refs #261.