### PR TITLE
fix(auth): passkey sign-in (#185)

### DIFF
--- a/src/lib/cognito.ts
+++ b/src/lib/cognito.ts
@@ -389,14 +389,27 @@ export async function initiatePasskeyAuth(email: string): Promise<{
 	session: string;
 	credentials: Record<string, unknown>;
 }> {
-	const result = await cognitoPost("InitiateAuth", {
-		AuthFlow: "USER_AUTH",
-		ClientId: CLIENT_ID,
-		AuthParameters: {
-			USERNAME: sanitize(email, "email"),
-			PREFERRED_CHALLENGE: "WEB_AUTHN",
-		},
-	});
+	let result: Record<string, unknown>;
+	try {
+		result = await cognitoPost("InitiateAuth", {
+			AuthFlow: "USER_AUTH",
+			ClientId: CLIENT_ID,
+			AuthParameters: {
+				USERNAME: sanitize(email, "email"),
+				PREFERRED_CHALLENGE: "WEB_AUTHN",
+			},
+		});
+	} catch (err) {
+		if (err instanceof AuthError && err.code === "InvalidParameterException") {
+			throw new AuthError(
+				"passkey sign-in is not enabled on the user pool yet. " +
+					"Please sign in with your password and TOTP code instead. " +
+					"(Admin: enable USER_AUTH explicit auth flow on the app client.)",
+				"PasskeyAuthFlowNotEnabled",
+			);
+		}
+		throw err;
+	}
 	console.log("[passkey] InitiateAuth response:", {
 		ChallengeName: result.ChallengeName,
 		ChallengeParameters: result.ChallengeParameters,

--- a/src/sites/auth/login/app.tsx
+++ b/src/sites/auth/login/app.tsx
@@ -103,62 +103,24 @@ function LoginForm() {
 		setFormError("");
 		setEmailError("");
 		try {
-			// Step 1: Try to get a passkey from the browser without specifying allowCredentials
-			// This shows ALL available passkeys for clouddelnorte.org (discoverable credentials)
-			let passkeyEmail =
+			const passkeyEmail =
 				email.trim() || localStorage.getItem("cdn.passkey_email") || "";
 
-			console.log(
-				"[passkey] handlePasskeyLogin start, email:",
-				passkeyEmail ? "(set)" : "(empty)",
-			);
-
 			if (!passkeyEmail) {
-				// No email known — try discoverable credential flow
-				// Ask browser to show available passkeys without server round-trip
-				const discoverResult = (await navigator.credentials.get({
-					publicKey: {
-						challenge: crypto.getRandomValues(new Uint8Array(32)),
-						rpId: "clouddelnorte.org",
-						userVerification: "preferred",
-					},
-				})) as PublicKeyCredential | null;
-
-				if (!discoverResult) throw new AuthError("passkey cancelled");
-
-				// Extract email from userHandle (Cognito stores the sub there)
-				const response =
-					discoverResult.response as AuthenticatorAssertionResponse;
-				if (response.userHandle) {
-					// userHandle is the Cognito user sub — we need to look up the email
-					// For now, decode it as UTF-8 in case it's the email directly
-					const decoded = new TextDecoder().decode(response.userHandle);
-					console.log(
-						"[passkey] discoverable userHandle decoded:",
-						decoded.includes("@") ? "email" : "UUID/other",
-						decoded.length,
-						"chars",
-					);
-					// If it looks like an email, use it; otherwise it's a sub UUID
-					if (decoded.includes("@")) {
-						passkeyEmail = decoded;
-					} else {
-						// It's a sub — we can't use InitiateAuth without email
-						// Fall back to asking for email
-						setEmailError(
-							"please enter your email to complete passkey sign-in",
-						);
-						setLoading(false);
-						return;
-					}
-				} else {
-					setEmailError("please enter your email to complete passkey sign-in");
-					setLoading(false);
-					return;
-				}
+				// Cognito InitiateAuth requires a USERNAME — we cannot start the
+				// WebAuthn ceremony without knowing which user to authenticate.
+				// The email field has autoComplete="username webauthn" so the
+				// browser will offer a saved passkey via conditional UI in the
+				// autofill dropdown, which then fills the email AND submits.
+				// If the user clicks the button without typing, point them at the
+				// email field rather than triggering a wasted biometric prompt.
+				setEmailError(
+					"enter your email first — your passkey will be offered automatically",
+				);
+				setLoading(false);
+				return;
 			}
 
-			// Step 2: Now we have the email — do the Cognito flow
 			console.log("[passkey] calling initiatePasskeyAuth for:", passkeyEmail);
 			const { session, credentials } = await initiatePasskeyAuth(passkeyEmail);
 			console.log(
@@ -179,6 +141,8 @@ function LoginForm() {
 			if (!assertion) throw new AuthError("passkey cancelled");
 			console.log("[passkey] got assertion, calling completePasskeyAuth");
 			await completePasskeyAuth(session, assertion);
+			// Persist email so the next sign-in pre-fills the field.
+			localStorage.setItem("cdn.passkey_email", passkeyEmail);
 			redirectWithTokens();
 		} catch (err) {
 			console.error("[passkey] error:", err);

--- a/src/sites/auth/passkeys/app.tsx
+++ b/src/sites/auth/passkeys/app.tsx
@@ -11,6 +11,7 @@ import {
 	AuthError,
 	base64urlToBuffer,
 	completeWebAuthnRegistration,
+	decodeToken,
 	deleteWebAuthnCredential,
 	getAccessToken,
 	listWebAuthnCredentials,
@@ -107,9 +108,10 @@ function PasskeyManager() {
 			try {
 				const idToken = sessionStorage.getItem("cdn.idToken");
 				if (idToken) {
-					const payload = JSON.parse(atob(idToken.split(".")[1]));
-					if (payload.email)
-						localStorage.setItem("cdn.passkey_email", payload.email);
+					const payload = decodeToken(idToken);
+					const email =
+						typeof payload.email === "string" ? payload.email : null;
+					if (email) localStorage.setItem("cdn.passkey_email", email);
 				}
 			} catch {
 				/* non-fatal */
@@ -181,9 +183,10 @@ function PasskeyManager() {
 			try {
 				const idToken = sessionStorage.getItem("cdn.idToken");
 				if (idToken) {
-					const payload = JSON.parse(atob(idToken.split(".")[1]));
-					if (payload.email)
-						localStorage.setItem("cdn.passkey_email", payload.email);
+					const payload = decodeToken(idToken);
+					const email =
+						typeof payload.email === "string" ? payload.email : null;
+					if (email) localStorage.setItem("cdn.passkey_email", email);
 				}
 			} catch {
 				/* non-fatal */


### PR DESCRIPTION
## What

Three code bugs were preventing passkey sign-in from working. All fixed here. A separate Cognito user-pool config change is also required to fully resolve #185 — tracked separately.

### Bug 1 — email never persisted after passkey registration

`src/sites/auth/passkeys/app.tsx` was decoding the Cognito JWT with bare `atob(idToken.split('.')[1])`. JWT payloads are base64url-encoded (`-`/`_` instead of `+`/`/` and unpadded). Plain `atob` throws on the first such character. The throw was caught by `catch {/* non-fatal */}` and silently swallowed, so `cdn.passkey_email` was never written to localStorage. Next visit to `/login/` had nothing to pre-fill from.

Fixed by importing `decodeToken` from `cognito.ts` (already does the base64url→base64 conversion, handles padding) and using it in both `handleRegister` and `handleAddDevice`.

### Bug 2 — discoverable flow triggered wasted biometric prompt

`src/sites/auth/login/app.tsx` `handlePasskeyLogin()`: when `cdn.passkey_email` was empty, it called `navigator.credentials.get()` with a random challenge, prompted the user for face/fingerprint, then if `userHandle` decoded to a UUID (which it always does — Cognito stores `sub` UUID in `userHandle`, not email) it threw the assertion away and asked the user for their email. User did the biometric for absolutely nothing.

Removed that branch. Empty-email path now shows a clear inline message pointing the user at the email field. The field has `autoComplete="username webauthn"` which enables browser-native conditional UI — the saved passkey appears as a suggestion in the autofill dropdown, and selecting it fills the email AND submits the sign-in.

Also added: persist `cdn.passkey_email` to localStorage on successful passkey sign-in (not just on password+MFA sign-in), so the round-trip user experience is sticky.

### Bug 3 — generic error masked the real Cognito problem

`initiatePasskeyAuth` in `src/lib/cognito.ts` calls `InitiateAuth` with `AuthFlow: USER_AUTH`. If the user pool client doesn't have `ALLOW_USER_AUTH` enabled, Cognito returns `InvalidParameterException` and the user sees "passkey login failed" — with no clue that it's a server-side config issue.

Wrapped the cognitoPost call in try/catch. `InvalidParameterException` now becomes `PasskeyAuthFlowNotEnabled` with a clear admin-actionable message: "passkey sign-in is not enabled on the user pool yet. Please sign in with your password and TOTP code instead. (Admin: enable USER_AUTH explicit auth flow on the app client.)"

## What's NOT fixed by this PR

The Cognito user pool client `57eikmt418ea6vti2f6h0pl74r` only has these explicit auth flows enabled:

- `USER_PASSWORD_AUTH`
- `USER_SRP_AUTH`
- `REFRESH_TOKEN_AUTH`

It needs `USER_AUTH` (also called `ALLOW_USER_AUTH`, the choice-based auth flow that supports `PREFERRED_CHALLENGE: WEB_AUTHN`). Tracking this separately because it's an AWS console / CLI change, not a code change. After that, passkey users will see the **clear error from this PR's bug-3 fix** instead of a generic failure — actionable signal.

## Tests

- `npm test`: 1010/1010 pass.
- `npm run build`: pass in 849ms.

## Refs

- Closes (partially): #185
- Cognito config follow-up: filed separately (linked in #185 comment)
- Prior fix attempts on this issue: 2b9092a3, 11dc296a, 5ebe62c2, 6d3b8024, 5aef3564