### PR TITLE
chore(biome): resolve noDescendingSpecificity warnings (#261 track 1)

### DIFF
--- a/src/components/fiona-panel/styles.css
+++ b/src/components/fiona-panel/styles.css
@@ -135,6 +135,26 @@
 	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='340'%3E%3Cpolyline points='310,30 318,48 305,52 322,70 308,88 328,110 310,140 295,170' stroke='%23ffaa00' stroke-width='4.5' fill='none' stroke-opacity='0.9'/%3E%3Cpolyline points='310,30 318,48 305,52 322,70 308,88 328,110 310,140 295,170' stroke='%23fffde0' stroke-width='1.5' fill='none' stroke-opacity='0.5'/%3E%3Cpolyline points='318,48 340,55 360,48 380,60' stroke='%23ffaa00' stroke-width='3' fill='none' stroke-opacity='0.7'/%3E%3Cpolyline points='322,70 345,80 370,95 395,105' stroke='%23ffaa00' stroke-width='3' fill='none' stroke-opacity='0.65'/%3E%3Cpolyline points='308,88 280,100 250,95 220,110' stroke='%23ffaa00' stroke-width='2.5' fill='none' stroke-opacity='0.6'/%3E%3Cpolyline points='328,110 355,130 385,140' stroke='%23ffaa00' stroke-width='2.5' fill='none' stroke-opacity='0.6'/%3E%3Ccircle cx='316' cy='46' r='10' fill='%23ffaa00' fill-opacity='0.45'/%3E%3Ccircle cx='316' cy='46' r='4' fill='%23fffde0' fill-opacity='0.95'/%3E%3Ccircle cx='322' cy='70' r='5' fill='%23ffaa00' fill-opacity='0.35'/%3E%3Ccircle cx='328' cy='110' r='5' fill='%23ffaa00' fill-opacity='0.3'/%3E%3Crect x='0' y='0' width='400' height='340' fill='%23080600' fill-opacity='0.82'/%3E%3C/svg%3E");
 }
 
+/* phosphor filter — grayscale + sepia desaturate slightly; saturate(1.8) retains
+   luminance separation between skin/hair/clothing; hue-rotate(68deg) tilts toward
+   classic phosphor green without destroying tonal detail */
+.fiona-canvas {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	opacity: 0;
+	transition:
+		opacity 0.8s ease,
+		filter 0.6s ease;
+	filter: grayscale(0.12) sepia(0.2) saturate(1.8) hue-rotate(68deg)
+		brightness(0.92) contrast(1.15);
+}
+
+.fiona-canvas.fiona-canvas--visible {
+	opacity: 1;
+}
+
 /* hide canvas entirely when shattered */
 .fiona-bezel.crack-3 .fiona-canvas {
 	opacity: 0;
@@ -717,26 +737,6 @@
 	100% {
 		background-position: 0% 0%;
 	}
-}
-
-/* phosphor filter — grayscale + sepia desaturate slightly; saturate(1.8) retains
-   luminance separation between skin/hair/clothing; hue-rotate(68deg) tilts toward
-   classic phosphor green without destroying tonal detail */
-.fiona-canvas {
-	position: absolute;
-	inset: 0;
-	width: 100%;
-	height: 100%;
-	opacity: 0;
-	transition:
-		opacity 0.8s ease,
-		filter 0.6s ease;
-	filter: grayscale(0.12) sepia(0.2) saturate(1.8) hue-rotate(68deg)
-		brightness(0.92) contrast(1.15);
-}
-
-.fiona-canvas.fiona-canvas--visible {
-	opacity: 1;
 }
 
 /* scanlines + rolling phosphor sweep — classic CRT horizontal scroll */

--- a/src/components/navigation/fiona.css
+++ b/src/components/navigation/fiona.css
@@ -132,6 +132,53 @@
 	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='340'%3E%3Cpolyline points='310,30 318,48 305,52 322,70 308,88 328,110 310,140 295,170' stroke='%23ffaa00' stroke-width='4.5' fill='none' stroke-opacity='0.9'/%3E%3Cpolyline points='310,30 318,48 305,52 322,70 308,88 328,110 310,140 295,170' stroke='%23fffde0' stroke-width='1.5' fill='none' stroke-opacity='0.5'/%3E%3Cpolyline points='318,48 340,55 360,48 380,60' stroke='%23ffaa00' stroke-width='3' fill='none' stroke-opacity='0.7'/%3E%3Cpolyline points='322,70 345,80 370,95 395,105' stroke='%23ffaa00' stroke-width='3' fill='none' stroke-opacity='0.65'/%3E%3Cpolyline points='308,88 280,100 250,95 220,110' stroke='%23ffaa00' stroke-width='2.5' fill='none' stroke-opacity='0.6'/%3E%3Cpolyline points='328,110 355,130 385,140' stroke='%23ffaa00' stroke-width='2.5' fill='none' stroke-opacity='0.6'/%3E%3Ccircle cx='316' cy='46' r='10' fill='%23ffaa00' fill-opacity='0.45'/%3E%3Ccircle cx='316' cy='46' r='4' fill='%23fffde0' fill-opacity='0.95'/%3E%3Ccircle cx='322' cy='70' r='5' fill='%23ffaa00' fill-opacity='0.35'/%3E%3Ccircle cx='328' cy='110' r='5' fill='%23ffaa00' fill-opacity='0.3'/%3E%3Crect x='0' y='0' width='400' height='340' fill='%23080600' fill-opacity='0.82'/%3E%3C/svg%3E");
 }
 
+.fiona-canvas {
+	opacity: 0;
+	filter: grayscale(0.12) sepia(0.2) saturate(1.8) hue-rotate(68deg)
+		brightness(0.92) contrast(1.15);
+	width: 100%;
+	height: 100%;
+	transition:
+		opacity 0.8s,
+		filter 0.6s;
+	position: absolute;
+	inset: 0;
+	/* Audio-reactive head dance — LEFT tilt (bass) + vertical NOD (mid). Bryan
+	   v0.0.0066: previous ±2.5deg sway felt like she was nodding both ways;
+	   left-only at -2deg max read as "into the bass" but proved too subtle —
+	   v0.0.0102 raises lateral to -4deg and adds a vertical nod riding
+	   --cdn-mid (kick/snare band) so fiona visibly head-bobs to the beat.
+	   Silent → 0deg + 0px throughout. Loud bass → -4deg lean. Loud mid → -6px
+	   nod. transform-origin at bottom so rotation pivots from the neck.
+	   Two parallel animations on different periods (3.6s tilt → individual
+	   `rotate` property, 0.9s nod → individual `translate` property). Using
+	   the modern individual-transform-properties (rotate / translate) instead
+	   of the legacy `transform` shorthand is critical: shorthand collides
+	   when two @keyframes both write `transform` (last-applied wins, no
+	   compose). The individual props cascade independently so lateral lean
+	   and vertical bob layer into a natural dance.
+	   Both animations paused unless body has cdn-stream-playing AND canvas is
+	   --visible — head only "dances" while audio is actually playing.
+	   No conflict with babylon emoteQueue/gestureQueue: those deform the 3D
+	   mesh INSIDE the canvas pixel buffer; the CSS transform rotates the
+	   <canvas> element AFTER rasterization, so the two layers compose. */
+	transform-origin: center bottom;
+	animation:
+		fiona-head-tilt-left 3.6s ease-in-out infinite,
+		fiona-head-nod 0.9s ease-in-out infinite;
+	animation-play-state: paused, paused;
+	will-change: rotate, translate;
+}
+
+.fiona-canvas.fiona-canvas--visible {
+	opacity: 1;
+}
+
+/* head nods temporarily disabled for isolation — re-enable by restoring running, running */
+body.cdn-stream-playing .fiona-canvas.fiona-canvas--visible {
+	animation-play-state: paused, paused;
+}
+
 .fiona-bezel.crack-3 .fiona-canvas {
 	pointer-events: none;
 	opacity: 0;
@@ -371,6 +418,122 @@
    gives it the same zoomed placement + cool sapphire treatment that
    matches sticky 2's resting state. Right-side mirror of sticky 1's
    bottom-left zoomed slot — keeps both notes visually distinct. */
+/* === notes row: holds sticky note 1 (left) and sticky note 2 (right) side by side
+   so both are visible without adding vertical height below the bezel.
+   STATE-INDEPENDENCE FIX (Bryan 2026-05-02): each sticky is `position: absolute`
+   pinned to its own corner so any state change on one (zoom / fall / sway /
+   ripfall / fadein) cannot push or shift the sibling. The row reserves a
+   fixed min-height so the layout below it doesn't jump when both fly out. */
+.fiona-notes-row {
+	position: relative;
+	width: 100%;
+	min-height: 56px;
+	margin-top: 6px;
+}
+
+/* === sticky note 2: visitor greeting + IP ============================
+   second sticky placed in the right gutter below the bezel, mirroring
+   sticky note 1's position on the left. both notes live in .fiona-notes-row
+   (flex row) so they appear side by side without stacking vertically. */
+.fiona-stickynote-2 {
+	/* button reset — element promoted from div to <button> for keyboard
+	   activation; strip default button chrome so the sticky-note look stays
+	   identical (background gradient + handwritten text + tilt). */
+	appearance: none;
+	border: 0;
+	font: inherit;
+	text-align: inherit;
+
+	position: absolute;
+	top: 0;
+	right: 18px;
+	padding: 3px 6px 4px;
+	max-width: clamp(72px, 22cqi, 110px);
+	width: fit-content;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	background-image:
+		repeating-linear-gradient(0deg, #5a32100d 0 1px, #0000 1px 4px),
+		linear-gradient(135deg, #d9f0ffd1 0%, #c4e1f5c7 60%, #a8cceabd 100%);
+	background-size:
+		100% 4px,
+		100% 100%;
+	color: #1a1424;
+	font-family: Caveat, "Comic Sans MS", "Segoe Script", cursive;
+	font-size: clamp(7px, 2cqi, 10px);
+	line-height: 1.1;
+	letter-spacing: 0.02em;
+	transform: rotate(2.8deg);
+	transform-origin: 50% -8px;
+	box-shadow:
+		1px 2px 4px #00000047,
+		1px 1px 2px #0000002e,
+		inset 0 -2px 3px #1e6090b5;
+	pointer-events: auto;
+	cursor: pointer;
+	-webkit-user-select: none;
+	user-select: none;
+	animation: 0.6s 1.6s both fiona-stickynote-fadein;
+}
+
+.fiona-stickynote-2:before {
+	content: "";
+	pointer-events: none;
+	position: absolute;
+	top: -10px;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 18px;
+	height: 9px;
+	background: repeating-linear-gradient(
+		90deg,
+		#b4b4b46b 0 1px,
+		#e4e4e499 1px 2.5px
+	);
+	border-radius: 1px;
+	opacity: 0.62;
+}
+
+.fiona-stickynote-2-line {
+	font-weight: 600;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	padding-right: 16px;
+}
+
+.fiona-stickynote-2-flag {
+	font-family:
+		"Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+	position: absolute;
+	top: 50%;
+	right: 4px;
+	transform: translateY(-50%) rotate(-2.8deg);
+	margin: 0;
+	padding: 0;
+	font-size: 1.1em;
+	line-height: 1;
+	pointer-events: none;
+	filter: drop-shadow(0 1px 1px #00000040);
+}
+
+.fiona-stickynote-2-ip {
+	font-family: "JetBrains Mono", "Courier New", monospace;
+	font-size: 0.85em;
+	font-weight: var(--cdn-weight-semibold, 600);
+	letter-spacing: 0.02em;
+	opacity: 0.85;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	padding-right: 16px;
+	display: inline-block;
+	min-width: 13ch; /* pre-allocated slot for IPv4 — loading→"66.18.175.199" no longer changes sticky note width */
+	font-variant-numeric: tabular-nums; /* equal-width digits prevent sub-char drift between IPs */
+	text-align: left;
+}
+
 .fiona-stickynote-2.fiona-stickynote-2--zoomed {
 	transform-origin: 50% 100%;
 	z-index: 500;
@@ -686,53 +849,6 @@
 	to {
 		background-position: 0 0;
 	}
-}
-
-.fiona-canvas {
-	opacity: 0;
-	filter: grayscale(0.12) sepia(0.2) saturate(1.8) hue-rotate(68deg)
-		brightness(0.92) contrast(1.15);
-	width: 100%;
-	height: 100%;
-	transition:
-		opacity 0.8s,
-		filter 0.6s;
-	position: absolute;
-	inset: 0;
-	/* Audio-reactive head dance — LEFT tilt (bass) + vertical NOD (mid). Bryan
-	   v0.0.0066: previous ±2.5deg sway felt like she was nodding both ways;
-	   left-only at -2deg max read as "into the bass" but proved too subtle —
-	   v0.0.0102 raises lateral to -4deg and adds a vertical nod riding
-	   --cdn-mid (kick/snare band) so fiona visibly head-bobs to the beat.
-	   Silent → 0deg + 0px throughout. Loud bass → -4deg lean. Loud mid → -6px
-	   nod. transform-origin at bottom so rotation pivots from the neck.
-	   Two parallel animations on different periods (3.6s tilt → individual
-	   `rotate` property, 0.9s nod → individual `translate` property). Using
-	   the modern individual-transform-properties (rotate / translate) instead
-	   of the legacy `transform` shorthand is critical: shorthand collides
-	   when two @keyframes both write `transform` (last-applied wins, no
-	   compose). The individual props cascade independently so lateral lean
-	   and vertical bob layer into a natural dance.
-	   Both animations paused unless body has cdn-stream-playing AND canvas is
-	   --visible — head only "dances" while audio is actually playing.
-	   No conflict with babylon emoteQueue/gestureQueue: those deform the 3D
-	   mesh INSIDE the canvas pixel buffer; the CSS transform rotates the
-	   <canvas> element AFTER rasterization, so the two layers compose. */
-	transform-origin: center bottom;
-	animation:
-		fiona-head-tilt-left 3.6s ease-in-out infinite,
-		fiona-head-nod 0.9s ease-in-out infinite;
-	animation-play-state: paused, paused;
-	will-change: rotate, translate;
-}
-
-/* head nods temporarily disabled for isolation — re-enable by restoring running, running */
-body.cdn-stream-playing .fiona-canvas.fiona-canvas--visible {
-	animation-play-state: paused, paused;
-}
-
-.fiona-canvas.fiona-canvas--visible {
-	opacity: 1;
 }
 
 @keyframes fiona-head-tilt-left {
@@ -3029,122 +3145,6 @@ body.cdn-stream-playing :root:not(.awsui-dark-mode) .fiona-led,
 	animation: none;
 	opacity: 0.18;
 	filter: brightness(0.4);
-}
-
-/* === notes row: holds sticky note 1 (left) and sticky note 2 (right) side by side
-   so both are visible without adding vertical height below the bezel.
-   STATE-INDEPENDENCE FIX (Bryan 2026-05-02): each sticky is `position: absolute`
-   pinned to its own corner so any state change on one (zoom / fall / sway /
-   ripfall / fadein) cannot push or shift the sibling. The row reserves a
-   fixed min-height so the layout below it doesn't jump when both fly out. */
-.fiona-notes-row {
-	position: relative;
-	width: 100%;
-	min-height: 56px;
-	margin-top: 6px;
-}
-
-/* === sticky note 2: visitor greeting + IP ============================
-   second sticky placed in the right gutter below the bezel, mirroring
-   sticky note 1's position on the left. both notes live in .fiona-notes-row
-   (flex row) so they appear side by side without stacking vertically. */
-.fiona-stickynote-2 {
-	/* button reset — element promoted from div to <button> for keyboard
-	   activation; strip default button chrome so the sticky-note look stays
-	   identical (background gradient + handwritten text + tilt). */
-	appearance: none;
-	border: 0;
-	font: inherit;
-	text-align: inherit;
-
-	position: absolute;
-	top: 0;
-	right: 18px;
-	padding: 3px 6px 4px;
-	max-width: clamp(72px, 22cqi, 110px);
-	width: fit-content;
-	display: flex;
-	flex-direction: column;
-	gap: 2px;
-	background-image:
-		repeating-linear-gradient(0deg, #5a32100d 0 1px, #0000 1px 4px),
-		linear-gradient(135deg, #d9f0ffd1 0%, #c4e1f5c7 60%, #a8cceabd 100%);
-	background-size:
-		100% 4px,
-		100% 100%;
-	color: #1a1424;
-	font-family: Caveat, "Comic Sans MS", "Segoe Script", cursive;
-	font-size: clamp(7px, 2cqi, 10px);
-	line-height: 1.1;
-	letter-spacing: 0.02em;
-	transform: rotate(2.8deg);
-	transform-origin: 50% -8px;
-	box-shadow:
-		1px 2px 4px #00000047,
-		1px 1px 2px #0000002e,
-		inset 0 -2px 3px #1e6090b5;
-	pointer-events: auto;
-	cursor: pointer;
-	-webkit-user-select: none;
-	user-select: none;
-	animation: 0.6s 1.6s both fiona-stickynote-fadein;
-}
-
-.fiona-stickynote-2:before {
-	content: "";
-	pointer-events: none;
-	position: absolute;
-	top: -10px;
-	left: 50%;
-	transform: translateX(-50%);
-	width: 18px;
-	height: 9px;
-	background: repeating-linear-gradient(
-		90deg,
-		#b4b4b46b 0 1px,
-		#e4e4e499 1px 2.5px
-	);
-	border-radius: 1px;
-	opacity: 0.62;
-}
-
-.fiona-stickynote-2-line {
-	font-weight: 600;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	padding-right: 16px;
-}
-
-.fiona-stickynote-2-flag {
-	font-family:
-		"Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
-	position: absolute;
-	top: 50%;
-	right: 4px;
-	transform: translateY(-50%) rotate(-2.8deg);
-	margin: 0;
-	padding: 0;
-	font-size: 1.1em;
-	line-height: 1;
-	pointer-events: none;
-	filter: drop-shadow(0 1px 1px #00000040);
-}
-
-.fiona-stickynote-2-ip {
-	font-family: "JetBrains Mono", "Courier New", monospace;
-	font-size: 0.85em;
-	font-weight: var(--cdn-weight-semibold, 600);
-	letter-spacing: 0.02em;
-	opacity: 0.85;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	padding-right: 16px;
-	display: inline-block;
-	min-width: 13ch; /* pre-allocated slot for IPv4 — loading→"66.18.175.199" no longer changes sticky note width */
-	font-variant-numeric: tabular-nums; /* equal-width digits prevent sub-char drift between IPs */
-	text-align: left;
 }
 
 /* ==========================================================================

--- a/src/components/navigation/menu-signage.css
+++ b/src/components/navigation/menu-signage.css
@@ -14,6 +14,37 @@
    guarantee WCAG AA 4.5:1 contrast. The 3D depth comes entirely from
    the multi-layer text-shadow stack. */
 
+/* ── Dark mode: violet-on-navy with amber accent on hover ────────────── */
+.awsui-dark-mode [class*="awsui_side-navigation"] [class*="awsui_link"] {
+	text-shadow:
+		0 0 3px rgba(144, 96, 240, 0.22),
+		0 2px 0 rgba(20, 10, 40, 0.4) !important;
+	transition: text-shadow 240ms ease-out !important;
+}
+
+.awsui-dark-mode [class*="awsui_side-navigation"] [class*="awsui_link"]:hover,
+.awsui-dark-mode
+	[class*="awsui_side-navigation"]
+	[class*="awsui_link"]:focus-visible {
+	text-shadow:
+		0 0 5px rgba(144, 96, 240, 0.4),
+		0 0 10px rgba(90, 31, 138, 0.3),
+		0 2px 0 rgba(20, 10, 40, 0.45),
+		0 0 16px rgba(201, 162, 63, 0.2) !important;
+}
+
+/* Active/current page — persistent low glow */
+.awsui-dark-mode [class*="awsui_side-navigation"]
+	[class*="awsui_link"][class*="active"],
+.awsui-dark-mode
+	[class*="awsui_side-navigation"]
+	[class*="awsui_link"][aria-current="page"] {
+	text-shadow:
+		0 0 4px rgba(144, 96, 240, 0.3),
+		0 2px 0 rgba(20, 10, 40, 0.42),
+		0 0 12px rgba(90, 31, 138, 0.15) !important;
+}
+
 /* ── Light mode: warm cream-on-amber ─────────────────────────────────── */
 :root:not(.awsui-dark-mode)
 	[class*="awsui_side-navigation"]
@@ -50,43 +81,12 @@
 		0 0 10px rgba(144, 96, 240, 0.12) !important;
 }
 
-/* ── Dark mode: violet-on-navy with amber accent on hover ────────────── */
-.awsui-dark-mode [class*="awsui_side-navigation"] [class*="awsui_link"] {
-	text-shadow:
-		0 0 3px rgba(144, 96, 240, 0.22),
-		0 2px 0 rgba(20, 10, 40, 0.4) !important;
-	transition: text-shadow 240ms ease-out !important;
-}
-
-.awsui-dark-mode [class*="awsui_side-navigation"] [class*="awsui_link"]:hover,
-.awsui-dark-mode
-	[class*="awsui_side-navigation"]
-	[class*="awsui_link"]:focus-visible {
-	text-shadow:
-		0 0 5px rgba(144, 96, 240, 0.4),
-		0 0 10px rgba(90, 31, 138, 0.3),
-		0 2px 0 rgba(20, 10, 40, 0.45),
-		0 0 16px rgba(201, 162, 63, 0.2) !important;
-}
-
-/* Active/current page — persistent low glow */
-.awsui-dark-mode [class*="awsui_side-navigation"]
-	[class*="awsui_link"][class*="active"],
-.awsui-dark-mode
-	[class*="awsui_side-navigation"]
-	[class*="awsui_link"][aria-current="page"] {
-	text-shadow:
-		0 0 4px rgba(144, 96, 240, 0.3),
-		0 2px 0 rgba(20, 10, 40, 0.42),
-		0 0 12px rgba(90, 31, 138, 0.15) !important;
-}
-
 /* ── prefers-reduced-motion: no transitions ──────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
+	.awsui-dark-mode [class*="awsui_side-navigation"] [class*="awsui_link"],
 	:root:not(.awsui-dark-mode)
 		[class*="awsui_side-navigation"]
-		[class*="awsui_link"],
-	.awsui-dark-mode [class*="awsui_side-navigation"] [class*="awsui_link"] {
+		[class*="awsui_link"] {
 		transition: none !important;
 	}
 }

--- a/src/components/persistent-player/styles.css
+++ b/src/components/persistent-player/styles.css
@@ -679,6 +679,10 @@ a.cdn-pp__label--donate:focus-visible {
 	animation: none;
 }
 
+.cdn-pp__btn--stop:hover {
+	transform: scale(1.06);
+}
+
 :root:not(.awsui-dark-mode) .cdn-pp__btn--stop:hover {
 	background: rgba(var(--station-primary-mode-rgb, 217, 123, 0), 0.1);
 	transform: scale(1.06);
@@ -714,10 +718,6 @@ a.cdn-pp__label--donate:focus-visible {
 	filter: blur(2px);
 	z-index: 0;
 	animation: 3.2s linear infinite cdn-ravy-spotlight-spin;
-}
-
-.cdn-pp__btn--stop:hover {
-	transform: scale(1.06);
 }
 
 .cdn-pp__btn--stop:focus-visible {

--- a/src/components/weather/styles.css
+++ b/src/components/weather/styles.css
@@ -128,18 +128,6 @@
 	color: var(--cdn-lavender, #d7c7ee);
 }
 
-/* Dark mode: explicit text colors on all metric/label elements so they never
-   rely solely on opacity inheritance over an ambiguous background. */
-.awsui-dark-mode .cdn-weather__metric dt,
-.awsui-dark-mode .cdn-weather__tomorrow-label {
-	color: rgba(215, 199, 238, 0.65);
-}
-
-.awsui-dark-mode .cdn-weather__metric dd,
-.awsui-dark-mode .cdn-weather__temp-c {
-	color: var(--cdn-lavender, #d7c7ee);
-}
-
 /* ── Header row — city + condition glyph ────────────────────────────────── */
 .cdn-weather__head {
 	display: flex;
@@ -410,6 +398,18 @@
 	opacity: 0.65;
 }
 
+/* Dark mode: explicit text colors on all metric/label elements so they never
+   rely solely on opacity inheritance over an ambiguous background. */
+.awsui-dark-mode .cdn-weather__metric dt,
+.awsui-dark-mode .cdn-weather__tomorrow-label {
+	color: rgba(215, 199, 238, 0.65);
+}
+
+.awsui-dark-mode .cdn-weather__metric dd,
+.awsui-dark-mode .cdn-weather__temp-c {
+	color: var(--cdn-lavender, #d7c7ee);
+}
+
 .cdn-weather__tomorrow-temps {
 	display: flex;
 	gap: 8px;
@@ -464,19 +464,18 @@
 		background-color 0.25s ease,
 		transform 0.25s ease;
 }
+.awsui-dark-mode .cdn-weather__dot {
+	background: rgba(144, 96, 240, 0.32);
+}
+.awsui-dark-mode .cdn-weather__dot--active {
+	background: var(--cdn-violet, #9060f0);
+	transform: scale(1.35);
+}
 
 :root:not(.awsui-dark-mode) .cdn-weather__dot {
 	background: rgba(139, 90, 43, 0.32);
 }
 :root:not(.awsui-dark-mode) .cdn-weather__dot--active {
 	background: var(--cdn-aws-orange, #ff9900);
-	transform: scale(1.35);
-}
-
-.awsui-dark-mode .cdn-weather__dot {
-	background: rgba(144, 96, 240, 0.32);
-}
-.awsui-dark-mode .cdn-weather__dot--active {
-	background: var(--cdn-violet, #9060f0);
 	transform: scale(1.35);
 }

--- a/src/layouts/shell/styles.css
+++ b/src/layouts/shell/styles.css
@@ -14,6 +14,18 @@
 	initial-value: 0;
 }
 
+/* A3 fix — desktop toolbar inner flex row vertical alignment */
+[class*="awsui_universal-toolbar"] > *,
+[class*="awsui_mobile-toolbar"] > * {
+	align-items: center !important;
+}
+
+[class*="awsui_breadcrumbs"] {
+	transition:
+		opacity 0.2s ease,
+		transform 0.2s ease;
+}
+
 #top-nav {
 	position: sticky;
 	left: 0;
@@ -38,6 +50,16 @@
    Previously set #ede5d4 solid base + gradient; now transparent per b8014898
    wallpaper-through-chrome approach. cdn-atmospheric.css handles atmospheric
    blur when cdn-viz-active is present. */
+.awsui-dark-mode [class*="awsui_has-header_"]
+	> [class*="awsui_background_"]:not(#\9),
+.awsui-dark-mode
+	[class*="awsui_content-layout"]
+	> [class*="awsui_background"]:not(#\9),
+.awsui-dark-mode [class*="awsui_header-background"]:not(#\9) {
+	background: transparent;
+	background-color: transparent;
+}
+
 :root:not(.awsui-dark-mode)
 	[class*="awsui_has-header_"]
 	> [class*="awsui_background_"]:not(#\9),
@@ -45,17 +67,6 @@
 	[class*="awsui_content-layout"]
 	> [class*="awsui_background"]:not(#\9),
 :root:not(.awsui-dark-mode) [class*="awsui_header-background"]:not(#\9) {
-	background: transparent;
-	background-color: transparent;
-}
-
-.awsui-dark-mode
-	[class*="awsui_has-header_"]
-	> [class*="awsui_background_"]:not(#\9),
-.awsui-dark-mode
-	[class*="awsui_content-layout"]
-	> [class*="awsui_background"]:not(#\9),
-.awsui-dark-mode [class*="awsui_header-background"]:not(#\9) {
 	background: transparent;
 	background-color: transparent;
 }
@@ -104,18 +115,18 @@
    Scoped via :root:not(.awsui-dark-mode) for light and .awsui-dark-mode for dark.
    No !important needed — these target :hover states Cloudscape doesn't style. */
 
-/* Light mode: warm amber left-accent flash */
-:root:not(.awsui-dark-mode) [class*="side-navigation"] a:hover {
-	box-shadow: inset 3px 0 0 #8b5a2b; /* --cdn-amber */
-	background-color: rgba(139, 90, 43, 0.06);
-}
-
 /* Dark mode: violet left-accent flash with subtle glow */
 .awsui-dark-mode [class*="side-navigation"] a:hover {
 	box-shadow:
 		inset 3px 0 0 #9060f0,
 		0 0 12px rgba(144, 96, 240, 0.1); /* --cdn-violet */
 	background-color: rgba(144, 96, 240, 0.06);
+}
+
+/* Light mode: warm amber left-accent flash */
+:root:not(.awsui-dark-mode) [class*="side-navigation"] a:hover {
+	box-shadow: inset 3px 0 0 #8b5a2b; /* --cdn-amber */
+	background-color: rgba(139, 90, 43, 0.06);
 }
 
 /* TASK 6 — TopNavigation polish */
@@ -163,6 +174,40 @@
 main[class*="awsui_layout"] {
 	min-block-size: auto !important;
 	block-size: auto !important;
+}
+
+/* Dark mode: deep navy with violet/indigo spotlights — same architecture */
+.awsui-dark-mode main[class*="awsui_layout"]:not(#\9),
+.awsui-dark-mode [class*="awsui_layout-main"]:not(#\9) {
+	background:
+		radial-gradient(
+			60% 45% at 25% 15%,
+			rgba(144, 96, 240, 0.18) 0%,
+			rgba(144, 96, 240, 0) 70%
+		),
+		radial-gradient(
+			50% 40% at 80% 85%,
+			rgba(48, 0, 106, calc(0.32 + var(--cdn-bass) * 0.12)) 0%,
+			rgba(48, 0, 106, 0) 65%
+		),
+		repeating-linear-gradient(
+			135deg,
+			rgba(255, 255, 255, 0.012) 0 2px,
+			transparent 2px 5px
+		),
+		#0a0c14;
+	background-attachment: fixed, fixed, fixed, scroll;
+	background-size:
+		180% 180%,
+		180% 180%,
+		auto,
+		auto;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.awsui-dark-mode main[class*="awsui_layout"]:not(#\9) {
+		animation: cdn-ambient-drift 28s ease-in-out infinite;
+	}
 }
 
 /* Light mode: warm cream fills the layout seam between nav and content containers.
@@ -237,40 +282,6 @@ main[class*="awsui_layout"] {
 	}
 }
 
-/* Dark mode: deep navy with violet/indigo spotlights — same architecture */
-.awsui-dark-mode main[class*="awsui_layout"]:not(#\9),
-.awsui-dark-mode [class*="awsui_layout-main"]:not(#\9) {
-	background:
-		radial-gradient(
-			60% 45% at 25% 15%,
-			rgba(144, 96, 240, 0.18) 0%,
-			rgba(144, 96, 240, 0) 70%
-		),
-		radial-gradient(
-			50% 40% at 80% 85%,
-			rgba(48, 0, 106, calc(0.32 + var(--cdn-bass) * 0.12)) 0%,
-			rgba(48, 0, 106, 0) 65%
-		),
-		repeating-linear-gradient(
-			135deg,
-			rgba(255, 255, 255, 0.012) 0 2px,
-			transparent 2px 5px
-		),
-		#0a0c14;
-	background-attachment: fixed, fixed, fixed, scroll;
-	background-size:
-		180% 180%,
-		180% 180%,
-		auto,
-		auto;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-	.awsui-dark-mode main[class*="awsui_layout"]:not(#\9) {
-		animation: cdn-ambient-drift 28s ease-in-out infinite;
-	}
-}
-
 /* Wave 71 — narrow transition on cdn-viz-active. Cloudscape's awsui_root
    injects `transition: all 0.18s` which causes the browser to transition
    EVERY computed property on scroll-triggered class changes. Override with
@@ -323,6 +334,46 @@ main[class*="awsui_layout"] {
 	animation: none;
 }
 
+/* Mobile + small viewport: tools panel needs explicit overflow + touch-action so the
+   help-panel content scrolls/drags. Cloudscape's tools drawer otherwise locks the
+   inner panel when content exceeds viewport on touch devices. */
+/* restored post-fc3edc19 — load-bearing for logged-in tools panel scroll */
+[class*="awsui_tools_"][class*="awsui_root"],
+[class*="awsui_tools-container"],
+[class*="awsui_tools_"] [class*="awsui_help-panel"] {
+	overflow-y: auto !important;
+	-webkit-overflow-scrolling: touch;
+	overscroll-behavior: contain;
+	touch-action: pan-y;
+	max-height: calc(100vh - 56px);
+	padding-bottom: 120px;
+}
+
+/* Outer Cloudscape chrome — defanged from opaque to TRANSPARENT in both modes.
+   Light: was #ede5d4 to mask Cloudscape's default white.
+   Dark:  Cloudscape applies its own dark layout-bg by default; we want the
+          el-paso-nights starfield + music-viz canvas to show through here.
+   These rules previously won source-order against cdn-atmospheric.css's
+   transparent rules at same specificity → kept the chrome opaque, blocked
+   wallpaper. Both modes flipped to transparent. The cdn-atmospheric.css
+   translucent rules apply panel-tier alpha tint where appropriate (inner
+   nav drawer + right tools panel) so text stays legible. */
+.awsui-dark-mode [class*="navigation-container"],
+.awsui-dark-mode [class*="side-navigation"],
+.awsui-dark-mode [class*="navigation__drawer"],
+.awsui-dark-mode [class*="awsui_tools-container"],
+.awsui-dark-mode [class*="awsui_scrolling-background"]:not(#\9),
+.awsui-dark-mode [class*="awsui_breadcrumbs"]:not(#\9),
+:root:not(.awsui-dark-mode) [class*="navigation-container"],
+:root:not(.awsui-dark-mode) [class*="side-navigation"],
+:root:not(.awsui-dark-mode) [class*="navigation__drawer"],
+:root:not(.awsui-dark-mode) [class*="awsui_tools-container"],
+:root:not(.awsui-dark-mode) [class*="awsui_scrolling-background"]:not(#\9),
+:root:not(.awsui-dark-mode) [class*="awsui_breadcrumbs"]:not(#\9) {
+	background: transparent;
+	background-color: transparent;
+}
+
 .cdn-viz-active:not(.awsui-dark-mode)
 	[class*="awsui_scrolling-background"]:not(#\9),
 .cdn-viz-active:not(.awsui-dark-mode) [class*="awsui_breadcrumbs"]:not(#\9) {
@@ -370,12 +421,39 @@ main[class*="awsui_layout"] {
    produced flat cream output, AND triggered Safari text-rendering issue
    where text inside became "heavily blurred" (sub-pixel sampling under
    stacked backdrop-filter layers). No useful effect, real cost. Drop it. */
+/* header: suppress bg + side/top borders; keep a subtle bottom separator */
+.cdn-card [class*="awsui_header_"] {
+	background: transparent;
+	box-shadow: none;
+	border-top: none;
+	border-left: none;
+	border-right: none;
+	border-bottom: 1px solid rgba(139, 90, 43, 0.14);
+	padding-bottom: var(--cdn-space-sm, 8px);
+}
+.awsui-dark-mode .cdn-card [class*="awsui_header_"] {
+	border-bottom-color: rgba(144, 96, 240, 0.18);
+}
+
 .cdn-viz-active:not(.awsui-dark-mode) .cdn-card [class*="awsui_header_"] {
 	background: rgb(237, 229, 212);
 }
 
 .cdn-viz-active.awsui-dark-mode .cdn-card [class*="awsui_header_"] {
 	background: rgb(10, 12, 20);
+}
+
+main[class*="awsui_layout"] > [class*="navigation-container"],
+main[class*="awsui_layout"] > [class*="tools-container"],
+main[class*="awsui_layout"] > [class*="content-container"] {
+	block-size: auto !important;
+}
+
+/* Side panels: clear persistent player (~72px) + footer (~48px) so panels
+   don't bleed under or leave dead space above the footer. */
+main[class*="awsui_layout"] > [class*="navigation-container"],
+main[class*="awsui_layout"] > [class*="tools-container"] {
+	padding-bottom: 120px;
 }
 
 /* Side nav */
@@ -398,6 +476,20 @@ main[class*="awsui_layout"] {
 	border-right-color: transparent;
 }
 
+#top-nav [class*="top-navigation"] {
+	/* Already fully opaque via the gradient background declarations in TASK 6.
+	   Explicit reset of any inherited backdrop-filter. */
+}
+
+@supports (backdrop-filter: blur(0)) {
+	/* #top-nav gets blur reinforcement via .cdn-viz-active rule above —
+	   that's intentional. The rule here is the opt-out for NON-viz-active state. */
+	:not(.cdn-viz-active) #top-nav [class*="top-navigation"] {
+		backdrop-filter: none;
+		-webkit-backdrop-filter: none;
+	}
+}
+
 /* Top navigation blur reinforcement */
 .cdn-viz-active #top-nav [class*="top-navigation"] {
 	backdrop-filter: blur(4px) saturate(1.3);
@@ -415,19 +507,6 @@ main[class*="awsui_layout"] {
 	border: none;
 	box-shadow: none;
 }
-/* header: suppress bg + side/top borders; keep a subtle bottom separator */
-.cdn-card [class*="awsui_header_"] {
-	background: transparent;
-	box-shadow: none;
-	border-top: none;
-	border-left: none;
-	border-right: none;
-	border-bottom: 1px solid rgba(139, 90, 43, 0.14);
-	padding-bottom: var(--cdn-space-sm, 8px);
-}
-.awsui-dark-mode .cdn-card [class*="awsui_header_"] {
-	border-bottom-color: rgba(144, 96, 240, 0.18);
-}
 
 /* Mouseover tearing fix on cdn-card containers: Cloudscape Container fires
    a 0.18s `transition: all` on its awsui_root which animates background-color
@@ -437,33 +516,6 @@ main[class*="awsui_layout"] {
    it intact on Containers elsewhere on the page. */
 .cdn-card [class*="awsui_root"] {
 	transition: none;
-}
-main[class*="awsui_layout"] > [class*="navigation-container"],
-main[class*="awsui_layout"] > [class*="tools-container"],
-main[class*="awsui_layout"] > [class*="content-container"] {
-	block-size: auto !important;
-}
-
-/* Side panels: clear persistent player (~72px) + footer (~48px) so panels
-   don't bleed under or leave dead space above the footer. */
-main[class*="awsui_layout"] > [class*="navigation-container"],
-main[class*="awsui_layout"] > [class*="tools-container"] {
-	padding-bottom: 120px;
-}
-
-/* Mobile + small viewport: tools panel needs explicit overflow + touch-action so the
-   help-panel content scrolls/drags. Cloudscape's tools drawer otherwise locks the
-   inner panel when content exceeds viewport on touch devices. */
-/* restored post-fc3edc19 — load-bearing for logged-in tools panel scroll */
-[class*="awsui_tools_"][class*="awsui_root"],
-[class*="awsui_tools-container"],
-[class*="awsui_tools_"] [class*="awsui_help-panel"] {
-	overflow-y: auto !important;
-	-webkit-overflow-scrolling: touch;
-	overscroll-behavior: contain;
-	touch-action: pan-y;
-	max-height: calc(100vh - 56px);
-	padding-bottom: 120px;
 }
 
 /* v0.0.0131 — info/tools-toggle disappears past ~1 viewport of scroll.
@@ -542,41 +594,16 @@ nav[class*="awsui_navigation_"]:not([class*="awsui_navigation-toggle_"]),
 	}
 }
 
-/* Outer Cloudscape chrome — defanged from opaque to TRANSPARENT in both modes.
-   Light: was #ede5d4 to mask Cloudscape's default white.
-   Dark:  Cloudscape applies its own dark layout-bg by default; we want the
-          el-paso-nights starfield + music-viz canvas to show through here.
-   These rules previously won source-order against cdn-atmospheric.css's
-   transparent rules at same specificity → kept the chrome opaque, blocked
-   wallpaper. Both modes flipped to transparent. The cdn-atmospheric.css
-   translucent rules apply panel-tier alpha tint where appropriate (inner
-   nav drawer + right tools panel) so text stays legible. */
-:root:not(.awsui-dark-mode) [class*="awsui_scrolling-background"]:not(#\9),
-:root:not(.awsui-dark-mode) [class*="awsui_breadcrumbs"]:not(#\9),
-:root:not(.awsui-dark-mode) [class*="navigation-container"],
-:root:not(.awsui-dark-mode) [class*="side-navigation"],
-:root:not(.awsui-dark-mode) [class*="navigation__drawer"],
-:root:not(.awsui-dark-mode) [class*="awsui_tools-container"],
-.awsui-dark-mode [class*="awsui_scrolling-background"]:not(#\9),
-.awsui-dark-mode [class*="awsui_breadcrumbs"]:not(#\9),
-.awsui-dark-mode [class*="navigation-container"],
-.awsui-dark-mode [class*="side-navigation"],
-.awsui-dark-mode [class*="navigation__drawer"],
-.awsui-dark-mode [class*="awsui_tools-container"] {
-	background: transparent;
-	background-color: transparent;
-}
-
 /* Mobile toolbar breadcrumb strip — Cloudscape's visual-refresh AppLayout
    renders a sticky <section.awsui_mobile-toolbar_*> on mobile viewports with
    background-color: #ffffff. The older [class*="awsui_breadcrumbs"] rule misses
    this parent container. Also covers the universal-toolbar variant (v3 toolbar
    refresh path) which paints the same opaque white.
    Probe: scripts/probe-breadcrumb-banner.mjs — 2026-05-15 */
-:root:not(.awsui-dark-mode) [class*="awsui_mobile-toolbar"]:not(#\9),
-:root:not(.awsui-dark-mode) [class*="awsui_universal-toolbar"]:not(#\9),
 .awsui-dark-mode [class*="awsui_mobile-toolbar"]:not(#\9),
-.awsui-dark-mode [class*="awsui_universal-toolbar"]:not(#\9) {
+.awsui-dark-mode [class*="awsui_universal-toolbar"]:not(#\9),
+:root:not(.awsui-dark-mode) [class*="awsui_mobile-toolbar"]:not(#\9),
+:root:not(.awsui-dark-mode) [class*="awsui_universal-toolbar"]:not(#\9) {
 	background: transparent;
 	background-color: transparent;
 	box-shadow: none;
@@ -586,12 +613,12 @@ nav[class*="awsui_navigation_"]:not([class*="awsui_navigation-toggle_"]),
    variant uses awsui_refresh_* class on the header band. Older selectors
    (awsui_has-header_, awsui_header-background_) miss it. Probe found this
    element painting opaque cream at the top of /feed/ above NextMeetup. */
-:root:not(.awsui-dark-mode)
-	[class*="awsui_refresh_"][class*="awsui_header_"]:not(#\9) {
+.awsui-dark-mode [class*="awsui_refresh_"][class*="awsui_header_"]:not(#\9) {
 	background: transparent;
 	background-color: transparent;
 }
-.awsui-dark-mode [class*="awsui_refresh_"][class*="awsui_header_"]:not(#\9) {
+:root:not(.awsui-dark-mode)
+	[class*="awsui_refresh_"][class*="awsui_header_"]:not(#\9) {
 	background: transparent;
 	background-color: transparent;
 }
@@ -847,6 +874,47 @@ nav[class*="awsui_navigation_"]:not([class*="awsui_navigation-toggle_"]),
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	letter-spacing: 0.005em;
+}
+
+/* ── P3 touch-target compliance (WCAG 2.5.8 — 44×44 minimum) ──────────────
+   Visible circle: 32×32. Transparent padding extends tap zone to 44×44.
+   display:flex centers the SVG icon within the visible circle. */
+button[class*="awsui_navigation-toggle"],
+button[class*="awsui_navigation-close"],
+[class*="awsui_tools-toggle_"] button,
+button[class*="awsui_tools-toggle"] {
+	width: 32px !important;
+	height: 32px !important;
+	min-width: 32px !important;
+	min-height: 32px !important;
+	max-width: 32px !important;
+	max-height: 32px !important;
+	padding: 6px !important;
+	box-sizing: content-box !important;
+	aspect-ratio: 1 !important;
+	border-radius: 50% !important;
+	transition: none !important;
+	display: flex !important;
+	align-items: center !important;
+	justify-content: center !important;
+}
+
+@media (max-width: 690px) {
+	[class*="awsui_mobile-toolbar"] button[class*="awsui_navigation-toggle"],
+	[class*="awsui_mobile-toolbar"] [class*="awsui_tools-toggle_"] button,
+	[class*="awsui_mobile-toolbar"] button[class*="awsui_tools-toggle"],
+	[class*="awsui_universal-toolbar"] button[class*="awsui_navigation-toggle"],
+	[class*="awsui_universal-toolbar"] [class*="awsui_tools-toggle_"] button,
+	[class*="awsui_universal-toolbar"] button[class*="awsui_tools-toggle"] {
+		flex-shrink: 0 !important;
+		width: 32px !important;
+		height: 32px !important;
+		min-width: 32px !important;
+		padding: 6px !important;
+		box-sizing: content-box !important;
+		aspect-ratio: 1 !important;
+		border-radius: 50% !important;
+	}
 }
 
 /* ── Emoji toggle buttons: remove Cloudscape button chrome ──
@@ -1372,17 +1440,6 @@ nav[class*="awsui_navigation_"]:not([class*="awsui_navigation-toggle_"]),
    Selector pattern follows the existing [class*="awsui_..."] pattern used
    throughout this file. */
 
-/* Light mode: palette purple (#5a1f8a) for interactive links */
-:root:not(.awsui-dark-mode) [class*="awsui_breadcrumb-group"] a,
-:root:not(.awsui-dark-mode) [class*="breadcrumb-group"] a {
-	color: var(--cdn-purple); /* #5a1f8a — primary interactive, in-palette */
-}
-
-:root:not(.awsui-dark-mode) [class*="awsui_breadcrumb-group"] a:hover,
-:root:not(.awsui-dark-mode) [class*="breadcrumb-group"] a:hover {
-	color: var(--cdn-violet); /* #9060f0 — lighter on hover */
-}
-
 /* Dark mode: palette violet (#9060f0) — AAA contrast on dark navy backgrounds */
 .awsui-dark-mode [class*="awsui_breadcrumb-group"] a,
 .awsui-dark-mode [class*="breadcrumb-group"] a {
@@ -1392,6 +1449,17 @@ nav[class*="awsui_navigation_"]:not([class*="awsui_navigation-toggle_"]),
 .awsui-dark-mode [class*="awsui_breadcrumb-group"] a:hover,
 .awsui-dark-mode [class*="breadcrumb-group"] a:hover {
 	color: var(--cdn-lavender); /* #d7c7ee — lighter lavender on hover */
+}
+
+/* Light mode: palette purple (#5a1f8a) for interactive links */
+:root:not(.awsui-dark-mode) [class*="awsui_breadcrumb-group"] a,
+:root:not(.awsui-dark-mode) [class*="breadcrumb-group"] a {
+	color: var(--cdn-purple); /* #5a1f8a — primary interactive, in-palette */
+}
+
+:root:not(.awsui-dark-mode) [class*="awsui_breadcrumb-group"] a:hover,
+:root:not(.awsui-dark-mode) [class*="breadcrumb-group"] a:hover {
+	color: var(--cdn-violet); /* #9060f0 — lighter on hover */
 }
 
 /* Help panel — leader sections */
@@ -1667,19 +1735,6 @@ nav[class*="awsui_navigation_"]:not(
 
 /* Top nav — opaque (the nav bar itself; header strip BELOW it is the
    atmospheric zone). Already has solid gradient bg from TASK 6 above. */
-#top-nav [class*="top-navigation"] {
-	/* Already fully opaque via the gradient background declarations in TASK 6.
-	   Explicit reset of any inherited backdrop-filter. */
-}
-
-@supports (backdrop-filter: blur(0)) {
-	/* #top-nav gets blur reinforcement via .cdn-viz-active rule above —
-	   that's intentional. The rule here is the opt-out for NON-viz-active state. */
-	:not(.cdn-viz-active) #top-nav [class*="top-navigation"] {
-		backdrop-filter: none;
-		-webkit-backdrop-filter: none;
-	}
-}
 
 /* Footer — opaque, must paint above the page cream background.
    position:relative + z-index ensures the footer's dark mahogany gradient
@@ -1990,29 +2045,6 @@ nav[class*="awsui_navigation_"]:not(
 	display: block;
 }
 
-/* ── P3 touch-target compliance (WCAG 2.5.8 — 44×44 minimum) ──────────────
-   Visible circle: 32×32. Transparent padding extends tap zone to 44×44.
-   display:flex centers the SVG icon within the visible circle. */
-button[class*="awsui_navigation-toggle"],
-button[class*="awsui_navigation-close"],
-[class*="awsui_tools-toggle_"] button,
-button[class*="awsui_tools-toggle"] {
-	width: 32px !important;
-	height: 32px !important;
-	min-width: 32px !important;
-	min-height: 32px !important;
-	max-width: 32px !important;
-	max-height: 32px !important;
-	padding: 6px !important;
-	box-sizing: content-box !important;
-	aspect-ratio: 1 !important;
-	border-radius: 50% !important;
-	transition: none !important;
-	display: flex !important;
-	align-items: center !important;
-	justify-content: center !important;
-}
-
 #top-nav [class*="utility-wrapper"] a[class*="awsui_link"] {
 	min-width: 44px;
 	min-height: 44px;
@@ -2024,35 +2056,12 @@ button[class*="awsui_tools-toggle"] {
 /* 1. Keep button backings circular at ALL viewports (under 690px they were
    becoming vertical rectangles due to flex-shrink losing aspect ratio).
    Visible circle 32×32 + 6px padding = 44×44 touch target. */
-@media (max-width: 690px) {
-	[class*="awsui_mobile-toolbar"] button[class*="awsui_navigation-toggle"],
-	[class*="awsui_mobile-toolbar"] [class*="awsui_tools-toggle_"] button,
-	[class*="awsui_mobile-toolbar"] button[class*="awsui_tools-toggle"],
-	[class*="awsui_universal-toolbar"] button[class*="awsui_navigation-toggle"],
-	[class*="awsui_universal-toolbar"] [class*="awsui_tools-toggle_"] button,
-	[class*="awsui_universal-toolbar"] button[class*="awsui_tools-toggle"] {
-		flex-shrink: 0 !important;
-		width: 32px !important;
-		height: 32px !important;
-		min-width: 32px !important;
-		padding: 6px !important;
-		box-sizing: content-box !important;
-		aspect-ratio: 1 !important;
-		border-radius: 50% !important;
-	}
-}
 
 /* 2. Breadcrumb bar tall enough for vinyl record icons (~40px) */
 [class*="awsui_mobile-toolbar"]:not(#\9):not(#\10),
 [class*="awsui_universal-toolbar"]:not(#\9):not(#\10) {
 	min-height: 48px;
 	align-items: center;
-}
-
-/* A3 fix — desktop toolbar inner flex row vertical alignment */
-[class*="awsui_universal-toolbar"] > *,
-[class*="awsui_mobile-toolbar"] > * {
-	align-items: center !important;
 }
 
 /* 3. Breadcrumb + menu open icons vertically centered in shared chrome bar */
@@ -2099,11 +2108,6 @@ body.cdn-scrolled
 	transform: none !important;
 	pointer-events: auto !important;
 	visibility: visible !important;
-}
-[class*="awsui_breadcrumbs"] {
-	transition:
-		opacity 0.2s ease,
-		transform 0.2s ease;
 }
 
 /* ── Wave 17 A3 — desktop tools-toggle vertical alignment nudge ────────────

--- a/src/pages/feed/components/youtube-shorts-carousel.css
+++ b/src/pages/feed/components/youtube-shorts-carousel.css
@@ -161,16 +161,6 @@
 	}
 }
 
-/* Light-mode (default) — surface tint over the cream card background. */
-:root:not(.awsui-dark-mode) .feed-shorts-carousel__thumb {
-	background: rgba(255, 255, 255, 0.4);
-}
-
-:root:not(.awsui-dark-mode) .feed-shorts-carousel__thumb:hover,
-:root:not(.awsui-dark-mode) .feed-shorts-carousel__thumb:focus-visible {
-	background: rgba(255, 255, 255, 0.7);
-}
-
 /* Dark-mode parity — inverse tint, brighter title text, lighter borders. */
 .awsui-dark-mode .feed-shorts-carousel__thumb {
 	background: rgba(255, 255, 255, 0.04);
@@ -180,6 +170,16 @@
 .awsui-dark-mode .feed-shorts-carousel__thumb:hover,
 .awsui-dark-mode .feed-shorts-carousel__thumb:focus-visible {
 	background: rgba(255, 255, 255, 0.1);
+}
+
+/* Light-mode (default) — surface tint over the cream card background. */
+:root:not(.awsui-dark-mode) .feed-shorts-carousel__thumb {
+	background: rgba(255, 255, 255, 0.4);
+}
+
+:root:not(.awsui-dark-mode) .feed-shorts-carousel__thumb:hover,
+:root:not(.awsui-dark-mode) .feed-shorts-carousel__thumb:focus-visible {
+	background: rgba(255, 255, 255, 0.7);
 }
 
 .awsui-dark-mode .feed-shorts-carousel__title {

--- a/src/pages/feed/styles.css
+++ b/src/pages/feed/styles.css
@@ -478,6 +478,18 @@
 	contain-intrinsic-size: 0 400px; /* estimated card height, prevents scroll-bar jump */
 }
 
+.awsui-dark-mode .cdn-card {
+	background-color: rgba(14, 14, 28, 0.52);
+	background-image: none;
+	backdrop-filter: blur(20px) saturate(1.1);
+	-webkit-backdrop-filter: blur(20px) saturate(1.1);
+	box-shadow:
+		0 1px 2px rgba(0, 0, 0, 0.3),
+		inset 0 1px 0 rgba(200, 190, 220, 0.08);
+	border-radius: var(--cdn-radius-md, 8px);
+	border: 1px solid rgba(180, 170, 200, 0.12);
+}
+
 /* design-system baseline — glass surface for feed cards (light mode).
    Cards are glass panes floating in front of the 3D scene. */
 :root:not(.awsui-dark-mode) .cdn-card {
@@ -497,16 +509,15 @@
 		background-color: rgba(250, 247, 240, 0.26);
 	}
 }
-.awsui-dark-mode .cdn-card {
-	background-color: rgba(14, 14, 28, 0.52);
-	background-image: none;
-	backdrop-filter: blur(20px) saturate(1.1);
-	-webkit-backdrop-filter: blur(20px) saturate(1.1);
-	box-shadow:
-		0 1px 2px rgba(0, 0, 0, 0.3),
-		inset 0 1px 0 rgba(200, 190, 220, 0.08);
-	border-radius: var(--cdn-radius-md, 8px);
-	border: 1px solid rgba(180, 170, 200, 0.12);
+
+/* glassmorphism — suppress Container chrome so the cdn-card glass surface shows.
+   descendant (not direct-child) combinator handles any React wrapper divs between
+   cdn-card and the Cloudscape root element. */
+.cdn-card [class*="awsui_root"],
+.cdn-card [class*="awsui_content_"] {
+	background: transparent;
+	border: none;
+	box-shadow: none;
 }
 
 /* wave 23.5 — fill container: Cloudscape Container root + content must stretch
@@ -524,16 +535,6 @@
 
 .feed-grid__cell.cdn-card > [class*="awsui_root"] > [class*="awsui_content_"] {
 	flex: 1 1 auto;
-}
-
-/* glassmorphism — suppress Container chrome so the cdn-card glass surface shows.
-   descendant (not direct-child) combinator handles any React wrapper divs between
-   cdn-card and the Cloudscape root element. */
-.cdn-card [class*="awsui_root"],
-.cdn-card [class*="awsui_content_"] {
-	background: transparent;
-	border: none;
-	box-shadow: none;
 }
 
 /* Wave cycle-2: text legibility backing at reduced card alpha */
@@ -1027,6 +1028,32 @@
 	}
 }
 
+.awsui-dark-mode [class*="awsui_link"][class*="variant-info"] {
+	display: inline-flex;
+	align-items: center;
+	padding: 1px 8px;
+	border-radius: 10px;
+	font-size: 0.68rem;
+	font-weight: 600;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	border: 1px solid rgba(144, 96, 240, 0.4);
+	background: rgba(144, 96, 240, 0.1);
+	color: var(--cdn-violet, #9060f0);
+	text-decoration: none;
+	transition:
+		background 0.18s ease,
+		border-color 0.18s ease,
+		box-shadow 0.18s ease;
+}
+
+.awsui-dark-mode [class*="awsui_link"][class*="variant-info"]:hover {
+	background: rgba(144, 96, 240, 0.2);
+	border-color: rgba(144, 96, 240, 0.7);
+	color: var(--cdn-lavender, #d7c7ee);
+	box-shadow: 0 0 8px rgba(144, 96, 240, 0.25);
+}
+
 /* ---------- Info button pill badge — Cloudscape Link variant="info" ---------- */
 /* Renders the header info link as a small purple/violet pill badge chip
    rather than Cloudscape's default blue text link. Scoped to ContentLayout header band. */
@@ -1057,36 +1084,15 @@
 	box-shadow: 0 0 6px rgba(144, 96, 240, 0.2);
 }
 
-.awsui-dark-mode [class*="awsui_link"][class*="variant-info"] {
-	display: inline-flex;
-	align-items: center;
-	padding: 1px 8px;
-	border-radius: 10px;
-	font-size: 0.68rem;
-	font-weight: 600;
-	letter-spacing: 0.06em;
-	text-transform: uppercase;
-	border: 1px solid rgba(144, 96, 240, 0.4);
-	background: rgba(144, 96, 240, 0.1);
-	color: var(--cdn-violet, #9060f0);
-	text-decoration: none;
-	transition:
-		background 0.18s ease,
-		border-color 0.18s ease,
-		box-shadow 0.18s ease;
-}
-
-.awsui-dark-mode [class*="awsui_link"][class*="variant-info"]:hover {
-	background: rgba(144, 96, 240, 0.2);
-	border-color: rgba(144, 96, 240, 0.7);
-	color: var(--cdn-lavender, #d7c7ee);
-	box-shadow: 0 0 8px rgba(144, 96, 240, 0.25);
-}
-
 /* ---------- Global link color — extend design system palette to Cloudscape Links ---------- */
 /* Cloudscape ships its own blue token for <Link>. Override at the app root so
    every Cloudscape Link picks up the cdn purple/violet/lavender palette. */
-
+.awsui-dark-mode [class*="awsui_link"] {
+	color: var(--cdn-violet, #9060f0);
+}
+.awsui-dark-mode [class*="awsui_link"]:hover {
+	color: var(--cdn-lavender, #d7c7ee);
+}
 :root:not(.awsui-dark-mode) [class*="awsui_link"] {
 	color: var(--cdn-purple, #5a1f8a);
 }
@@ -1094,19 +1100,12 @@
 	color: var(--cdn-violet, #9060f0);
 }
 
-.awsui-dark-mode [class*="awsui_link"] {
-	color: var(--cdn-violet, #9060f0);
-}
-.awsui-dark-mode [class*="awsui_link"]:hover {
-	color: var(--cdn-lavender, #d7c7ee);
-}
-
 /* plain anchor tags inside content (next-meetup CTA, help-panel ul anchors) */
-:root:not(.awsui-dark-mode) .cdn-card a:not([class*="awsui_link"]) {
-	color: var(--cdn-purple, #5a1f8a);
-}
 .awsui-dark-mode .cdn-card a:not([class*="awsui_link"]) {
 	color: var(--cdn-violet, #9060f0);
+}
+:root:not(.awsui-dark-mode) .cdn-card a:not([class*="awsui_link"]) {
+	color: var(--cdn-purple, #5a1f8a);
 }
 
 /* ---------- Live hero — full-width above NextMeetup when a stream is live ---------- */

--- a/src/sites/auth/_layout/auth-form.css
+++ b/src/sites/auth/_layout/auth-form.css
@@ -189,13 +189,11 @@
 	transform: translateY(-1px);
 }
 
-/* ── primary button inner span — force white text over cloudscape color ── */
+.cdn-auth-form:not(#\9):not(#\9):not(#\9) button[class*="variant-primary"] span,
 .cdn-auth-form:not(#\9):not(#\9):not(
 		#\9
-	) [class*="awsui_button"][class*="variant-primary"]
-	span,
-.cdn-auth-form:not(#\9):not(#\9):not(#\9)
-	button[class*="variant-primary"]
+	)
+	[class*="awsui_button"][class*="variant-primary"]
 	span {
 	color: #fff;
 }

--- a/src/sites/auth/_layout/styles.css
+++ b/src/sites/auth/_layout/styles.css
@@ -392,6 +392,89 @@ body.cdn-auth-subdomain.awsui-dark-mode:not(#\9):not(#\9):not(#\9)
 	background: var(--cdn-streak-h-dark);
 }
 
+/* Wrapper sits on the SpaceBetween button wrapper inside each Form; descend
+   into the rendered cloudscape button to paint the shimmer / shake / success.
+   !important needed to beat the existing variant-primary background override
+   that lives at the top of this file. */
+.cdn-auth-submit-state.verifying button[class*="variant-primary"],
+.cdn-auth-submit-state.verifying
+	[class*="awsui_button"][class*="variant-primary"] {
+	background: linear-gradient(
+		90deg,
+		var(--cdn-amber) 0%,
+		var(--cdn-aws-orange) 25%,
+		var(--cdn-violet) 50%,
+		var(--cdn-aws-orange) 75%,
+		var(--cdn-amber) 100%
+	);
+	background-size: 200% 100%;
+	border-color: transparent;
+	color: var(--cdn-white);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.cdn-auth-submit-state.verifying button[class*="variant-primary"],
+	.cdn-auth-submit-state.verifying
+		[class*="awsui_button"][class*="variant-primary"] {
+		animation: cdn-auth-verifying-shimmer 1.4s linear infinite;
+	}
+
+	.cdn-auth-submit-state.failed button[class*="variant-primary"],
+	.cdn-auth-submit-state.failed
+		[class*="awsui_button"][class*="variant-primary"] {
+		animation: cdn-auth-shake 350ms cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+	}
+
+	.cdn-auth-submit-state.success button[class*="variant-primary"],
+	.cdn-auth-submit-state.success
+		[class*="awsui_button"][class*="variant-primary"] {
+		animation: cdn-auth-success-flash 600ms ease-out both;
+	}
+}
+
+.cdn-auth-submit-state.success button[class*="variant-primary"],
+.cdn-auth-submit-state.success
+	[class*="awsui_button"][class*="variant-primary"] {
+	background: var(--cdn-violet);
+	border-color: var(--cdn-violet);
+	color: var(--cdn-white);
+}
+
+/* Tiny ✓ marker — rendered as a sibling span by app.tsx when state=success.
+   Sits absolutely beside the button via the wrapper's relative positioning. */
+.cdn-auth-submit-state {
+	position: relative;
+	display: inline-block;
+}
+
+.cdn-auth-success-check {
+	display: inline-block;
+	margin-left: 8px;
+	color: var(--cdn-violet);
+	font-weight: 700;
+	font-size: 1.1rem;
+	animation: cdn-auth-header-in 250ms ease-out both;
+}
+
+.awsui-dark-mode .cdn-auth-success-check {
+	color: var(--cdn-lavender);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.cdn-auth-submit-state.verifying button[class*="variant-primary"],
+	.cdn-auth-submit-state.verifying
+		[class*="awsui_button"][class*="variant-primary"],
+	.cdn-auth-submit-state.failed button[class*="variant-primary"],
+	.cdn-auth-submit-state.failed
+		[class*="awsui_button"][class*="variant-primary"],
+	.cdn-auth-submit-state.success button[class*="variant-primary"],
+	.cdn-auth-submit-state.success
+		[class*="awsui_button"][class*="variant-primary"],
+	.cdn-auth-success-check {
+		animation: none;
+	}
+}
+
 /* ── Entrance choreography — postcard landing ────────────────────────────────
    Header fades in with slight rotation settle; card drops in like a postcard
    landing on a desk. Both gated on prefers-reduced-motion. */
@@ -460,6 +543,24 @@ body.cdn-auth-subdomain.awsui-dark-mode:not(#\9):not(#\9):not(#\9)
    Dark mode: violet stays — it pops against navy and reads as the brand
    accent on dark backgrounds. */
 
+.awsui-dark-mode .cdn-auth-card button[class*="variant-primary"],
+.awsui-dark-mode
+	.cdn-auth-card
+	[class*="awsui_button"][class*="variant-primary"] {
+	background: var(--cdn-violet);
+	border-color: var(--cdn-violet);
+	color: var(--cdn-white);
+}
+
+.awsui-dark-mode .cdn-auth-card button[class*="variant-primary"]:hover,
+.awsui-dark-mode
+	.cdn-auth-card
+	[class*="awsui_button"][class*="variant-primary"]:hover {
+	background: var(--cdn-purple);
+	border-color: var(--cdn-purple);
+	box-shadow: 0 0 0 3px rgba(144, 96, 240, 0.22);
+}
+
 :root:not(.awsui-dark-mode)
 	.cdn-auth-card
 	[class*="awsui_button"][class*="variant-primary"],
@@ -478,24 +579,6 @@ body.cdn-auth-subdomain.awsui-dark-mode:not(#\9):not(#\9):not(#\9)
 	background: color-mix(in srgb, var(--cdn-amber) 80%, black 20%);
 	border-color: color-mix(in srgb, var(--cdn-amber) 80%, black 20%);
 	box-shadow: 0 0 0 3px rgba(139, 90, 43, 0.22);
-}
-
-.awsui-dark-mode
-	.cdn-auth-card
-	[class*="awsui_button"][class*="variant-primary"],
-.awsui-dark-mode .cdn-auth-card button[class*="variant-primary"] {
-	background: var(--cdn-violet);
-	border-color: var(--cdn-violet);
-	color: var(--cdn-white);
-}
-
-.awsui-dark-mode
-	.cdn-auth-card
-	[class*="awsui_button"][class*="variant-primary"]:hover,
-.awsui-dark-mode .cdn-auth-card button[class*="variant-primary"]:hover {
-	background: var(--cdn-purple);
-	border-color: var(--cdn-purple);
-	box-shadow: 0 0 0 3px rgba(144, 96, 240, 0.22);
 }
 
 /* ── Secondary button (Cancel/Previous) — recede behind the primary ────────
@@ -654,89 +737,6 @@ body.cdn-auth-subdomain.awsui-dark-mode:not(#\9):not(#\9):not(#\9)
 	100% {
 		background-color: var(--cdn-violet);
 		filter: brightness(1);
-	}
-}
-
-/* Wrapper sits on the SpaceBetween button wrapper inside each Form; descend
-   into the rendered cloudscape button to paint the shimmer / shake / success.
-   !important needed to beat the existing variant-primary background override
-   that lives at the top of this file. */
-.cdn-auth-submit-state.verifying button[class*="variant-primary"],
-.cdn-auth-submit-state.verifying
-	[class*="awsui_button"][class*="variant-primary"] {
-	background: linear-gradient(
-		90deg,
-		var(--cdn-amber) 0%,
-		var(--cdn-aws-orange) 25%,
-		var(--cdn-violet) 50%,
-		var(--cdn-aws-orange) 75%,
-		var(--cdn-amber) 100%
-	);
-	background-size: 200% 100%;
-	border-color: transparent;
-	color: var(--cdn-white);
-}
-
-@media (prefers-reduced-motion: no-preference) {
-	.cdn-auth-submit-state.verifying button[class*="variant-primary"],
-	.cdn-auth-submit-state.verifying
-		[class*="awsui_button"][class*="variant-primary"] {
-		animation: cdn-auth-verifying-shimmer 1.4s linear infinite;
-	}
-
-	.cdn-auth-submit-state.failed button[class*="variant-primary"],
-	.cdn-auth-submit-state.failed
-		[class*="awsui_button"][class*="variant-primary"] {
-		animation: cdn-auth-shake 350ms cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
-	}
-
-	.cdn-auth-submit-state.success button[class*="variant-primary"],
-	.cdn-auth-submit-state.success
-		[class*="awsui_button"][class*="variant-primary"] {
-		animation: cdn-auth-success-flash 600ms ease-out both;
-	}
-}
-
-.cdn-auth-submit-state.success button[class*="variant-primary"],
-.cdn-auth-submit-state.success
-	[class*="awsui_button"][class*="variant-primary"] {
-	background: var(--cdn-violet);
-	border-color: var(--cdn-violet);
-	color: var(--cdn-white);
-}
-
-/* Tiny ✓ marker — rendered as a sibling span by app.tsx when state=success.
-   Sits absolutely beside the button via the wrapper's relative positioning. */
-.cdn-auth-submit-state {
-	position: relative;
-	display: inline-block;
-}
-
-.cdn-auth-success-check {
-	display: inline-block;
-	margin-left: 8px;
-	color: var(--cdn-violet);
-	font-weight: 700;
-	font-size: 1.1rem;
-	animation: cdn-auth-header-in 250ms ease-out both;
-}
-
-.awsui-dark-mode .cdn-auth-success-check {
-	color: var(--cdn-lavender);
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.cdn-auth-submit-state.verifying button[class*="variant-primary"],
-	.cdn-auth-submit-state.verifying
-		[class*="awsui_button"][class*="variant-primary"],
-	.cdn-auth-submit-state.failed button[class*="variant-primary"],
-	.cdn-auth-submit-state.failed
-		[class*="awsui_button"][class*="variant-primary"],
-	.cdn-auth-submit-state.success button[class*="variant-primary"],
-	.cdn-auth-submit-state.success
-		[class*="awsui_button"][class*="variant-primary"],
-	.cdn-auth-success-check {
-		animation: none;
 	}
 }
 


### PR DESCRIPTION
Track 1 of issue #261 biome warning cleanup.

- Clears all 85 `lint/style/noDescendingSpecificity` warnings via behavior-preserving CSS selector reordering (no property-value changes)
- Total warnings: 260 → 175
- Build green (tsc + vite)
- Headless visual verification PASS (zero regression on /feed, /home, /theme — desktop+mobile, light+dark)

Remaining tracks (noExplicitAny 52, noNonNullAssertion 49, misc ~74) follow as separate PRs.

References #261