### PR TITLE
fix(awsug): restore persistent player — remove hidePlayer

### DIFF
--- a/src/sites/awsug/_layout/index.tsx
+++ b/src/sites/awsug/_layout/index.tsx
@@ -104,7 +104,6 @@ export default function AwsugLayout({
 
 	return (
 		<Shell
-			hidePlayer
 			theme={theme}
 			onThemeChange={(t) => {
 				setTheme(t);


### PR DESCRIPTION
## Summary

Removes the `hidePlayer` prop from `<Shell hidePlayer ...>` at
`src/sites/awsug/_layout/index.tsx:107`. Single-prop deletion. The persistent
music player is restored on `awsug.clouddelnorte.org` for authenticated users.

## Iteration 3 — corrected hypothesis

Iteration 3's original LOCKED hypothesis (hostname misclassification of awsug
as an auth subdomain) was disproved by the sub-task 3.2 code-mapper sweep. The
codemap doc at `.kiro/specs/music-player-playback/iter3-3.2-codemap.md`
documents the disproof:

- There is no hostname classifier in the codebase.
- The single WRITE site for `cdn-auth-subdomain` is `AuthLayout`'s
  unconditional `useEffect` at `src/sites/auth/_layout/index.tsx:88`.
- The harness reaches that mount on awsug.* only because awsug's
  `requireAuth()` redirects unauthenticated visitors to
  `auth.clouddelnorte.org/login/`, where AuthLayout mounts. The harness's
  body-class observation is on the auth page after redirect.

Product intent confirmed: the music player should play on awsug for
authenticated users. The `hidePlayer` prop on `AwsugLayout` was a regression
suppressing the player for every visitor. This change removes it.

## Verification

- Vitest: `npx vitest run src/sites/awsug/_layout` — 1 file, 4 tests passed
  (navigation.test.tsx). No AwsugLayout-specific test asserts `hidePlayer`.
- Preview verify (sub-task 3.4): harness against
  `https://dev.clouddelnorte.org/awsug-preview/` with kexp station, captured
  2026-05-28T02:07:17Z. All five DoD gates green:
  - `property2Pass == true`
  - `finalReadyState == 4`
  - `finalPaused == false`
  - No `StaleElementReferenceException` (`fatal == null`)
  - Zero new SEVERE console messages
  - `postClickAudio.bodyClasses == ['cdn-nav-open', 'cdn-stream-playing']`
  - `postClickAudio.audioPresent == true`, `paused == false`, `readyState == 4`

Prod parity verification on `awsug.clouddelnorte.org` requires harness
authentication and is sub-task 3.6 of the iteration-3 spec. Investigation pass
follows after this PR merges.

## Constraints honored

- No frozen-path edits (`src/components/persistent-player/**`, streams libs,
  CSP JSON, Fiona/BabylonJS/WebGL/footer/weather, `streams-reachability.ts`).
- No CSP widening.
- No AuthContext idempotent-setState change from `bbc95540` (out of scope per
  iteration 3 directive).

## References

- Closes (or part of) `chasko-labs/cloud-del-norte-website#399`.
- Spec triple: `.kiro/specs/music-player-playback/{requirements,design,tasks}.md`.
- Codemap: `.kiro/specs/music-player-playback/iter3-3.2-codemap.md`.
- Spec-discipline addendum: `BryanChasko/haunting-kiro-cli#1158`.
