### PR TITLE
feat: ?babylon-tier URL override (#382)

### DIFF
--- a/src/components/fiona-frame/__tests__/fiona-frame.test.tsx
+++ b/src/components/fiona-frame/__tests__/fiona-frame.test.tsx
@@ -19,6 +19,7 @@ vi.mock("../../../lib/device-capabilities", () => ({
 		renderer: "NVIDIA GeForce RTX 4080",
 		deviceMemory: 16,
 		hardwareConcurrency: 12,
+		override: null,
 	})),
 }));
 
@@ -104,6 +105,7 @@ describe("FionaFrame — gate timeout + static fallback (#382)", () => {
 			renderer: "NVIDIA GeForce RTX 4080",
 			deviceMemory: 16,
 			hardwareConcurrency: 12,
+			override: null,
 		});
 		render(<FionaFrame />);
 		expect(logSpy).toHaveBeenCalledTimes(1);

--- a/src/lib/__tests__/device-capabilities.test.ts
+++ b/src/lib/__tests__/device-capabilities.test.ts
@@ -1,12 +1,14 @@
 // Wave 53 — unit tests for device-capabilities.ts
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	getDeviceDiagnostics,
 	getDeviceTier,
 	hasFewCores,
 	hasLowMemory,
 	isCapableForBabylon,
 	isSoftwareWebGL,
 	prefersReducedMotion,
+	readTierOverride,
 } from "../device-capabilities";
 
 function mockCanvas(renderer: string | null) {
@@ -47,8 +49,21 @@ function mockMotion(matches: boolean) {
 	} as unknown as MediaQueryList);
 }
 
+/** Issue #382 — set window.location.search via history.replaceState (jsdom). */
+function mockUrl(search: string) {
+	window.history.replaceState({}, "", search === "" ? "/" : `/${search}`);
+}
+
 afterEach(() => {
 	vi.restoreAllMocks();
+	// Issue #382 — reset URL + session override state between tests so the
+	// override mechanism doesn't leak across cases.
+	window.history.replaceState({}, "", "/");
+	try {
+		window.sessionStorage.clear();
+	} catch {
+		/* ignore */
+	}
 });
 
 // ---------------------------------------------------------------------------
@@ -212,10 +227,8 @@ describe("getDeviceTier", () => {
 // ---------------------------------------------------------------------------
 // getDeviceDiagnostics  (issue #382)
 // ---------------------------------------------------------------------------
-import { getDeviceDiagnostics } from "../device-capabilities";
-
 describe("getDeviceDiagnostics", () => {
-	it("returns the full diagnostic shape with all six signal keys", () => {
+	it("returns the full diagnostic shape with all signal keys", () => {
 		mockMotion(false);
 		mockCanvas("NVIDIA GeForce RTX 4080/PCIe/SSE2");
 		mockNav({ deviceMemory: 16, hardwareConcurrency: 12 });
@@ -229,6 +242,7 @@ describe("getDeviceDiagnostics", () => {
 			renderer: "NVIDIA GeForce RTX 4080/PCIe/SSE2",
 			deviceMemory: 16,
 			hardwareConcurrency: 12,
+			override: null,
 		});
 	});
 
@@ -261,5 +275,114 @@ describe("getDeviceDiagnostics", () => {
 		expect(d.lowMemory).toBe(false);
 		expect(d.deviceMemory).toBeUndefined();
 		expect(d.tier).toBe("high");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// readTierOverride / ?babylon-tier URL override (issue #382)
+// ---------------------------------------------------------------------------
+describe("readTierOverride / ?babylon-tier URL override", () => {
+	beforeEach(() => {
+		window.history.replaceState({}, "", "/");
+		try {
+			window.sessionStorage.clear();
+		} catch {
+			/* ignore */
+		}
+	});
+
+	it("returns null when no URL param and no sessionStorage", () => {
+		expect(readTierOverride()).toBeNull();
+	});
+
+	it("returns 'high' when ?babylon-tier=high is in URL", () => {
+		mockUrl("?babylon-tier=high");
+		expect(readTierOverride()).toBe("high");
+	});
+
+	it("returns 'low' when ?babylon-tier=low is in URL", () => {
+		mockUrl("?babylon-tier=low");
+		expect(readTierOverride()).toBe("low");
+	});
+
+	it("returns 'medium' when ?babylon-tier=medium is in URL", () => {
+		mockUrl("?babylon-tier=medium");
+		expect(readTierOverride()).toBe("medium");
+	});
+
+	it("persists URL value to sessionStorage so subsequent calls without URL param honour it", () => {
+		mockUrl("?babylon-tier=high");
+		expect(readTierOverride()).toBe("high");
+		mockUrl(""); // navigate away from the param
+		expect(readTierOverride()).toBe("high");
+	});
+
+	it("?babylon-tier=reset clears sessionStorage and returns null", () => {
+		mockUrl("?babylon-tier=low");
+		expect(readTierOverride()).toBe("low");
+		mockUrl("?babylon-tier=reset");
+		expect(readTierOverride()).toBeNull();
+		mockUrl("");
+		expect(readTierOverride()).toBeNull();
+		expect(
+			window.sessionStorage.getItem("cdn-babylon-tier-override"),
+		).toBeNull();
+	});
+
+	it("ignores unrecognised values (?babylon-tier=garbage → null)", () => {
+		mockUrl("?babylon-tier=garbage");
+		expect(readTierOverride()).toBeNull();
+	});
+
+	it("URL value wins over a different sessionStorage value", () => {
+		window.sessionStorage.setItem("cdn-babylon-tier-override", "low");
+		mockUrl("?babylon-tier=high");
+		expect(readTierOverride()).toBe("high");
+		// URL also wrote-through the new value to sessionStorage
+		expect(window.sessionStorage.getItem("cdn-babylon-tier-override")).toBe(
+			"high",
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getDeviceTier + override (integration of getDeviceTier with readTierOverride)
+// ---------------------------------------------------------------------------
+describe("getDeviceTier honours ?babylon-tier override", () => {
+	beforeEach(() => {
+		window.history.replaceState({}, "", "/");
+		try {
+			window.sessionStorage.clear();
+		} catch {
+			/* ignore */
+		}
+	});
+
+	it("forces 'high' even when SwiftShader probe would gate to low", () => {
+		mockMotion(false);
+		mockCanvas("SwiftShader");
+		mockNav({ deviceMemory: 2, hardwareConcurrency: 2 });
+		mockUrl("?babylon-tier=high");
+		expect(getDeviceTier()).toBe("high");
+	});
+
+	it("forces 'low' even on a Pixel-10-class device", () => {
+		mockMotion(false);
+		mockCanvas("Adreno 750");
+		mockNav({ deviceMemory: 12, hardwareConcurrency: 9 });
+		mockUrl("?babylon-tier=low");
+		expect(getDeviceTier()).toBe("low");
+	});
+
+	it("getDeviceDiagnostics surfaces the override field", () => {
+		mockMotion(false);
+		mockCanvas("SwiftShader");
+		mockNav({ deviceMemory: 16, hardwareConcurrency: 8 });
+		mockUrl("?babylon-tier=high");
+		const d = getDeviceDiagnostics();
+		expect(d.tier).toBe("high");
+		expect(d.override).toBe("high");
+		// Real probe results are still reported — only `tier` reflects the override.
+		expect(d.softwareWebGL).toBe(true);
 	});
 });

--- a/src/lib/device-capabilities.ts
+++ b/src/lib/device-capabilities.ts
@@ -1,11 +1,77 @@
 // Wave 53 — centralized device capability detection for Babylon gating.
 // All Babylon scenes are accessories, not bones. CSS + skeletons load first;
 // Babylon enhances capable devices after first paint.
+//
+// Issue #382 — ?babylon-tier=high|medium|low|reset URL override (session-scoped).
+// Lets reporters and QA force a specific tier without changing OS/browser flags.
+// Visit ?babylon-tier=high to bypass the gate; ?babylon-tier=reset to clear.
 
 export type DeviceTier = "high" | "medium" | "low";
 
 const SOFTWARE_RENDERER_RE =
 	/SwiftShader|llvmpipe|Software|Microsoft Basic Render/i;
+
+const TIER_OVERRIDE_STORAGE_KEY = "cdn-babylon-tier-override";
+const TIER_OVERRIDE_URL_PARAM = "babylon-tier";
+
+function isDeviceTier(value: string): value is DeviceTier {
+	return value === "high" || value === "medium" || value === "low";
+}
+
+/**
+ * Read a session-scoped tier override.
+ *
+ * Resolution order:
+ *  1. `?babylon-tier=high|medium|low` in the current URL  — writes to
+ *     sessionStorage so subsequent navigations within the tab keep the
+ *     override without needing the param again.
+ *  2. `?babylon-tier=reset` in the current URL  — clears any stored
+ *     override and returns null (real probes run).
+ *  3. Existing sessionStorage value from a prior URL visit in this tab.
+ *  4. Otherwise null — caller falls back to capability probes.
+ *
+ * Storage failures (Safari private mode, sandboxed contexts) are swallowed:
+ * the override still works for the current call, just not persisted.
+ */
+export function readTierOverride(): DeviceTier | null {
+	if (typeof window === "undefined") return null;
+
+	let urlValue: string | null = null;
+	try {
+		urlValue = new URLSearchParams(window.location.search).get(
+			TIER_OVERRIDE_URL_PARAM,
+		);
+	} catch {
+		/* malformed URL — ignore */
+	}
+
+	if (urlValue === "reset") {
+		try {
+			window.sessionStorage.removeItem(TIER_OVERRIDE_STORAGE_KEY);
+		} catch {
+			/* storage unavailable — still return null */
+		}
+		return null;
+	}
+
+	if (urlValue !== null && isDeviceTier(urlValue)) {
+		try {
+			window.sessionStorage.setItem(TIER_OVERRIDE_STORAGE_KEY, urlValue);
+		} catch {
+			/* storage unavailable — override still applies for this call */
+		}
+		return urlValue;
+	}
+
+	try {
+		const stored = window.sessionStorage.getItem(TIER_OVERRIDE_STORAGE_KEY);
+		if (stored !== null && isDeviceTier(stored)) return stored;
+	} catch {
+		/* storage unavailable — fall through */
+	}
+
+	return null;
+}
 
 /**
  * One-shot WebGL probe. Returns the UNMASKED_RENDERER_WEBGL string (or "") and
@@ -77,8 +143,12 @@ export function isCapableForBabylon(): boolean {
  * high   — capable + ≥8 GB RAM + ≥8 cores  (Pixel 10, MacBook Air M-series)
  * medium — capable but constrained           (older Intel MacBook Air, mid-range Android)
  * low    — not capable                       (Pixel 4, VMs, software WebGL)
+ *
+ * Honours `?babylon-tier=...` URL override when present (issue #382).
  */
 export function getDeviceTier(): DeviceTier {
+	const override = readTierOverride();
+	if (override !== null) return override;
 	if (!isCapableForBabylon()) return "low";
 	const mem = (navigator as Navigator & { deviceMemory?: number }).deviceMemory;
 	const cores = navigator.hardwareConcurrency;
@@ -101,15 +171,18 @@ export interface DeviceDiagnostics {
 	deviceMemory: number | undefined;
 	/** navigator.hardwareConcurrency. */
 	hardwareConcurrency: number;
+	/** When non-null, ?babylon-tier=... or sessionStorage forced the tier (issue #382). */
+	override: DeviceTier | null;
 }
 
 /**
  * Single-probe diagnostic snapshot for logging. Captures every signal that
  * feeds the tier decision so a downstream caller can log "why did this device
- * land in low tier?" without re-running each helper (each WebGL probe creates
- * and disposes a context — fine for one shot, wasteful in a loop).
+ * land in low tier?" without re-running each helper. Includes the URL/session
+ * override state so logs make it obvious when a forced tier is in effect.
  */
 export function getDeviceDiagnostics(): DeviceDiagnostics {
+	const override = readTierOverride();
 	const renderer = probeRenderer();
 	const softwareWebGL = SOFTWARE_RENDERER_RE.test(renderer);
 	const reducedMotion = matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -120,7 +193,9 @@ export function getDeviceDiagnostics(): DeviceDiagnostics {
 	const fewCores = hardwareConcurrency < 4;
 
 	let tier: DeviceTier;
-	if (reducedMotion || softwareWebGL || (lowMemory && fewCores)) {
+	if (override !== null) {
+		tier = override;
+	} else if (reducedMotion || softwareWebGL || (lowMemory && fewCores)) {
 		tier = "low";
 	} else {
 		const highMem = deviceMemory === undefined ? true : deviceMemory >= 8;
@@ -137,5 +212,6 @@ export function getDeviceDiagnostics(): DeviceDiagnostics {
 		renderer,
 		deviceMemory,
 		hardwareConcurrency,
+		override,
 	};
 }


### PR DESCRIPTION
## What

Adds a session-scoped tier override controlled via URL:

- `?babylon-tier=high` — force tier high regardless of probes
- `?babylon-tier=medium` — force medium
- `?babylon-tier=low` — force low (test the gated UX)
- `?babylon-tier=reset` — clear any session override

The URL value is persisted to sessionStorage under `cdn-babylon-tier-override` so subsequent navigations within the tab keep the override without needing the param again. URL value wins over a stale sessionStorage value (write-through).

## Why

Issue #382 follow-up. The diagnostic log shipped in #388 tells us *which* signal gated a user, but a reporter still has no way to **prove** the gate is the cause from outside. With this PR, a reporter visits `?babylon-tier=high` and we can immediately verify whether the scene actually runs on their hardware once forced. Same mechanism gives QA a way to test the gated fallback UX on capable hardware via `?babylon-tier=low`.

## API surface

- New exported `readTierOverride(): DeviceTier | null` in `src/lib/device-capabilities.ts`.
- `getDeviceTier()` short-circuits on the override before running probes.
- `DeviceDiagnostics` interface gains `override: DeviceTier | null`. The existing `[fiona-gate] tier=low {…}` diagnostic log automatically picks this up via `getDeviceDiagnostics()`.
- All existing public APIs unchanged in shape (only added the optional `override` field).

## Tests

- `npm test`: 1009/1009 pass (was 998 — 11 new tests cover override URL parsing, sessionStorage persistence, reset, invalid values, URL-wins precedence, and integration with getDeviceTier / getDeviceDiagnostics).
- `npm run build`: success in 5.79s, no new warnings.

## Notes

Storage failures (Safari private mode, sandboxed contexts) are swallowed — the override still works for the current call, just not persisted across navigations. If you need persistence in those contexts, fall back to keeping the `?babylon-tier=` param in the URL.