### PR TITLE
chore(biome): type Babylon Engine/Scene refs, drop any (#261 track 2a)

### DIFF
--- a/src/components/babylon-spin-demo/index.tsx
+++ b/src/components/babylon-spin-demo/index.tsx
@@ -4,6 +4,8 @@
 //
 // Wave 66 — added IntersectionObserver gate + babylon-budget integration.
 // Engine is disposed when the carousel scrolls off-screen and re-created on re-entry.
+import type { Engine } from "@babylonjs/core/Engines/engine";
+import type { Scene } from "@babylonjs/core/scene";
 import { useEffect, useRef } from "react";
 import { loadBabylonCommon } from "../../lib/babylon-loader";
 import {
@@ -24,12 +26,11 @@ export default function BabylonSpinDemo({
 		if (!canvas) return;
 
 		let disposed = false;
-		// biome-ignore lint/suspicious/noExplicitAny: dynamic babylon import
-		let _eng: any = null;
+		let _eng: Engine | null = null;
 		let ro: ResizeObserver | null = null;
 		let io: IntersectionObserver | null = null;
 
-		let currentScene: any = null; // biome-ignore lint/suspicious/noExplicitAny: dynamic babylon scene
+		let currentScene: Scene | null = null;
 
 		function teardown() {
 			ro?.disconnect();
@@ -89,7 +90,10 @@ export default function BabylonSpinDemo({
 
 			// scene needs an active camera before view registration; the
 			// ArcRotateCamera created above is implicitly the activeCamera.
-			registerSceneView(canvas, scene.activeCamera!, render);
+			const cam = scene.activeCamera;
+			if (cam) {
+				registerSceneView(canvas, cam, render);
+			}
 		}
 
 		// IntersectionObserver: only run when carousel is on-screen

--- a/src/components/footer/atmosphere-ribbon.tsx
+++ b/src/components/footer/atmosphere-ribbon.tsx
@@ -6,6 +6,8 @@
 // Wave 66 — added IntersectionObserver gate + babylon-budget integration.
 // Wave 70b — fade-in: ribbon starts opacity:0, fades in once loaded.
 
+import type { Engine } from "@babylonjs/core/Engines/engine";
+import type { Scene } from "@babylonjs/core/scene";
 import { useEffect, useRef, useState } from "react";
 import { loadBabylonCommon } from "../../lib/babylon-loader";
 import {
@@ -57,8 +59,7 @@ function RibbonFallback({ onReady }: { onReady: () => void }) {
 
 function RibbonScene({ hour, onReady }: { hour: number; onReady: () => void }) {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
-	// biome-ignore lint/suspicious/noExplicitAny: dynamic babylon import
-	const engRef = useRef<any>(null);
+	const engRef = useRef<Engine | null>(null);
 
 	useEffect(() => {
 		const canvas = canvasRef.current;
@@ -77,7 +78,7 @@ function RibbonScene({ hour, onReady }: { hour: number; onReady: () => void }) {
 		const [sr, sg, sb, sa] = skyColor(tod);
 		const xNorm = sunHourToX(hour); // 0=left, 1=right
 
-		let currentScene: any = null; // biome-ignore lint/suspicious/noExplicitAny: dynamic babylon scene
+		let currentScene: Scene | null = null;
 		let scrollStartHandler: (() => void) | null = null;
 		let scrollEndHandler: (() => void) | null = null;
 

--- a/src/components/weather/atmosphere-scene.tsx
+++ b/src/components/weather/atmosphere-scene.tsx
@@ -15,6 +15,8 @@
 // Epilepsy rules: NO flicker, NO strobe. Only steady glows, slow animations,
 // and a single 12-s ease arc for thunderstorm.
 
+import type { Engine } from "@babylonjs/core/Engines/engine";
+import type { Scene } from "@babylonjs/core/scene";
 import { useEffect, useRef } from "react";
 import { loadBabylonCommon } from "../../lib/babylon-loader";
 import {
@@ -76,8 +78,7 @@ export default function AtmosphereScene({
 	hour,
 }: AtmosphereSceneProps) {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
-	// biome-ignore lint/suspicious/noExplicitAny: dynamic babylon import
-	const engRef = useRef<any>(null);
+	const engRef = useRef<Engine | null>(null);
 	// Stable ref so the IO callback always reads current props without re-running the effect
 	const propsRef = useRef({ weatherCode, hour });
 	propsRef.current = { weatherCode, hour };
@@ -88,8 +89,7 @@ export default function AtmosphereScene({
 		if (!canvas) return;
 
 		let disposed = false;
-		// biome-ignore lint/suspicious/noExplicitAny: dynamic babylon import
-		let eng: any = null;
+		let eng: Engine | null = null;
 		let ro: ResizeObserver | null = null;
 		let io: IntersectionObserver | null = null;
 
@@ -97,7 +97,7 @@ export default function AtmosphereScene({
 			"(prefers-reduced-motion: reduce)",
 		).matches;
 
-		let currentScene: any = null; // biome-ignore lint/suspicious/noExplicitAny: dynamic babylon scene
+		let currentScene: Scene | null = null;
 
 		function teardown() {
 			ro?.disconnect();
@@ -317,15 +317,16 @@ export default function AtmosphereScene({
 
 			// ResizeObserver
 			ro = new ResizeObserver(() => {
-				eng.resize();
+				if (eng) eng.resize();
 			});
 			ro.observe(canvas);
 
-			if (reduced) {
-				registerSceneView(canvas, scene.activeCamera!, render);
-				scene.render();
-			} else {
-				registerSceneView(canvas, scene.activeCamera!, render);
+			const activeCam = scene.activeCamera;
+			if (activeCam) {
+				registerSceneView(canvas, activeCam, render);
+				if (reduced) {
+					scene.render();
+				}
 			}
 		}
 

--- a/src/components/weather/index.tsx
+++ b/src/components/weather/index.tsx
@@ -159,19 +159,17 @@ export default function Weather() {
 			});
 		};
 		// useEffect only runs in the browser — window is always defined here
-		let timerId: number | undefined;
+		let timerId: ReturnType<typeof setTimeout> | undefined;
 		let idleCbId: number | undefined;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const win = window as any;
 		if ("requestIdleCallback" in window) {
 			idleCbId = requestIdleCallback(doFetch, { timeout: 2000 });
 		} else {
-			timerId = win.setTimeout(doFetch, 1500);
+			timerId = setTimeout(doFetch, 1500);
 		}
 		return () => {
 			cancelled = true;
 			if (idleCbId !== undefined) cancelIdleCallback(idleCbId);
-			if (timerId !== undefined) win.clearTimeout(timerId);
+			if (timerId !== undefined) clearTimeout(timerId);
 		};
 	}, [city]);
 


### PR DESCRIPTION
Track 2a of issue #261.

Replaces 4 explicit `any` in Babylon components with `@babylonjs/core` `Engine`/`Scene` types:
- `babylon-spin-demo/index.tsx`
- `footer/atmosphere-ribbon.tsx`
- `weather/atmosphere-scene.tsx`
- `weather/index.tsx`

Nullable `activeCamera` null-guarded (no non-null assertions). `timerId` typed properly.

Warnings: 175 → 165 (10 cleared). Build green.

References #261.

**Note:** Remaining `noExplicitAny` (WebAuthn, data/API, test mocks) tracked in #261 for follow-up batches.