### PR TITLE
docs(music-player-playback): correct devicefarm path typos + annotate iter-1d capture references

### DIFF
--- a/.kiro/specs/music-player-playback/tasks.md
+++ b/.kiro/specs/music-player-playback/tasks.md
@@ -7,19 +7,19 @@ Iterations, not phases. Each iteration ships value or learning. Each ends with a
 **Goal:** capture evidence sufficient to lock the fix family. No production code changes.
 
 - [ ] **0.1 Author Selenium diagnostic script**
- - File: `tests/devicefarm/music-player-diagnostic.py`
- - Read first: `scripts/probe-cta-button-classes.mjs` (Playwright probe pattern), any existing `tests/devicefarm/` examples.
+ - File: `tests/device-farm/music-player-diagnostic.py`
+ - Read first: `scripts/probe-cta-button-classes.mjs` (Playwright probe pattern), any existing `tests/device-farm/` examples.
  - Boto3 + Selenium, TestGrid project ARN `arn:aws:devicefarm:us-west-2:946179428633:testgrid-project:0f1bfe22-0371-40c8-bcac-f96709363893`.
  - Auth: `AWS_PROFILE=bryanchasko-kiro` (SSO active) or Roles Anywhere via `/workload.crt` if running in CI.
  - Per-station capture: console (all levels), network HAR, audio state via `driver.execute_script`, body class list, performance entries.
- - Output: `tests/devicefarm/captures/<timestamp>/<station>.{json,har}`.
+ - Output: `tests/device-farm/captures/<timestamp>/<station>.{json,har}`.
 
 - [ ] **0.2 Run against all three subdomains**
  - Run script against `clouddelnorte.org`, `awsug.clouddelnorte.org`, `auth.clouddelnorte.org`.
  - Captures committed (no secrets — Selenium runs unauthenticated).
 
 - [ ] **0.3 Findings classification**
- - File: `tests/devicefarm/captures/<timestamp>/findings.md`
+ - File: `tests/device-farm/captures/<timestamp>/findings.md`
  - Per station + subdomain: which hypothesis matches, or "other" with description.
  - Lock the fix family for Iteration 1 here. If multiple families surface, pick the one that unblocks the most stations.
 
@@ -79,7 +79,9 @@ Iterations, not phases. Each iteration ships value or learning. Each ends with a
    - [x] No new console errors introduced. **PASS — zero SEVERE messages.**
    - [x] No StaleElementReferenceException on play button. **PASS — clicked=true, fatal=null.**
    - [x] `git diff src/components/persistent-player/` is empty (Property 6). **PASS.**
- - Capture: `tests/device-farm/captures/20260527T190456Z/`.
+ - Capture: `tests/device-farm/captures/20260527T190456Z/`
+      (captured during the fix/awsug-rerender-race iteration, since
+      squash-merged to main separately; see git history).
 
 - [x] **1d.2 Iteration 1 retrospective (forward-looking)**
  - Append to this file: which component was the actual re-render trigger, what guard was applied, why the smaller alternatives were ruled out, what feeds back into the streams architecture.
@@ -130,7 +132,7 @@ Two new tests in `src/contexts/__tests__/auth-context.test.tsx` prove no-churn o
 
 Push to `fix/awsug-rerender-race` triggered (manually, via Woodpecker API — webhook auto-trigger was stuck) Woodpecker pipeline `#1785`, which deployed the build to `dev.clouddelnorte.org/awsug-preview/`. The harness was then run with `--base-url https://dev.clouddelnorte.org/awsug-preview/ --stations kexp`.
 
-Capture: `tests/device-farm/captures/20260527T190456Z/`. Result: `property2Pass: true`. Sample 1 (~500ms post-click) showed `readyState=4` and `paused=false`. No `StaleElementReferenceException`. No new SEVERE console messages. KEXP stream 200/audio-aac/ACAO=*.
+Capture: `tests/device-farm/captures/20260527T190456Z/` (captured during the fix/awsug-rerender-race iteration, since squash-merged to main separately; see git history). Result: `property2Pass: true`. Sample 1 (~500ms post-click) showed `readyState=4` and `paused=false`. No `StaleElementReferenceException`. No new SEVERE console messages. KEXP stream 200/audio-aac/ACAO=*.
 
 ### Constraint amendment (live)
 
@@ -167,7 +169,7 @@ PR #398 (`fix/awsug-rerender-race` → `main`): OPEN, awaiting auditor review. I
  - Auditor reviews → orin posts verdict → squash-merge → `deploy.sh` from haunting source. Bryan is not a step.
 
 - [ ] **2.3 Post-deploy verification on main**
- - Re-run `tests/devicefarm/music-player-diagnostic.py` against deployed main.
+ - Re-run `tests/device-farm/music-player-diagnostic.py` against deployed main.
  - KEXP × awsug PASS confirmed in production.
 
 - [ ] **2.4 Final retrospective**


### PR DESCRIPTION
## Summary

Follow-up doc patch on `.kiro/specs/music-player-playback/tasks.md`. Seven edits, single file, zero source changes.

## Source

PR #406 (merge `ac4b55de`) audit returned APPROVE on all five spec-doc gates, with two non-blocking narrative findings the auditor surfaced:

1. Four instances of `tests/devicefarm/` (no hyphen) in Iteration 0 — lines 10, 11, 15, 22.
2. Iter-1d capture reference to `tests/device-farm/captures/20260527T190456Z/` that lived on `fix/awsug-rerender-race` (since squash-merged separately), not on `spec/music-player-playback`.

cdn-PO preflight on this cleanup branch surfaced a fifth instance of finding #1 at line 170 (Iteration 2 task 2.3 "Post-deploy verification on main") — same defect class, missed by the auditor's iteration-0-scoped sweep. cdn-anchor locked the call to handle all five typo instances and both capture references in this single PR.

## Edit set

- 5× `tests/devicefarm/` → `tests/device-farm/` (lines 10, 11, 15, 22, 170). Safe global string replacement; the AWS Device Farm ARN at line 12 (`arn:aws:devicefarm:`) is intentionally unchanged — it's the AWS service identifier, not a file path.
- 2× annotation on the `20260527T190456Z` capture references (lines 82 and 133) — same annotation text in both, format adapted to bullet vs prose context.

## Annotation rationale

The capture at `tests/device-farm/captures/20260527T190456Z/` was produced during work on the `fix/awsug-rerender-race` iteration and subsequently squash-merged to main as part of a separate PR. The capture directory itself does not exist on this branch (or any branch off the squashed history). Annotating preserves the historical narrative — the capture was real, the result was real, the property checks were real — without misleading future readers into searching for a directory that no longer exists at that path.

Annotation reads:

> (captured during the fix/awsug-rerender-race iteration, since squash-merged to main separately; see git history)

Line 82 uses bullet-continuation form (multi-line, indented under the bullet). Line 133 uses inline form (parenthetical inside the prose paragraph). Same text content, format follows surrounding context.

## Cross-references

- Follows PR #406 (merge commit `ac4b55de`) — "close iteration 3 — corrected hypothesis, codemap, retrospective"
- Codemap: `.kiro/specs/music-player-playback/iter3-3.2-codemap.md` (introduced in PR #406)
- No source changes; Woodpecker path-filter will skip the deploy step on merge.

## Commits

5b7de9c1 docs(music-player-playback): correct devicefarm path typos + annotate iter-1d capture references
