### PR TITLE
fix(persistent-player): remove auth-subdomain defenses — visibility is layout's responsibility

### DIFF
--- a/src/components/persistent-player/index.tsx
+++ b/src/components/persistent-player/index.tsx
@@ -1367,11 +1367,5 @@ function PersistentPlayerInner() {
 }
 
 export default function PersistentPlayer() {
-	if (
-		typeof document !== "undefined" &&
-		document.body.classList.contains("cdn-auth-subdomain")
-	) {
-		return null;
-	}
 	return <PersistentPlayerInner />;
 }

--- a/src/components/persistent-player/styles.css
+++ b/src/components/persistent-player/styles.css
@@ -937,11 +937,6 @@ body.cdn-stream-playing .cdn-pp__waveform {
 	}
 }
 
-/* Hide player on auth subdomain — no audio distraction during sign-up */
-.cdn-auth-subdomain .cdn-player-slot {
-	display: none;
-}
-
 /* ==========================================================================
    Audio-reactive sigil (l rethink — liora design)
 


### PR DESCRIPTION
## Summary

Remove two component-level defenses from `persistent-player` that were keyed off `body.cdn-auth-subdomain`. Visibility on auth pages is `AuthLayout`'s responsibility, not the player's.

## Changes

- `src/components/persistent-player/index.tsx` — remove the JS render guard at lines 1370-1375 that returned `null` when `document.body.classList.contains("cdn-auth-subdomain")` was true. The component no longer introspects `document.body`.
- `src/components/persistent-player/styles.css` — remove the CSS rule at lines 939-943 (`.cdn-auth-subdomain .cdn-player-slot { display: none }`) and its inline comment.

## What is NOT changed

`AuthLayout`'s own defenses are intentionally preserved. Auth pages still hide the player correctly via:

- `src/sites/auth/_layout/styles.css:35` — `body.cdn-auth-subdomain .cdn-player-slot { display: none; }`
- `src/sites/auth/_layout/styles.css:1032` — `body.cdn-auth-subdomain .cdn-player-slot { display: none !important; }`
- `src/sites/auth/_layout/index.tsx:88` — the `useEffect` that adds/removes the body class

These are byte-identical to `main`.

## iter-4 chain

- **iter-4.0** (anon prod parity FAIL on `awsug.clouddelnorte.org`) — Dispatch 4 capture committed at `tests/device-farm/captures/20260529T124228Z/awsug.clouddelnorte.org/kexp.json`. The capture showed `bodyClasses: ["cdn-nav-open", "cdn-auth-subdomain"]` and `playerMounted=false` post-click. Falsified iter-3.2 codemap conclusion. Closed in PR #408.
- **iter-4.1** (manual investigation by `ghost-tarn-cdn-react-coder`) — enumerated 5 mechanisms keyed off `cdn-auth-subdomain`: 1 class-adder (`auth/_layout/index.tsx:88`) + 4 hiders. PR #401 had previously deleted a 6th mechanism (AwsugLayout `hidePlayer={true}` prop). Three legs investigated: (a1) build conflation, (a2) import path, (a3) CloudFront routing. Tarn's reading: a3 was the only viable explanation.
- **iter-4.1.B** (CloudFront inspection by anchor-dispatched `poltergeist-stratia-aws-infra`) — distribution `E2QLAWFVIT1AR8` is serving correctly. The auth-* bundles are PHYSICALLY in `s3://awsug.clouddelnorte.org/assets/`. The awsug build emits them. (a3) CloudFront RULED OUT. Real leak source is the awsug build itself: `src/sites/awsug/auth/callback/` and `src/sites/awsug/auth/redeem/` routes pull auth-related chunks into the awsug graph. Tracked separately as iter-4.2.B.
- **iter-4.2.A** (this PR) — symptom kill via defenses removal. Resolves the visible player-hiding regardless of leak source. iter-4.2.B (build-config audit) follows separately and addresses the root cause.

## Architectural rationale

`persistent-player` is layout-agnostic. Component-level introspection of `document.body` for a class set by a sibling layout component conflates concerns. The class belongs to `AuthLayout`'s mount lifecycle; visibility belongs to whatever layout is currently rendering. The player should not enforce visibility against a class it doesn't own.

Removing these defenses is a delete, not a scope-narrow, because the contract being removed was wrong, not just over-broad.

## Test

- Vitest full suite: 111 files / 1010 tests PASS (21.35s)
- `persistent-player` suite specifically: 5 files / 40 tests PASS
- No test was encoding the removed render guard contract.
- Biome pre-commit hook: clean.

## Verification plan post-merge

1. Squash-merge to `main`.
2. Run `deploy.sh` from repo root; wait 60s for CloudFront edge propagation.
3. Re-run Dispatch 4 (anon prod parity verify): `AWS_PROFILE=kiro-device-farm python3 tests/device-farm/music-player-diagnostic.py --stations kexp --subdomains https://awsug.clouddelnorte.org`.
4. PASS criteria: `property2Pass=true`, `finalReadyState>=2`, `finalPaused=false`, no `StaleElementReferenceException`, zero new SEVERE console messages.

## Cross-references

Refs: #399, #408, #401