### PR TITLE
fix(fiona): respect prefers-reduced-motion (#382)

### DIFF
--- a/src/components/fiona-frame/__tests__/fiona-frame.test.tsx
+++ b/src/components/fiona-frame/__tests__/fiona-frame.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Mock device-capabilities so we control the gate decision per test.
 vi.mock("../../../lib/device-capabilities", () => ({
 	getDeviceTier: vi.fn(() => "high"),
+	prefersReducedMotion: vi.fn(() => false),
 	getDeviceDiagnostics: vi.fn(() => ({
 		tier: "high",
 		reducedMotion: false,
@@ -51,6 +52,7 @@ vi.mock("../../babylon-gate", () => ({
 import {
 	getDeviceDiagnostics,
 	getDeviceTier,
+	prefersReducedMotion,
 } from "../../../lib/device-capabilities";
 import FionaFrame from "../index";
 
@@ -131,5 +133,17 @@ describe("FionaFrame — gate timeout + static fallback (#382)", () => {
 		expect(screen.queryByRole("img")).not.toBeInTheDocument();
 		expect(screen.getByText(/modem connecting/i)).toBeInTheDocument();
 		expect(logSpy).not.toHaveBeenCalled();
+	});
+
+	it("swaps to static fallback IMMEDIATELY (no 4s wait) when gated AND prefers-reduced-motion is on", () => {
+		vi.mocked(getDeviceTier).mockReturnValue("low");
+		vi.mocked(prefersReducedMotion).mockReturnValue(true);
+		render(<FionaFrame />);
+		// No timer advance needed — reduce-motion path skips the 4s wait.
+		const img = screen.getByRole("img", {
+			name: /Fiona avatar - 3D view unavailable on this device/i,
+		});
+		expect(img).toBeInTheDocument();
+		expect(screen.queryByText(/modem connecting/i)).not.toBeInTheDocument();
 	});
 });

--- a/src/components/fiona-frame/index.tsx
+++ b/src/components/fiona-frame/index.tsx
@@ -4,6 +4,7 @@ import {
 	type DeviceTier,
 	getDeviceDiagnostics,
 	getDeviceTier,
+	prefersReducedMotion,
 } from "../../lib/device-capabilities";
 import { loadVisitorInfo, type VisitorInfo } from "../../utils/visitor";
 import BabylonGate from "../babylon-gate";
@@ -137,10 +138,18 @@ export default function FionaFrame() {
 		};
 	}, []);
 
-	// Issue #382 — gated-out devices: log diagnostic ONCE, then after
-	// GATE_FALLBACK_DELAY_MS swap the shimmer for a static avatar poster.
+	// Issue #382 — gated-out devices: log diagnostic ONCE. Then either swap
+	// the shimmer immediately (reduce-motion users explicitly asked for no
+	// animation — the shimmer's background drift + label pulse violate that)
+	// or after GATE_FALLBACK_DELAY_MS for everyone else.
 	useEffect(() => {
 		if (!gatedOut) return;
+		let reducedMotion = false;
+		try {
+			reducedMotion = prefersReducedMotion();
+		} catch {
+			/* matchMedia unavailable — default to non-reduced */
+		}
 		if (!diagnosticLoggedRef.current) {
 			diagnosticLoggedRef.current = true;
 			try {
@@ -157,6 +166,10 @@ export default function FionaFrame() {
 			} catch {
 				/* never let diagnostics break rendering */
 			}
+		}
+		if (reducedMotion) {
+			setGatedFallback(true);
+			return;
 		}
 		const timer = window.setTimeout(() => {
 			setGatedFallback(true);

--- a/src/components/navigation/fiona.css
+++ b/src/components/navigation/fiona.css
@@ -1767,6 +1767,20 @@ body.cdn-stream-playing :root:not(.awsui-dark-mode) .fiona-led,
 		animation: none;
 		clip-path: none;
 	}
+	/* Issue #382 — the shimmer placeholder used to keep its background drift
+	   and label pulse looping under reduced-motion. The whole point of
+	   prefers-reduced-motion is no looping animation. Kill all three. */
+	.fiona-placeholder {
+		animation: none;
+	}
+	.fiona-placeholder-label {
+		animation: none;
+		letter-spacing: 0.18em;
+		opacity: 1;
+	}
+	.fiona-panel-wrap {
+		animation: none;
+	}
 }
 
 .fiona-credits-scroll-window {


### PR DESCRIPTION
## What

Two small fixes for users with prefers-reduced-motion: reduce on:

1. **CSS** — extends the existing `@media (prefers-reduced-motion: reduce)` block in `fiona.css` to disable the looping animations on `.fiona-placeholder` (background drift), `.fiona-placeholder-label` (letter-spacing + opacity pulse), and `.fiona-panel-wrap` (CRT flicker). Previously these kept looping forever even when the user explicitly asked the OS for reduced motion.

2. **FionaFrame** — when the device is gated AND prefers-reduced-motion is on, swap to the static fallback **immediately** instead of waiting 4 seconds. The 4s shimmer phase exists to give the canvas a chance to mount on slow devices; a reduce-motion user is never going to see the canvas anyway, so making them watch the shimmer for 4s is dishonest.

## Why

Issue #382, plan items 1a + 1b. Plan item 1c (decouple reduce-motion from `isCapableForBabylon` and pass a `motion: "reduced"` hint to `mountFionaPanel`) is deferred — it requires coordinated changes in fiona-embed (sumerian-hosts side).

## Tests

- `npm test`: 1010/1010 pass (1 new test verifying immediate fallback when gated + reduced-motion).
- `npm run build`: pass.