### PR TITLE
chore(biome): drive lint warnings to zero (#261)

### DIFF
--- a/src/components/feedback-form/__tests__/index.test.tsx
+++ b/src/components/feedback-form/__tests__/index.test.tsx
@@ -2,10 +2,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-type AnyProps = Record<string, unknown> & {
-	children?: React.ReactNode;
-	footer?: React.ReactNode;
-};
+type MockProps = { [key: string]: React.ReactNode };
 
 // ── FileUpload mock — exposes a trigger function via data-testid ─────────────
 // The mock stores the onChange prop in a ref accessible to tests so they
@@ -13,19 +10,37 @@ type AnyProps = Record<string, unknown> & {
 let fileUploadOnChange: ((files: File[]) => void) | null = null;
 
 vi.mock("@cloudscape-design/components/file-upload", () => ({
-	default: ({ onChange, value }: AnyProps) => {
+	default: ({
+		onChange,
+		value,
+	}: {
+		onChange?: (evt: { detail: { value: File[] } }) => void;
+		value?: File[];
+	}) => {
 		fileUploadOnChange = (files: File[]) =>
-			(onChange as Function)?.({ detail: { value: files } });
+			onChange?.({
+				detail: { value: files },
+			});
 		return React.createElement("div", {
 			"data-testid": "file-upload",
-			"data-file-count": (value as File[])?.length ?? 0,
+			"data-file-count": value?.length ?? 0,
 		});
 	},
 }));
 
 // ── Other Cloudscape mocks ───────────────────────────────────────────────────
 vi.mock("@cloudscape-design/components/modal", () => ({
-	default: ({ children, footer, header, visible }: AnyProps) =>
+	default: ({
+		children,
+		footer,
+		header,
+		visible,
+	}: {
+		children?: React.ReactNode;
+		footer?: React.ReactNode;
+		header?: React.ReactNode;
+		visible?: boolean;
+	}) =>
 		visible
 			? React.createElement(
 					"div",
@@ -37,15 +52,22 @@ vi.mock("@cloudscape-design/components/modal", () => ({
 			: null,
 }));
 vi.mock("@cloudscape-design/components/button", () => ({
-	default: ({ children, onClick }: AnyProps) =>
-		React.createElement(
-			"button",
-			{ onClick: onClick as React.MouseEventHandler },
-			children,
-		),
+	default: ({
+		children,
+		onClick,
+	}: {
+		children?: React.ReactNode;
+		onClick?: React.MouseEventHandler;
+	}) => React.createElement("button", { type: "button", onClick }, children),
 }));
 vi.mock("@cloudscape-design/components/form", () => ({
-	default: ({ children, errorText }: AnyProps) =>
+	default: ({
+		children,
+		errorText,
+	}: {
+		children?: React.ReactNode;
+		errorText?: string;
+	}) =>
 		React.createElement(
 			"div",
 			{ "data-testid": "form", "data-error": errorText },
@@ -53,7 +75,15 @@ vi.mock("@cloudscape-design/components/form", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/form-field", () => ({
-	default: ({ children, errorText, label }: AnyProps) =>
+	default: ({
+		children,
+		errorText,
+		label,
+	}: {
+		children?: React.ReactNode;
+		errorText?: string;
+		label?: string;
+	}) =>
 		React.createElement(
 			"div",
 			{
@@ -64,42 +94,62 @@ vi.mock("@cloudscape-design/components/form-field", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/input", () => ({
-	default: ({ value, onChange, ariaLabel }: AnyProps) =>
+	default: ({
+		value,
+		onChange,
+		ariaLabel,
+	}: {
+		value?: string;
+		onChange?: (evt: { detail: { value: string } }) => void;
+		ariaLabel?: string;
+	}) =>
 		React.createElement("input", {
 			"aria-label": String(ariaLabel ?? ""),
 			value: value as string,
 			onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-				(onChange as Function)?.({ detail: { value: e.target.value } }),
+				onChange?.({
+					detail: { value: e.target.value },
+				}),
 		}),
 }));
 vi.mock("@cloudscape-design/components/textarea", () => ({
-	default: ({ value, onChange, ariaLabel }: AnyProps) =>
+	default: ({
+		value,
+		onChange,
+		ariaLabel,
+	}: {
+		value?: string;
+		onChange?: (evt: { detail: { value: string } }) => void;
+		ariaLabel?: string;
+	}) =>
 		React.createElement("textarea", {
 			"aria-label": String(ariaLabel ?? ""),
 			value: value as string,
 			onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-				(onChange as Function)?.({ detail: { value: e.target.value } }),
+				onChange?.({
+					detail: { value: e.target.value },
+				}),
 		}),
 }));
 vi.mock("@cloudscape-design/components/alert", () => ({
-	default: ({ children, action }: AnyProps) =>
-		React.createElement(
-			"div",
-			{ role: "alert" },
-			children,
-			(action ?? null) as React.ReactNode,
-		),
+	default: ({ children, action }: MockProps) =>
+		React.createElement("div", { role: "alert" }, children, action),
 }));
 vi.mock("@cloudscape-design/components/link", () => ({
-	default: ({ children, href }: AnyProps) =>
-		React.createElement("a", { href: String(href ?? "") }, children),
+	default: ({
+		children,
+		href,
+	}: {
+		children?: React.ReactNode;
+		href?: string;
+	}) => React.createElement("a", { href: String(href ?? "") }, children),
 }));
 vi.mock("@cloudscape-design/components/box", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/space-between", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 

--- a/src/components/footer/__tests__/atmosphere-ribbon.test.tsx
+++ b/src/components/footer/__tests__/atmosphere-ribbon.test.tsx
@@ -21,14 +21,16 @@ vi.mock("@babylonjs/core", () => {
 	};
 
 	class Engine {
-		constructor() {
-			Object.assign(this, eng);
-		}
+		runRenderLoop = eng.runRenderLoop;
+		stopRenderLoop = eng.stopRenderLoop;
+		dispose = eng.dispose;
+		resize = eng.resize;
 	}
 	class Scene {
-		constructor() {
-			Object.assign(this, scene);
-		}
+		clearColor = scene.clearColor;
+		render = scene.render;
+		beginAnimation = scene.beginAnimation;
+		ambientColor = scene.ambientColor;
 	}
 	class ArcRotateCamera {
 		inputs = { clear: vi.fn() };
@@ -40,9 +42,8 @@ vi.mock("@babylonjs/core", () => {
 		orthoTop = 0;
 	}
 	class StandardMaterial {
-		constructor() {
-			Object.assign(this, { emissiveColor: null, disableLighting: false });
-		}
+		emissiveColor = null;
+		disableLighting = false;
 	}
 	class Animation {
 		constructor(public name: string) {}
@@ -79,8 +80,17 @@ vi.mock("@babylonjs/core", () => {
 		ArcRotateCamera,
 		StandardMaterial,
 		Animation,
-		Color4: class Color4 {},
-		Color3: class Color3 {},
+		Color4: class Color4 {
+			r = 0;
+			g = 0;
+			b = 0;
+			a = 0;
+		},
+		Color3: class Color3 {
+			r = 0;
+			g = 0;
+			b = 0;
+		},
 		Vector3: class Vector3 {
 			static Zero() {
 				return {};

--- a/src/components/footer/__tests__/leader-card.test.tsx
+++ b/src/components/footer/__tests__/leader-card.test.tsx
@@ -2,20 +2,30 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-type AnyProps = Record<string, unknown> & { children?: React.ReactNode };
+type MockProps = { [key: string]: React.ReactNode };
 
 // --- Cloudscape component mocks ---
 
 vi.mock("@cloudscape-design/components/box", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", { "data-testid": "box" }, children),
 }));
 vi.mock("@cloudscape-design/components/space-between", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/link", () => ({
-	default: ({ children, href, external, ariaLabel }: AnyProps) =>
+	default: ({
+		children,
+		href,
+		external,
+		ariaLabel,
+	}: {
+		children?: React.ReactNode;
+		href?: string;
+		external?: boolean;
+		ariaLabel?: string;
+	}) =>
 		React.createElement(
 			"a",
 			{
@@ -27,7 +37,13 @@ vi.mock("@cloudscape-design/components/link", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/badge", () => ({
-	default: ({ children, color }: AnyProps) =>
+	default: ({
+		children,
+		color,
+	}: {
+		children?: React.ReactNode;
+		color?: string;
+	}) =>
 		React.createElement(
 			"span",
 			{ "data-testid": "badge", "data-color": color },

--- a/src/components/footer/leader-card.tsx
+++ b/src/components/footer/leader-card.tsx
@@ -48,6 +48,7 @@ export default function LeaderCard({ leader }: LeaderCardProps) {
 				</Box>
 			)}
 
+			{/* biome-ignore lint/a11y/useSemanticElements: CSS pill styling targets [role="listitem"] selectors; converting to ul/li would break those selectors */}
 			<div
 				className="cdn-footer-social"
 				role="list"
@@ -67,6 +68,7 @@ function PlaceholderCTA({ meetupUrl }: { meetupUrl: string | null }) {
 	const { t } = useTranslation();
 	const url = meetupUrl ?? "https://www.meetup.com/awsugclouddelnorte/";
 	return (
+		// biome-ignore lint/a11y/useSemanticElements: CSS pill styling targets [role="listitem"] selectors; converting to li would break those selectors
 		<span role="listitem">
 			<Link href={url} external variant="primary" fontSize="body-s">
 				{t("footer.joinUs")}
@@ -113,6 +115,7 @@ function SocialLinks({
 	return (
 		<>
 			{links.map(({ label, href }) => (
+				// biome-ignore lint/a11y/useSemanticElements: CSS pill styling targets [role="listitem"] selectors; converting to li would break those selectors
 				<span key={label} role="listitem">
 					<Link
 						href={href}

--- a/src/components/persistent-player/index.tsx
+++ b/src/components/persistent-player/index.tsx
@@ -120,7 +120,7 @@ type StreamHealth = "ok" | "retrying" | "failed";
 function PersistentPlayerBar({
 	state,
 	autoplay,
-	onStop,
+	onStop: _onStop,
 	onSkipStation,
 	onPlayStateChange,
 }: {
@@ -485,7 +485,6 @@ function PersistentPlayerBar({
 	// resolves the error before the 5s threshold fires; if a fresh URL also
 	// fails the existing path still runs and contributes to the same
 	// failed-state transition.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: isPodcast forces re-registration when audio element is recreated via key prop
 	useEffect(() => {
 		const audio = audioRef.current;
 		if (!audio) return;
@@ -588,7 +587,6 @@ function PersistentPlayerBar({
 	// stops the stream. --cdn-bass / --cdn-mid / --cdn-treble naturally drop
 	// to silence on pause but the keyframes still tick; a body-class toggle
 	// flips animation-play-state to paused for a clean stop
-	// biome-ignore lint/correctness/useExhaustiveDependencies: isPodcast forces re-registration when audio element is recreated via key prop
 	useEffect(() => {
 		const audio = audioRef.current;
 		if (!audio) return;

--- a/src/components/podcast-episode-scroller/__tests__/index.test.tsx
+++ b/src/components/podcast-episode-scroller/__tests__/index.test.tsx
@@ -23,13 +23,10 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-type AnyProps = Record<string, unknown> & {
-	children?: React.ReactNode;
-	header?: React.ReactNode;
-};
+type MockProps = { [key: string]: React.ReactNode };
 
 vi.mock("@cloudscape-design/components/container", () => ({
-	default: ({ children, header }: AnyProps) =>
+	default: ({ children, header }: MockProps) =>
 		React.createElement(
 			"section",
 			{ "data-testid": "container" },
@@ -39,18 +36,24 @@ vi.mock("@cloudscape-design/components/container", () => ({
 }));
 
 vi.mock("@cloudscape-design/components/header", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("h3", { "data-testid": "scroller-header" }, children),
 }));
 
 vi.mock("@cloudscape-design/components/button", () => ({
-	default: ({ children, onClick }: AnyProps) =>
+	default: ({
+		children,
+		onClick,
+	}: {
+		children?: React.ReactNode;
+		onClick?: React.MouseEventHandler;
+	}) =>
 		React.createElement(
 			"button",
 			{
 				type: "button",
 				"data-testid": "load-more-button",
-				onClick: onClick as React.MouseEventHandler,
+				onClick,
 			},
 			children,
 		),

--- a/src/components/require-auth/index.tsx
+++ b/src/components/require-auth/index.tsx
@@ -34,7 +34,7 @@ export function RequireAuth({
 	}, [auth.isAuthenticated]);
 
 	if (!auth.isAuthenticated) {
-		if (fallback) return <>{fallback}</>;
+		if (fallback) return fallback;
 		return (
 			<Box padding="xxl" textAlign="center">
 				<SpaceBetween size="l" alignItems="center">

--- a/src/components/speakeasy-sign/index.tsx
+++ b/src/components/speakeasy-sign/index.tsx
@@ -2,7 +2,7 @@ import "./styles.css";
 
 export default function SpeakeasySign() {
 	return (
-		<div className="speakeasy-sign" role="region" aria-label="speakeasy">
+		<section className="speakeasy-sign" aria-label="speakeasy">
 			<svg
 				viewBox="0 0 120 24"
 				xmlns="http://www.w3.org/2000/svg"
@@ -46,6 +46,6 @@ export default function SpeakeasySign() {
 					speakeasy
 				</text>
 			</svg>
-		</div>
+		</section>
 	);
 }

--- a/src/components/speaker-proposal-form/index.tsx
+++ b/src/components/speaker-proposal-form/index.tsx
@@ -64,7 +64,11 @@ const TIME_OPTIONS: MultiselectOption[] = [
 	{ value: "evening", label: "evening" },
 ];
 
-export default function SpeakerProposalForm({ open, onClose, source }: Props) {
+export default function SpeakerProposalForm({
+	open,
+	onClose,
+	source: _source,
+}: Props) {
 	const { t } = useTranslation();
 	const claims = useRef(decodeTokenClaims());
 	const captchaContainerRef = useRef<HTMLDivElement>(null);

--- a/src/components/weather/__tests__/atmosphere-scene.test.tsx
+++ b/src/components/weather/__tests__/atmosphere-scene.test.tsx
@@ -17,36 +17,30 @@ vi.mock("@babylonjs/core", () => {
 	const eng = { runRenderLoop, stopRenderLoop, dispose, resize };
 	const scene = { clearColor: null, render: vi.fn(), beginAnimation };
 
-	// biome-ignore lint/complexity/noStaticOnlyClass: vitest requires class syntax for constructable mocks
 	class Engine {
 		constructor() {
 			Object.assign(this, eng);
 		}
 	}
-	// biome-ignore lint/complexity/noStaticOnlyClass: same
 	class Scene {
 		constructor() {
 			Object.assign(this, scene);
 		}
 	}
-	// biome-ignore lint/complexity/noStaticOnlyClass: vitest requires class syntax for constructable mocks
 	class ArcRotateCamera {
 		inputs = { clear: vi.fn() };
 		animations: unknown[] = [];
 	}
-	// biome-ignore lint/complexity/noStaticOnlyClass: same
 	class HemisphericLight {
 		constructor() {
 			Object.assign(this, { intensity: 1, diffuse: null });
 		}
 	}
-	// biome-ignore lint/complexity/noStaticOnlyClass: same
 	class DirectionalLight {
 		constructor() {
 			Object.assign(this, { intensity: 1, diffuse: null });
 		}
 	}
-	// biome-ignore lint/complexity/noStaticOnlyClass: same
 	class StandardMaterial {
 		constructor() {
 			Object.assign(this, {
@@ -56,7 +50,6 @@ vi.mock("@babylonjs/core", () => {
 			});
 		}
 	}
-	// biome-ignore lint/complexity/noStaticOnlyClass: same
 	class Animation {
 		constructor(public name: string) {}
 		setKeys = vi.fn();
@@ -95,11 +88,13 @@ vi.mock("@babylonjs/core", () => {
 		DirectionalLight,
 		Animation,
 		Color4: class Color4 {},
+		// biome-ignore lint/complexity/noStaticOnlyClass: mocking a class-based Babylon API that is instantiated with new
 		Color3: class Color3 {
 			static White() {
 				return {};
 			}
 		},
+		// biome-ignore lint/complexity/noStaticOnlyClass: mocking a class-based Babylon API that is instantiated with new
 		Vector3: class Vector3 {
 			static Zero() {
 				return {};

--- a/src/contexts/__tests__/auth-context.test.tsx
+++ b/src/contexts/__tests__/auth-context.test.tsx
@@ -119,6 +119,7 @@ describe("AuthProvider + useAuth", () => {
 		const caught = vi.fn();
 		function Consumer() {
 			try {
+				// biome-ignore lint/correctness/useHookAtTopLevel: hook is intentionally called in try/catch to test that it throws outside provider
 				useAuth();
 			} catch (e) {
 				caught((e as Error).message);

--- a/src/contexts/locale-context.tsx
+++ b/src/contexts/locale-context.tsx
@@ -14,7 +14,7 @@ export const LocaleContext = createContext<LocaleContextValue | null>(null);
 
 interface LocaleProviderProps {
 	locale: Locale;
-	children: ReactNode;
+	children?: ReactNode;
 }
 
 const translations = {

--- a/src/hooks/__tests__/usePageVisibility.test.ts
+++ b/src/hooks/__tests__/usePageVisibility.test.ts
@@ -13,7 +13,6 @@ describe("usePageVisibility", () => {
 		if (originalHidden) {
 			Object.defineProperty(document, "hidden", originalHidden);
 		} else {
-			// biome-ignore lint/performance/noDelete: restore property in tests
 			delete (document as { hidden?: boolean }).hidden;
 		}
 	});

--- a/src/layouts/shell/index.tsx
+++ b/src/layouts/shell/index.tsx
@@ -691,13 +691,9 @@ function ShellContent({
 						    player no longer overlaps the AWS UG header band. The slot
 						    is reserved on every page so layout doesn't shift between
 						    pages with/without an active stream. */}
-						<div
-							className="cdn-player-slot"
-							role="region"
-							aria-label="radio player"
-						>
+						<section className="cdn-player-slot" aria-label="radio player">
 							{!hidePlayer && <PersistentPlayer />}
-						</div>
+						</section>
 						{children}
 					</>
 				}

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -124,9 +124,8 @@ describe("auth module", () => {
 			const verifier: string = state.pkceVerifier;
 
 			const target = assign.mock.calls[0][0] as string;
-			const challenge = new URLSearchParams(target.split("?")[1]).get(
-				"code_challenge",
-			)!;
+			const challenge =
+				new URLSearchParams(target.split("?")[1]).get("code_challenge") ?? "";
 
 			const digest = await crypto.subtle.digest(
 				"SHA-256",

--- a/src/lib/background-viz/audio.ts
+++ b/src/lib/background-viz/audio.ts
@@ -121,7 +121,7 @@ export function createAudioBridge(_ctx: CanvasRenderingContext2D): {
 		if (!sourceRegistry.has(el)) {
 			const source = ctx.createMediaElementSource(el);
 			sourceRegistry.set(el, source);
-			source.connect(compressor!);
+			if (compressor) source.connect(compressor);
 		}
 
 		currentStationKey = stationKey;

--- a/src/lib/background-viz/static.ts
+++ b/src/lib/background-viz/static.ts
@@ -82,10 +82,10 @@ export function buildStaticLight(
 ): OffscreenCanvas | null {
 	if (typeof OffscreenCanvas === "undefined") return null;
 	let canvas: OffscreenCanvas;
-	let ctx: OffscreenCanvasRenderingContext2D;
+	let ctx: OffscreenCanvasRenderingContext2D | null;
 	try {
 		canvas = new OffscreenCanvas(w, h);
-		ctx = canvas.getContext("2d")!;
+		ctx = canvas.getContext("2d");
 		if (!ctx) return null;
 	} catch {
 		return null;
@@ -129,10 +129,10 @@ export function buildStaticDark(
 ): OffscreenCanvas | null {
 	if (typeof OffscreenCanvas === "undefined") return null;
 	let canvas: OffscreenCanvas;
-	let ctx: OffscreenCanvasRenderingContext2D;
+	let ctx: OffscreenCanvasRenderingContext2D | null;
 	try {
 		canvas = new OffscreenCanvas(w, h);
-		ctx = canvas.getContext("2d")!;
+		ctx = canvas.getContext("2d");
 		if (!ctx) return null;
 	} catch {
 		return null;

--- a/src/lib/cognito.ts
+++ b/src/lib/cognito.ts
@@ -108,7 +108,9 @@ export function getRefreshToken(): string | null {
 
 export function clearTokens(): void {
 	[KEY_ID_TOKEN, KEY_ACCESS_TOKEN, KEY_REFRESH_TOKEN, KEY_EXPIRES_AT].forEach(
-		(k) => sessionStorage.removeItem(k),
+		(k) => {
+			sessionStorage.removeItem(k);
+		},
 	);
 }
 
@@ -343,6 +345,19 @@ export async function refreshTokens(): Promise<void> {
 }
 // ---- Passkey / WebAuthn ----
 
+export interface RegistrationResponseJSON {
+	id: string;
+	rawId: string;
+	type: string;
+	response: {
+		clientDataJSON: string;
+		attestationObject: string;
+		transports?: string[];
+	};
+	authenticatorAttachment?: string | null;
+	clientExtensionResults: AuthenticationExtensionsClientOutputs;
+}
+
 export async function startWebAuthnRegistration(): Promise<
 	Record<string, unknown>
 > {
@@ -352,13 +367,13 @@ export async function startWebAuthnRegistration(): Promise<
 }
 
 export async function completeWebAuthnRegistration(
-	credential: Record<string, unknown>,
+	credential: RegistrationResponseJSON,
 ): Promise<void> {
 	const accessToken = getAccessToken();
 	if (!accessToken) throw new AuthError("not authenticated");
 	await cognitoPost("CompleteWebAuthnRegistration", {
 		AccessToken: accessToken,
-		Credential: credential,
+		Credential: credential as unknown as Record<string, unknown>,
 	});
 }
 

--- a/src/lib/player-persist.ts
+++ b/src/lib/player-persist.ts
@@ -44,8 +44,8 @@ export function clearPodcastPosition(): void {
 		const raw = localStorage.getItem(KEY);
 		if (!raw) return;
 		const state = JSON.parse(raw) as PersistedPlayerState;
-		delete state.podcastCurrentTime;
-		delete state.podcastEpisodeUrl;
+		state.podcastCurrentTime = undefined;
+		state.podcastEpisodeUrl = undefined;
 		localStorage.setItem(KEY, JSON.stringify(state));
 	} catch {
 		// non-fatal

--- a/src/pages/admin/__tests__/app.test.tsx
+++ b/src/pages/admin/__tests__/app.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthState } from "../../../contexts/auth-context";
 import { AuthContext } from "../../../contexts/auth-context";
 
-type AnyProps = Record<string, any>;
+type MockProps = { [key: string]: React.ReactNode };
 
 class ResizeObserverMock {
 	observe() {}
@@ -30,7 +30,7 @@ vi.mock("../../../lib/admin", () => ({
 }));
 
 vi.mock("../../../layouts/shell", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", { "data-testid": "shell" }, children),
 }));
 vi.mock("../../../components/navigation", () => ({

--- a/src/pages/admin/main.tsx
+++ b/src/pages/admin/main.tsx
@@ -6,7 +6,9 @@ import "../../styles/tokens.css";
 
 import App from "./app";
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+const root = ReactDOM.createRoot(container);
 
 root.render(
 	<React.StrictMode>

--- a/src/pages/auth/callback/main.tsx
+++ b/src/pages/auth/callback/main.tsx
@@ -4,7 +4,9 @@ import "@cloudscape-design/global-styles/index.css";
 import "../../../styles/tokens.css";
 import App from "./app";
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+const root = ReactDOM.createRoot(container);
 root.render(
 	<React.StrictMode>
 		<App />

--- a/src/pages/costs/main.tsx
+++ b/src/pages/costs/main.tsx
@@ -8,7 +8,9 @@ import "../../styles/tokens.css";
 
 import App from "./app";
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+const root = ReactDOM.createRoot(container);
 
 root.render(
 	<React.StrictMode>

--- a/src/pages/create-meeting/__tests__/auth-gating.test.tsx
+++ b/src/pages/create-meeting/__tests__/auth-gating.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthState } from "../../../contexts/auth-context";
 import { AuthContext } from "../../../contexts/auth-context";
 
-type AnyProps = Record<string, any>;
+type MockProps = { [key: string]: React.ReactNode };
 
 class ResizeObserverMock {
 	observe() {}
@@ -25,7 +25,7 @@ vi.mock("../../../lib/auth", () => ({
 }));
 
 vi.mock("../../../layouts/shell", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("../../../components/navigation", () => ({
@@ -47,7 +47,7 @@ vi.mock("../validation/basic-validation", () => ({
 		focusFirstErrorField: vi.fn(),
 	}),
 	BasicValidationContext: {
-		Provider: ({ children }: AnyProps) =>
+		Provider: ({ children }: MockProps) =>
 			React.createElement("div", null, children),
 	},
 }));

--- a/src/pages/create-meeting/__tests__/locale-rendering.test.tsx
+++ b/src/pages/create-meeting/__tests__/locale-rendering.test.tsx
@@ -6,11 +6,11 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../contexts/locale-context";
 
-type AnyProps = Record<string, any>;
+type MockProps = { [key: string]: React.ReactNode };
 
 // Mock Cloudscape components
 vi.mock("@cloudscape-design/components/content-layout", () => ({
-	default: ({ children, header }: AnyProps) =>
+	default: ({ children, header }: MockProps) =>
 		React.createElement(
 			"div",
 			{ "data-testid": "content-layout" },
@@ -19,32 +19,38 @@ vi.mock("@cloudscape-design/components/content-layout", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/header", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("h1", null, children),
 }));
 vi.mock("@cloudscape-design/components/button", () => ({
-	default: ({ children }: AnyProps) =>
-		React.createElement("button", null, children),
+	default: ({ children }: MockProps) =>
+		React.createElement("button", { type: "button" }, children),
 }));
 vi.mock("@cloudscape-design/components/form", () => ({
-	default: ({ children, actions }: AnyProps) =>
+	default: ({ children, actions }: MockProps) =>
 		React.createElement("div", { "data-testid": "form" }, actions, children),
 }));
 vi.mock("@cloudscape-design/components/space-between", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/help-panel", () => ({
-	default: ({ header }: AnyProps) =>
+	default: ({ header }: MockProps) =>
 		React.createElement("aside", { "data-testid": "help-panel" }, header),
 }));
 
 // Mock Shell and navigation — render breadcrumbs so we can assert breadcrumb text
 vi.mock("../../../layouts/shell", () => ({
-	default: ({ children, breadcrumbs }: AnyProps) =>
+	default: ({
+		children,
+		breadcrumbs,
+	}: {
+		children: React.ReactNode;
+		breadcrumbs?: React.ReactNode;
+	}) =>
 		React.createElement(
 			LocaleProvider,
-			{ locale: "us" } as any,
+			{ locale: "us" },
 			React.createElement(
 				"div",
 				{ "data-testid": "shell" },
@@ -57,7 +63,7 @@ vi.mock("../../../components/navigation", () => ({
 	default: () => React.createElement("nav", { "data-testid": "navigation" }),
 }));
 vi.mock("../../../components/breadcrumbs", () => ({
-	default: ({ active }: AnyProps) =>
+	default: ({ active }: { active?: { text?: string } }) =>
 		React.createElement(
 			"nav",
 			{ "aria-label": "breadcrumbs" },
@@ -75,7 +81,7 @@ vi.mock("../components/shape", () => ({
 
 // RequireAuth is exercised in its own unit tests; pass-through here so locale assertions can run.
 vi.mock("../../../components/require-auth", () => ({
-	RequireAuth: ({ children }: AnyProps) =>
+	RequireAuth: ({ children }: MockProps) =>
 		React.createElement(React.Fragment, null, children),
 }));
 
@@ -88,7 +94,7 @@ vi.mock("../validation/basic-validation", () => ({
 		focusFirstErrorField: vi.fn(),
 	}),
 	BasicValidationContext: {
-		Provider: ({ children }: AnyProps) =>
+		Provider: ({ children }: MockProps) =>
 			React.createElement("div", null, children),
 	},
 }));

--- a/src/pages/create-meeting/__tests__/meetup-rsvp-url.test.tsx
+++ b/src/pages/create-meeting/__tests__/meetup-rsvp-url.test.tsx
@@ -5,27 +5,27 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-type AnyProps = Record<string, unknown> & { children?: React.ReactNode };
+type MockProps = { [key: string]: React.ReactNode };
 
 // ── Cloudscape mocks ──────────────────────────────────────────────────────────
 vi.mock("@cloudscape-design/components/container", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/header", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/space-between", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/column-layout", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/box", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/date-picker", () => ({
@@ -35,16 +35,32 @@ vi.mock("@cloudscape-design/components/time-input", () => ({
 	default: () => React.createElement("div", { "data-testid": "time-input" }),
 }));
 vi.mock("@cloudscape-design/components/textarea", () => ({
-	default: ({ value, onChange }: AnyProps) =>
+	default: ({
+		value,
+		onChange,
+	}: {
+		value?: string;
+		onChange?: (evt: { detail: { value: string } }) => void;
+	}) =>
 		React.createElement("textarea", {
 			"data-testid": "notes-input",
 			value: value as string,
 			onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-				(onChange as Function)?.({ detail: { value: e.target.value } }),
+				onChange?.({
+					detail: { value: e.target.value },
+				}),
 		}),
 }));
 vi.mock("@cloudscape-design/components/form-field", () => ({
-	default: ({ children, errorText, label }: AnyProps) =>
+	default: ({
+		children,
+		errorText,
+		label,
+	}: {
+		children?: React.ReactNode;
+		errorText?: string;
+		label?: React.ReactNode;
+	}) =>
 		React.createElement(
 			"div",
 			{
@@ -52,7 +68,7 @@ vi.mock("@cloudscape-design/components/form-field", () => ({
 				"data-label": String(label ?? ""),
 				"data-error": String(errorText ?? ""),
 			},
-			label as React.ReactNode,
+			label,
 			children,
 		),
 }));
@@ -66,10 +82,17 @@ vi.mock("@cloudscape-design/components/input", () => ({
 		onChange,
 		placeholder,
 		ref,
-	}: AnyProps & { ref?: (r: unknown) => void }) => {
+	}: {
+		value?: string;
+		onChange?: (evt: { detail: { value: string } }) => void;
+		placeholder?: string;
+		ref?: (r: unknown) => void;
+	}) => {
 		if (placeholder === "https://www.meetup.com/...") {
 			rsvpInputOnChange = (val: string) =>
-				(onChange as Function)?.({ detail: { value: val } });
+				onChange?.({
+					detail: { value: val },
+				});
 		}
 		// expose ref with a no-op focus so addErrorField doesn't throw
 		ref?.({ focus: () => {} });
@@ -80,7 +103,9 @@ vi.mock("@cloudscape-design/components/input", () => ({
 					: "other-input",
 			value: value as string,
 			onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-				(onChange as Function)?.({ detail: { value: e.target.value } }),
+				onChange?.({
+					detail: { value: e.target.value },
+				}),
 		});
 	},
 }));

--- a/src/pages/create-meeting/components/details.tsx
+++ b/src/pages/create-meeting/components/details.tsx
@@ -19,7 +19,7 @@ const options = [...services, ...meeting_type].map((i) => ({
 	label: i,
 }));
 
-export default function details() {
+export default function Details() {
 	const { t } = useTranslation();
 	const [published, setPublished] = useState("yes");
 	const [selecteddetails, setSelecteddetails] = useState<

--- a/src/pages/create-meeting/components/marketing.tsx
+++ b/src/pages/create-meeting/components/marketing.tsx
@@ -204,9 +204,7 @@ export default function MeetingDetails({ onChange }: Props) {
 
 							{/* Meetup RSVP URL */}
 							<FormField
-								label={
-									<>{t("createMeeting.meetingDetails.meetupRsvpUrlLabel")}</>
-								}
+								label={t("createMeeting.meetingDetails.meetupRsvpUrlLabel")}
 								errorText={isFormSubmitted && meetupRsvpUrlError}
 								i18nStrings={{
 									errorIconAriaLabel: t(

--- a/src/pages/create-meeting/main.tsx
+++ b/src/pages/create-meeting/main.tsx
@@ -8,7 +8,9 @@ import "../../styles/tokens.css";
 
 import App from "./app";
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+const root = ReactDOM.createRoot(container);
 
 root.render(
 	<React.StrictMode>

--- a/src/pages/dune-test/creative-preview.tsx
+++ b/src/pages/dune-test/creative-preview.tsx
@@ -113,4 +113,6 @@ function Preview() {
 
 import { createRoot } from "react-dom/client";
 
-createRoot(document.getElementById("app")!).render(<Preview />);
+const appContainer = document.getElementById("app");
+if (!appContainer) throw new Error("app element not found");
+createRoot(appContainer).render(<Preview />);

--- a/src/pages/feed/app.tsx
+++ b/src/pages/feed/app.tsx
@@ -73,7 +73,6 @@ const LIVE_PRIORITY = [
 	"twitchAwsOnAir",
 	"twitchAws",
 ] as const;
-type LiveKey = (typeof LIVE_PRIORITY)[number];
 
 // stable shuffled order generated once per page load
 const SECTION_KEYS: SectionKey[] = [
@@ -121,11 +120,11 @@ function shuffled<T>(arr: T[]): T[] {
 const LIVE_DETECTION_ENABLED = false;
 
 function AppContent({
-	theme,
-	onThemeChange,
-	locale,
-	onLocaleChange,
-	onOpenTools,
+	theme: _theme,
+	onThemeChange: _onThemeChange,
+	locale: _locale,
+	onLocaleChange: _onLocaleChange,
+	onOpenTools: _onOpenTools,
 }: {
 	theme: Theme;
 	onThemeChange: (t: Theme) => void;
@@ -257,7 +256,6 @@ function AppContent({
 	);
 
 	// stable shuffle — recomputed only if sections reference changes (it won't)
-	// biome-ignore lint/correctness/useExhaustiveDependencies: SECTION_KEYS is module-level constant
 	const shuffledOrder = useMemo<SectionKey[]>(() => shuffled(SECTION_KEYS), []);
 
 	// union of twitch + andres live keys

--- a/src/pages/feed/components/__tests__/featured-event.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-event.test.tsx
@@ -305,7 +305,8 @@ describe("FeaturedEvent — wave 44 no-image fallback", () => {
 			".feed-featured-event__image--light",
 		);
 		expect(lightImg).not.toBeNull();
-		fireEvent.error(lightImg!);
+		if (!lightImg) return;
+		fireEvent.error(lightImg);
 		// After onError, the light img should be removed from DOM
 		expect(
 			container.querySelector(".feed-featured-event__image--light"),

--- a/src/pages/feed/components/__tests__/next-meetup.test.tsx
+++ b/src/pages/feed/components/__tests__/next-meetup.test.tsx
@@ -169,7 +169,8 @@ describe("NextMeetup — wave 33a uplift", () => {
 			await new Promise((r) => setTimeout(r, 25));
 		}
 		expect(img).not.toBeNull();
-		fireEvent.error(img!);
+		if (!img) return;
+		fireEvent.error(img);
 		// After onError, the img should be removed from DOM
 		expect(container.querySelector(".feed-next-meetup__image")).toBeNull();
 		// The wrapper slot still carries aria-label for AT

--- a/src/pages/feed/components/__tests__/upcoming-virtual-event.test.tsx
+++ b/src/pages/feed/components/__tests__/upcoming-virtual-event.test.tsx
@@ -293,7 +293,8 @@ describe("UpcomingVirtualEvent — wave 44 no-image fallback", () => {
 			".feed-upcoming-virtual-event__image--light",
 		);
 		expect(lightImg).not.toBeNull();
-		fireEvent.error(lightImg!);
+		if (!lightImg) return;
+		fireEvent.error(lightImg);
 		expect(
 			container.querySelector(".feed-upcoming-virtual-event__image--light"),
 		).toBeNull();

--- a/src/pages/feed/components/builder-center-card.tsx
+++ b/src/pages/feed/components/builder-center-card.tsx
@@ -172,6 +172,7 @@ export default function BuilderCenterCard() {
 				</ol>
 
 				{canRotate && (
+					// biome-ignore lint/a11y/useSemanticElements: carousel navigation controls, not a form fieldset; group semantics provided via role
 					<div
 						className="feed-builder-deck__controls"
 						role="group"

--- a/src/pages/feed/components/featured-event.tsx
+++ b/src/pages/feed/components/featured-event.tsx
@@ -84,6 +84,7 @@ function markImageLoaded(event: SyntheticEvent<HTMLImageElement>) {
  */
 function MarqueeHeader({ text }: { text: string }) {
 	return (
+		// biome-ignore lint/a11y/useSemanticElements: marquee is visually styled; heading semantics provided via role="heading"+aria-level to avoid h2 default-style/layout conflict
 		<div className="feed-featured-event__marquee" role="heading" aria-level={2}>
 			<span className="feed-featured-event__marquee-text">{text}</span>
 			<div className="feed-featured-event__marquee-bulbs" aria-hidden="true">

--- a/src/pages/feed/components/feed-card-shell.tsx
+++ b/src/pages/feed/components/feed-card-shell.tsx
@@ -133,6 +133,7 @@ function FeedCardShellMarquee({
 	headerActions?: ReactNode;
 }) {
 	return (
+		// biome-ignore lint/a11y/useSemanticElements: marquee is visually styled; heading semantics provided via role="heading"+aria-level to avoid h2 default-style/layout conflict
 		<div className="feed-card-shell__marquee" role="heading" aria-level={2}>
 			<span className="feed-card-shell__marquee-text">{headerText}</span>
 			{headerActions && (

--- a/src/pages/feed/components/next-meetup.tsx
+++ b/src/pages/feed/components/next-meetup.tsx
@@ -237,13 +237,13 @@ function parseIcal(text: string): MeetupEvent | null {
 		future.sort(
 			(a, b) => new Date(a.dtstart).getTime() - new Date(b.dtstart).getTime(),
 		);
-		return { ...future[0]!, isPast: false };
+		return { ...future[0], isPast: false };
 	}
 	// most recent past
 	past.sort(
 		(a, b) => new Date(b.dtstart).getTime() - new Date(a.dtstart).getTime(),
 	);
-	return past.length > 0 ? { ...past[0]!, isPast: true } : null;
+	return past.length > 0 ? { ...past[0], isPast: true } : null;
 }
 
 type LoadState = "loading" | "loaded" | "fallback";
@@ -263,9 +263,10 @@ type LoadState = "loading" | "loaded" | "fallback";
  */
 function MarqueeHeader({ text }: { text: string }) {
 	return (
+		// biome-ignore lint/a11y/useSemanticElements: marquee is visually styled; heading semantics provided via role="heading"+aria-level to avoid h2 default-style/layout conflict
 		<div className="feed-next-meetup__marquee" role="heading" aria-level={2}>
 			<span className="feed-next-meetup__marquee-text">{text}</span>
-			<span className="feed-next-meetup__marquee-tape" aria-hidden="true" />
+			<div className="feed-next-meetup__marquee-tape" aria-hidden="true" />
 		</div>
 	);
 }

--- a/src/pages/feed/components/twitch-section.tsx
+++ b/src/pages/feed/components/twitch-section.tsx
@@ -66,7 +66,9 @@ function loadTwitchSDK(onReady: () => void) {
 	script.async = true;
 	script.onload = () => {
 		twitchScriptLoading = false;
-		twitchReadyCallbacks.splice(0).forEach((cb) => cb());
+		twitchReadyCallbacks.splice(0).forEach((cb) => {
+			cb();
+		});
 	};
 	document.head.appendChild(script);
 }

--- a/src/pages/feed/components/upcoming-virtual-event.tsx
+++ b/src/pages/feed/components/upcoming-virtual-event.tsx
@@ -96,6 +96,7 @@ function markImageLoaded(event: SyntheticEvent<HTMLImageElement>) {
  */
 function MarqueeHeader({ text }: { text: string }) {
 	return (
+		// biome-ignore lint/a11y/useSemanticElements: marquee is visually styled; heading semantics provided via role="heading"+aria-level to avoid h2 default-style/layout conflict
 		<div
 			className="feed-upcoming-virtual-event__marquee"
 			role="heading"

--- a/src/pages/feed/components/youtube-carousel.tsx
+++ b/src/pages/feed/components/youtube-carousel.tsx
@@ -89,6 +89,7 @@ export default function YoutubeCarousel() {
 					</div>
 					<div className="feed-carousel__controls">
 						<button
+							type="button"
 							className="feed-carousel__btn"
 							onClick={prev}
 							aria-label={t("feedPage.youtubePrevVideo")}
@@ -99,6 +100,7 @@ export default function YoutubeCarousel() {
 							{current + 1} / {VIDEO_IDS.length}
 						</span>
 						<button
+							type="button"
 							className="feed-carousel__btn"
 							onClick={next}
 							aria-label={t("feedPage.youtubeNextVideo")}

--- a/src/pages/feed/components/youtube-shorts-carousel.tsx
+++ b/src/pages/feed/components/youtube-shorts-carousel.tsx
@@ -162,13 +162,9 @@ export default function YouTubeShortsCarousel({
 	return (
 		<Container
 			header={
-				<div
-					className="feed-shorts__attribution-header"
-					role="heading"
-					aria-level={2}
-				>
+				<h2 className="feed-shorts__attribution-header">
 					{t("feedPage.shortsHostBlurb")}
-				</div>
+				</h2>
 			}
 		>
 			{!ready ? (
@@ -214,6 +210,7 @@ export default function YouTubeShortsCarousel({
 							}
 						/>
 					</div>
+					{/* biome-ignore lint/a11y/useSemanticElements: carousel group wrapper, not a form fieldset; group semantics provided via role */}
 					<div
 						className="feed-shorts-carousel"
 						role="group"

--- a/src/pages/feed/components/youtube-spin-placeholder.tsx
+++ b/src/pages/feed/components/youtube-spin-placeholder.tsx
@@ -69,9 +69,8 @@ export function YouTubeSpinPlaceholder({
 
 	return (
 		/* Wave 53 hook: data-spin-anchor — Babylon will mount here */
-		<div
+		<section
 			className="yt-carousel-placeholder"
-			role="region"
 			aria-label={ariaLabel}
 			data-spin-anchor="true"
 		>
@@ -142,6 +141,6 @@ export function YouTubeSpinPlaceholder({
 					))}
 				</div>
 			</div>
-		</div>
+		</section>
 	);
 }

--- a/src/pages/feed/main.tsx
+++ b/src/pages/feed/main.tsx
@@ -10,7 +10,9 @@ import "../../styles/cdn-skeleton.css";
 import App from "./app";
 import { initScrollJankMitigation } from "./scroll-jank-mitigation";
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+const root = ReactDOM.createRoot(container);
 
 root.render(
 	<React.StrictMode>

--- a/src/pages/home/__tests__/app.test.tsx
+++ b/src/pages/home/__tests__/app.test.tsx
@@ -3,12 +3,12 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../contexts/locale-context";
 
-type AnyProps = Record<string, any>;
+type MockProps = { [key: string]: React.ReactNode };
 
 // --- Mock Cloudscape components (they hang in jsdom without mocking) ---
 
 vi.mock("@cloudscape-design/components/content-layout", () => ({
-	default: ({ children, header }: AnyProps) =>
+	default: ({ children, header }: MockProps) =>
 		React.createElement(
 			"div",
 			{ "data-testid": "content-layout" },
@@ -17,22 +17,23 @@ vi.mock("@cloudscape-design/components/content-layout", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/grid", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", { "data-testid": "grid" }, children),
 }));
 vi.mock("@cloudscape-design/components/header", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("h2", { "data-testid": "header" }, children),
 }));
 vi.mock("@cloudscape-design/components/link", () => ({
-	default: ({ children }: AnyProps) => React.createElement("a", null, children),
+	default: ({ children }: MockProps) =>
+		React.createElement("a", null, children),
 }));
 vi.mock("@cloudscape-design/components/box", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", { "data-testid": "box" }, children),
 }));
 vi.mock("@cloudscape-design/components/container", () => ({
-	default: ({ children, header }: AnyProps) =>
+	default: ({ children, header }: MockProps) =>
 		React.createElement(
 			"div",
 			{ "data-testid": "container" },
@@ -41,15 +42,25 @@ vi.mock("@cloudscape-design/components/container", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/column-layout", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", { "data-testid": "column-layout" }, children),
 }));
 vi.mock("@cloudscape-design/components/button", () => ({
-	default: ({ children }: AnyProps) =>
-		React.createElement("button", { "data-testid": "button" }, children),
+	default: ({ children }: MockProps) =>
+		React.createElement(
+			"button",
+			{ type: "button", "data-testid": "button" },
+			children,
+		),
 }));
 vi.mock("@cloudscape-design/components/modal", () => ({
-	default: ({ children, visible }: AnyProps) =>
+	default: ({
+		children,
+		visible,
+	}: {
+		children?: React.ReactNode;
+		visible?: boolean;
+	}) =>
 		visible
 			? React.createElement("div", { "data-testid": "modal" }, children)
 			: null,
@@ -62,7 +73,7 @@ vi.mock("@cloudscape-design/components/pie-chart", () => ({
 		React.createElement("div", { "data-testid": "pie-chart" }, "PieChart"),
 }));
 vi.mock("@cloudscape-design/components/status-indicator", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement(
 			"span",
 			{ "data-testid": "status-indicator" },
@@ -71,12 +82,12 @@ vi.mock("@cloudscape-design/components/status-indicator", () => ({
 }));
 // Barrel import (current code) — SpaceBetween is a named export
 vi.mock("@cloudscape-design/components", () => ({
-	SpaceBetween: ({ children }: AnyProps) =>
+	SpaceBetween: ({ children }: MockProps) =>
 		React.createElement("div", { "data-testid": "space-between" }, children),
 }));
 // Deep import (after Lyren's barrel-fix) — SpaceBetween is a default export
 vi.mock("@cloudscape-design/components/space-between", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", { "data-testid": "space-between" }, children),
 }));
 
@@ -92,7 +103,7 @@ vi.mock("../../../layouts/shell", () => ({
 	}) =>
 		React.createElement(
 			LocaleProvider,
-			{ locale: "us" } as any,
+			{ locale: "us" },
 			React.createElement(
 				"div",
 				{ "data-testid": "shell" },

--- a/src/pages/home/__tests__/locale-rendering.test.tsx
+++ b/src/pages/home/__tests__/locale-rendering.test.tsx
@@ -6,11 +6,11 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../contexts/locale-context";
 
-type AnyProps = Record<string, any>;
+type MockProps = { [key: string]: React.ReactNode };
 
 // Mock Cloudscape components
 vi.mock("@cloudscape-design/components/content-layout", () => ({
-	default: ({ children, header }: AnyProps) =>
+	default: ({ children, header }: MockProps) =>
 		React.createElement(
 			"div",
 			{ "data-testid": "content-layout" },
@@ -19,11 +19,11 @@ vi.mock("@cloudscape-design/components/content-layout", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/grid", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", { "data-testid": "grid" }, children),
 }));
 vi.mock("@cloudscape-design/components/header", () => ({
-	default: ({ children, info }: AnyProps) =>
+	default: ({ children, info }: MockProps) =>
 		React.createElement(
 			"div",
 			null,
@@ -32,7 +32,8 @@ vi.mock("@cloudscape-design/components/header", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/link", () => ({
-	default: ({ children }: AnyProps) => React.createElement("a", null, children),
+	default: ({ children }: MockProps) =>
+		React.createElement("a", null, children),
 }));
 
 // Mock Shell and dependencies
@@ -46,7 +47,7 @@ vi.mock("../../../layouts/shell", () => ({
 	}) =>
 		React.createElement(
 			LocaleProvider,
-			{ locale: "us" } as any,
+			{ locale: "us" },
 			React.createElement(
 				"div",
 				{ "data-testid": "shell" },

--- a/src/pages/home/app.tsx
+++ b/src/pages/home/app.tsx
@@ -35,10 +35,10 @@ import {
 } from "./data";
 
 function AppContent({
-	theme,
-	onThemeChange,
-	locale,
-	onLocaleChange,
+	theme: _theme,
+	onThemeChange: _onThemeChange,
+	locale: _locale,
+	onLocaleChange: _onLocaleChange,
 }: {
 	theme: Theme;
 	onThemeChange: (t: Theme) => void;

--- a/src/pages/home/components/meetings.tsx
+++ b/src/pages/home/components/meetings.tsx
@@ -33,7 +33,7 @@ export interface VariationsProps {
 	items: TableProps["items"];
 }
 
-export default function meetings({ data, items }: VariationsProps) {
+export default function Meetings({ data, items: _items }: VariationsProps) {
 	const { t } = useTranslation();
 	const translatedData = data.map((item) => ({
 		...item,

--- a/src/pages/home/main.tsx
+++ b/src/pages/home/main.tsx
@@ -8,7 +8,9 @@ import "../../styles/tokens.css";
 
 import App from "./app";
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+const root = ReactDOM.createRoot(container);
 
 root.render(
 	<React.StrictMode>

--- a/src/pages/learning/api/RiftRewindDashboard.tsx
+++ b/src/pages/learning/api/RiftRewindDashboard.tsx
@@ -42,6 +42,17 @@ interface ApiAttempt {
 	data_count: number;
 }
 
+interface TournamentWinner {
+	player: string;
+	team: string;
+	championPlayed: string;
+	tournamentWins: number;
+	tournamentLosses: number;
+	winRate: number;
+	performanceScore: number;
+	event: string;
+}
+
 const RiftRewindDashboard: React.FC = () => {
 	const { t } = useTranslation();
 	const [matches, setMatches] = useState<MatchSummary[]>([]);
@@ -54,7 +65,15 @@ const RiftRewindDashboard: React.FC = () => {
 	const [championApiResponse, setChampionApiResponse] = useState<string>("");
 	const [endpointDetails, setEndpointDetails] = useState<string>("");
 	const [hasTriedLiveData, setHasTriedLiveData] = useState(false);
-	const [championsApiDetails, setChampionsApiDetails] = useState<any>(null);
+	const [championsApiDetails, setChampionsApiDetails] = useState<{
+		actual_status: string;
+		expected_url: string;
+		expected_response: string;
+		actual_response: string;
+		data_source: string;
+		authentication: string;
+		response_format: string;
+	} | null>(null);
 	const [contests, setContests] = useState<Contest[]>([]);
 	const [activeDemo, setActiveDemo] = useState<"contests" | "players" | null>(
 		null,
@@ -340,7 +359,7 @@ const RiftRewindDashboard: React.FC = () => {
 	];
 
 	const getTournamentWinners = (year: string) => {
-		const winnersData: Record<string, any[]> = {
+		const winnersData: Record<string, TournamentWinner[]> = {
 			"2024": [
 				{
 					player: "Faker",
@@ -872,7 +891,7 @@ const RiftRewindDashboard: React.FC = () => {
 							{
 								id: "player",
 								header: t("learning.api.player"),
-								cell: (item: any) => (
+								cell: (item: TournamentWinner) => (
 									<Box>
 										<Box variant="strong">{item.player}</Box>
 										<Box variant="small">{item.team}</Box>
@@ -882,12 +901,12 @@ const RiftRewindDashboard: React.FC = () => {
 							{
 								id: "champion",
 								header: t("learning.api.signatureChampionHeader"),
-								cell: (item: any) => item.championPlayed,
+								cell: (item: TournamentWinner) => item.championPlayed,
 							},
 							{
 								id: "tournamentRecord",
 								header: t("learning.api.tournamentRecordHeader"),
-								cell: (item: any) => (
+								cell: (item: TournamentWinner) => (
 									<Box>
 										<Box variant="strong" color="text-status-info">
 											{item.winRate}%
@@ -901,14 +920,14 @@ const RiftRewindDashboard: React.FC = () => {
 							{
 								id: "performance",
 								header: t("learning.api.performanceScoreHeader"),
-								cell: (item: any) => (
+								cell: (item: TournamentWinner) => (
 									<Box variant="strong">{item.performanceScore}/100</Box>
 								),
 							},
 							{
 								id: "achievement",
 								header: t("learning.api.achievement"),
-								cell: (item: any) => (
+								cell: (item: TournamentWinner) => (
 									<Box>
 										🏆{" "}
 										<Box variant="strong" display="inline">

--- a/src/pages/learning/api/__tests__/app.test.tsx
+++ b/src/pages/learning/api/__tests__/app.test.tsx
@@ -3,15 +3,19 @@ import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../../contexts/locale-context";
 
-type AnyProps = Record<string, any>;
-
 // Mock Shell — AppLayout uses ResizeObserver/timers that hang in jsdom.
 // Must render breadcrumbs prop to test locale-dependent breadcrumb text.
 vi.mock("../../../../layouts/shell", () => ({
-	default: ({ children, breadcrumbs }: AnyProps) =>
+	default: ({
+		children,
+		breadcrumbs,
+	}: {
+		children: React.ReactNode;
+		breadcrumbs?: React.ReactNode;
+	}) =>
 		React.createElement(
 			LocaleProvider,
-			{ locale: "us" } as any,
+			{ locale: "us" },
 			React.createElement(
 				"div",
 				{ "data-testid": "shell" },
@@ -26,7 +30,7 @@ vi.mock("../../../../components/navigation", () => ({
 }));
 
 vi.mock("../../../../components/breadcrumbs", () => ({
-	default: ({ active }: AnyProps) =>
+	default: ({ active }: { active?: { text?: string } }) =>
 		React.createElement(
 			"nav",
 			{ "aria-label": "breadcrumbs" },

--- a/src/pages/learning/api/main.tsx
+++ b/src/pages/learning/api/main.tsx
@@ -4,7 +4,9 @@ import "@cloudscape-design/global-styles/index.css";
 import "../../../styles/tokens.css";
 import App from "./app";
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+const root = ReactDOM.createRoot(container);
 root.render(
 	<React.StrictMode>
 		<App />

--- a/src/pages/maintenance-calendar/__tests__/app.test.tsx
+++ b/src/pages/maintenance-calendar/__tests__/app.test.tsx
@@ -3,23 +3,34 @@ import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../contexts/locale-context";
 
-type AnyProps = Record<string, any>;
+type MockProps = { [key: string]: React.ReactNode };
 
 vi.mock("@cloudscape-design/components/table", () => ({
-	default: ({ header, items, columnDefinitions }: AnyProps) =>
+	default: ({
+		header,
+		items,
+		columnDefinitions,
+	}: {
+		header?: React.ReactNode;
+		items?: Record<string, unknown>[];
+		columnDefinitions?: {
+			id?: string;
+			cell?: (item: unknown) => React.ReactNode;
+		}[];
+	}) =>
 		React.createElement(
 			"div",
 			{ "data-testid": "table" },
 			header,
-			items.map((_: unknown, i: number) =>
+			(items ?? []).map((_: unknown, i: number) =>
 				React.createElement(
 					"div",
 					{ key: i, "data-testid": "table-row" },
-					columnDefinitions.map((col: AnyProps) =>
+					(columnDefinitions ?? []).map((col) =>
 						React.createElement(
 							"div",
 							{ key: col.id, "data-testid": `cell-${col.id}` },
-							col.cell(items[i]),
+							col.cell?.((items ?? [])[i]),
 						),
 					),
 				),
@@ -27,11 +38,17 @@ vi.mock("@cloudscape-design/components/table", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/select", () => ({
-	default: ({ ariaLabel, options }: AnyProps) =>
+	default: ({
+		ariaLabel,
+		options,
+	}: {
+		ariaLabel?: string;
+		options?: { value?: string; label?: string }[];
+	}) =>
 		React.createElement(
 			"select",
 			{ "aria-label": ariaLabel },
-			options?.map((o: AnyProps) =>
+			options?.map((o) =>
 				React.createElement(
 					"option",
 					{ key: o.value, value: o.value },
@@ -41,11 +58,24 @@ vi.mock("@cloudscape-design/components/select", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/button", () => ({
-	default: ({ children, onClick }: AnyProps) =>
-		React.createElement("button", { onClick }, children),
+	default: ({
+		children,
+		onClick,
+	}: {
+		children?: React.ReactNode;
+		onClick?: () => void;
+	}) => React.createElement("button", { type: "button", onClick }, children),
 }));
 vi.mock("@cloudscape-design/components/header", () => ({
-	default: ({ children, actions, variant }: AnyProps) =>
+	default: ({
+		children,
+		actions,
+		variant,
+	}: {
+		children?: React.ReactNode;
+		actions?: React.ReactNode;
+		variant?: string;
+	}) =>
 		React.createElement(
 			"div",
 			null,
@@ -54,24 +84,29 @@ vi.mock("@cloudscape-design/components/header", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/content-layout", () => ({
-	default: ({ children, header }: AnyProps) =>
+	default: ({ children, header }: MockProps) =>
 		React.createElement("div", null, header, children),
 }));
 vi.mock("@cloudscape-design/components/space-between", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/badge", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("span", null, children),
 }));
 vi.mock("@cloudscape-design/components/box", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/link", () => ({
-	default: ({ children, href }: AnyProps) =>
-		React.createElement("a", { href }, children),
+	default: ({
+		children,
+		href,
+	}: {
+		children?: React.ReactNode;
+		href?: string;
+	}) => React.createElement("a", { href }, children),
 }));
 
 import MaintenanceCalendar from "../MaintenanceCalendar";
@@ -98,7 +133,7 @@ vi.mock("../../../layouts/shell", () => ({
 	}) =>
 		React.createElement(
 			LocaleProvider,
-			{ locale: "us" } as any,
+			{ locale: "us" },
 			React.createElement(
 				"div",
 				{ "data-testid": "shell" },

--- a/src/pages/maintenance-calendar/__tests__/locale-rendering.test.tsx
+++ b/src/pages/maintenance-calendar/__tests__/locale-rendering.test.tsx
@@ -2,24 +2,35 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-type AnyProps = Record<string, any>;
+type MockProps = { [key: string]: React.ReactNode };
 
 // Mock Cloudscape components
 vi.mock("@cloudscape-design/components/table", () => ({
-	default: ({ header, items, columnDefinitions }: AnyProps) =>
+	default: ({
+		header,
+		items,
+		columnDefinitions,
+	}: {
+		header?: React.ReactNode;
+		items?: Record<string, unknown>[];
+		columnDefinitions?: {
+			id?: string;
+			cell?: (item: unknown) => React.ReactNode;
+		}[];
+	}) =>
 		React.createElement(
 			"div",
 			{ "data-testid": "table" },
 			header,
-			items.map((_: unknown, i: number) =>
+			(items ?? []).map((_: unknown, i: number) =>
 				React.createElement(
 					"div",
 					{ key: i, "data-testid": "table-row" },
-					columnDefinitions.map((col: AnyProps) =>
+					(columnDefinitions ?? []).map((col) =>
 						React.createElement(
 							"div",
 							{ key: col.id, "data-testid": `cell-${col.id}` },
-							col.cell(items[i]),
+							col.cell?.((items ?? [])[i]),
 						),
 					),
 				),
@@ -27,11 +38,17 @@ vi.mock("@cloudscape-design/components/table", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/select", () => ({
-	default: ({ ariaLabel, options }: AnyProps) =>
+	default: ({
+		ariaLabel,
+		options,
+	}: {
+		ariaLabel?: string;
+		options?: { value?: string; label?: string }[];
+	}) =>
 		React.createElement(
 			"select",
 			{ "aria-label": ariaLabel },
-			options?.map((o: AnyProps) =>
+			options?.map((o) =>
 				React.createElement(
 					"option",
 					{ key: o.value, value: o.value },
@@ -41,11 +58,24 @@ vi.mock("@cloudscape-design/components/select", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/button", () => ({
-	default: ({ children, onClick }: AnyProps) =>
-		React.createElement("button", { onClick }, children),
+	default: ({
+		children,
+		onClick,
+	}: {
+		children?: React.ReactNode;
+		onClick?: () => void;
+	}) => React.createElement("button", { type: "button", onClick }, children),
 }));
 vi.mock("@cloudscape-design/components/header", () => ({
-	default: ({ children, actions, variant }: AnyProps) =>
+	default: ({
+		children,
+		actions,
+		variant,
+	}: {
+		children?: React.ReactNode;
+		actions?: React.ReactNode;
+		variant?: string;
+	}) =>
 		React.createElement(
 			"div",
 			null,
@@ -54,24 +84,29 @@ vi.mock("@cloudscape-design/components/header", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/content-layout", () => ({
-	default: ({ children, header }: AnyProps) =>
+	default: ({ children, header }: MockProps) =>
 		React.createElement("div", null, header, children),
 }));
 vi.mock("@cloudscape-design/components/space-between", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/badge", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("span", null, children),
 }));
 vi.mock("@cloudscape-design/components/box", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/link", () => ({
-	default: ({ children, href }: AnyProps) =>
-		React.createElement("a", { href }, children),
+	default: ({
+		children,
+		href,
+	}: {
+		children?: React.ReactNode;
+		href?: string;
+	}) => React.createElement("a", { href }, children),
 }));
 
 // Mock layout components

--- a/src/pages/maintenance-calendar/main.tsx
+++ b/src/pages/maintenance-calendar/main.tsx
@@ -8,7 +8,9 @@ import "../../styles/tokens.css";
 
 import App from "./app";
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+const root = ReactDOM.createRoot(container);
 
 root.render(
 	<React.StrictMode>

--- a/src/pages/maintenance-calendar/utils/__tests__/fetcher.test.ts
+++ b/src/pages/maintenance-calendar/utils/__tests__/fetcher.test.ts
@@ -125,7 +125,8 @@ describe("checkStaleManual", () => {
 		const entry = { id: "python", lastManualUpdate: "2024-03-02" };
 		const result = checkStaleManual(entry, 90, fixedNow);
 		expect(result).not.toBeNull();
-		expect(result!).toBeGreaterThanOrEqual(90);
+		if (result === null) return;
+		expect(result).toBeGreaterThanOrEqual(90);
 	});
 
 	it("returns null when lastManualUpdate is 30 days ago (not stale)", () => {
@@ -153,7 +154,8 @@ describe("checkStaleManual", () => {
 			new Date("2023-04-15T00:00:00Z"),
 		);
 		expect(result).not.toBeNull();
-		expect(result!).toBeGreaterThan(90);
+		if (result === null) return;
+		expect(result).toBeGreaterThan(90);
 	});
 });
 

--- a/src/pages/maintenance-calendar/utils/__tests__/projection.test.ts
+++ b/src/pages/maintenance-calendar/utils/__tests__/projection.test.ts
@@ -32,13 +32,17 @@ describe("avgIntervalDays", () => {
 		const b = makeRelease("2025-01-01");
 		const avg = avgIntervalDays([a, b]);
 		expect(avg).not.toBeNull();
-		expect(Math.round(avg!)).toBe(366); // 2024 is a leap year
+		if (avg === null) return;
+		expect(Math.round(avg)).toBe(366); // 2024 is a leap year
 	});
 
 	it("handles unsorted input and still computes correct average", () => {
 		const unsorted = [REL_2024_10, REL_2024_01, REL_2024_07, REL_2024_04];
 		const sorted = [REL_2024_01, REL_2024_04, REL_2024_07, REL_2024_10];
-		expect(avgIntervalDays(unsorted)).toBeCloseTo(avgIntervalDays(sorted)!, 5);
+		const unsortedAvg = avgIntervalDays(unsorted);
+		const sortedAvg = avgIntervalDays(sorted);
+		if (unsortedAvg === null || sortedAvg === null) return;
+		expect(unsortedAvg).toBeCloseTo(sortedAvg, 5);
 	});
 
 	it("calculates correct average across 5 evenly-spaced releases", () => {
@@ -52,8 +56,9 @@ describe("avgIntervalDays", () => {
 		];
 		const avg = avgIntervalDays(releases);
 		expect(avg).not.toBeNull();
-		expect(avg!).toBeGreaterThan(85);
-		expect(avg!).toBeLessThan(100);
+		if (avg === null) return;
+		expect(avg).toBeGreaterThan(85);
+		expect(avg).toBeLessThan(100);
 	});
 });
 
@@ -121,7 +126,8 @@ describe("projectNextVersion", () => {
 		];
 		const result = projectNextVersion(releases);
 		expect(result).not.toBeNull();
-		expect(result!.projectedDate! > "2025-01-01").toBe(true);
+		if (!result?.projectedDate) return;
+		expect(result.projectedDate > "2025-01-01").toBe(true);
 	});
 
 	it('returns announced date with confidence "announced" when announcedDate is provided', () => {
@@ -177,6 +183,7 @@ describe("projectNextLTS", () => {
 		const releases = [REL_2024_01, REL_2024_07, REL_2025_01];
 		const result = projectNextLTS(releases);
 		expect(result).not.toBeNull();
-		expect(result!.projectedDate! > "2025-01-01").toBe(true);
+		if (!result?.projectedDate) return;
+		expect(result.projectedDate > "2025-01-01").toBe(true);
 	});
 });

--- a/src/pages/maintenance-calendar/utils/fetcher.ts
+++ b/src/pages/maintenance-calendar/utils/fetcher.ts
@@ -15,8 +15,9 @@ export function mergePartials(
 ): TechCalendar[] {
 	const result = new Map(seed.map((t) => [t.id, { ...t }]));
 	for (const partial of partials) {
-		if (result.has(partial.id)) {
-			result.set(partial.id, { ...result.get(partial.id)!, ...partial });
+		const existing = result.get(partial.id);
+		if (existing) {
+			result.set(partial.id, { ...existing, ...partial });
 		}
 	}
 	return Array.from(result.values());
@@ -32,8 +33,9 @@ export function applyManualOverrides(
 ): TechCalendar[] {
 	const result = new Map(techs.map((t) => [t.id, { ...t }]));
 	for (const manual of manualEntries) {
-		if (result.has(manual.id)) {
-			result.set(manual.id, { ...result.get(manual.id)!, ...manual });
+		const existing = result.get(manual.id);
+		if (existing) {
+			result.set(manual.id, { ...existing, ...manual });
 		}
 	}
 	return Array.from(result.values());

--- a/src/pages/meeting-public/main.tsx
+++ b/src/pages/meeting-public/main.tsx
@@ -4,7 +4,9 @@ import "@cloudscape-design/global-styles/index.css";
 import "../../styles/tokens.css";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+ReactDOM.createRoot(container).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,

--- a/src/pages/meetings/__tests__/auth-gating.test.tsx
+++ b/src/pages/meetings/__tests__/auth-gating.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthState } from "../../../contexts/auth-context";
 import { AuthContext } from "../../../contexts/auth-context";
 
-type AnyProps = Record<string, any>;
+type MockProps = { [key: string]: React.ReactNode };
 
 class ResizeObserverMock {
 	observe() {}
@@ -25,7 +25,7 @@ vi.mock("../../../lib/auth", () => ({
 
 // Shell passes children through (skip AuthProvider wrap — we provide our own below).
 vi.mock("../../../layouts/shell", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("../../../components/navigation", () => ({

--- a/src/pages/meetings/__tests__/locale-rendering.test.tsx
+++ b/src/pages/meetings/__tests__/locale-rendering.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../contexts/locale-context";
 
-type AnyProps = Record<string, any>;
+type MockProps = { [key: string]: React.ReactNode };
 
 class ResizeObserverMock {
 	observe() {}
@@ -15,7 +15,18 @@ globalThis.ResizeObserver =
 
 // Mock Cloudscape components
 vi.mock("@cloudscape-design/components/table", () => ({
-	default: ({ header, items, columnDefinitions }: AnyProps) =>
+	default: ({
+		header,
+		items,
+		columnDefinitions,
+	}: {
+		header?: React.ReactNode;
+		items?: Record<string, unknown>[];
+		columnDefinitions?: {
+			id?: string;
+			cell?: (item: unknown) => React.ReactNode;
+		}[];
+	}) =>
 		React.createElement(
 			"div",
 			{ "data-testid": "table" },
@@ -24,7 +35,7 @@ vi.mock("@cloudscape-design/components/table", () => ({
 				React.createElement(
 					"div",
 					{ key: i, "data-testid": "table-row" },
-					(columnDefinitions ?? []).map((col: AnyProps) =>
+					(columnDefinitions ?? []).map((col) =>
 						React.createElement(
 							"div",
 							{ key: col.id, "data-testid": `cell-${col.id}` },
@@ -36,7 +47,7 @@ vi.mock("@cloudscape-design/components/table", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/header", () => ({
-	default: ({ children, actions }: AnyProps) =>
+	default: ({ children, actions }: MockProps) =>
 		React.createElement(
 			"div",
 			null,
@@ -45,18 +56,29 @@ vi.mock("@cloudscape-design/components/header", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/button", () => ({
-	default: ({ children, onClick }: AnyProps) =>
-		React.createElement("button", { onClick }, children),
+	default: ({
+		children,
+		onClick,
+	}: {
+		children?: React.ReactNode;
+		onClick?: () => void;
+	}) => React.createElement("button", { type: "button", onClick }, children),
 }));
 vi.mock("@cloudscape-design/components/space-between", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/pagination", () => ({
 	default: () => React.createElement("div", { "data-testid": "pagination" }),
 }));
 vi.mock("@cloudscape-design/components/modal", () => ({
-	default: ({ children, visible }: AnyProps) =>
+	default: ({
+		children,
+		visible,
+	}: {
+		children?: React.ReactNode;
+		visible?: boolean;
+	}) =>
 		visible
 			? React.createElement("div", { "data-testid": "modal" }, children)
 			: null,
@@ -66,7 +88,7 @@ vi.mock("../components/jitsi-embed", () => ({
 		React.createElement("div", { "data-testid": "jitsi-embed-stub" }),
 }));
 vi.mock("@cloudscape-design/components/text-filter", () => ({
-	default: ({ filteringPlaceholder }: AnyProps) =>
+	default: ({ filteringPlaceholder }: { filteringPlaceholder?: string }) =>
 		React.createElement("input", { placeholder: filteringPlaceholder }),
 }));
 vi.mock("@cloudscape-design/components/collection-preferences", () => ({
@@ -74,11 +96,11 @@ vi.mock("@cloudscape-design/components/collection-preferences", () => ({
 		React.createElement("div", { "data-testid": "collection-preferences" }),
 }));
 vi.mock("@cloudscape-design/components/box", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/collection-hooks", () => ({
-	useCollection: (_items: unknown[], _opts: AnyProps) => ({
+	useCollection: (_items: unknown[], _opts: Record<string, unknown>) => ({
 		items: [],
 		filterProps: { filteringText: "", onChange: vi.fn() },
 		actions: { setFiltering: vi.fn() },
@@ -96,10 +118,16 @@ vi.mock("@cloudscape-design/collection-hooks", () => ({
 
 // Mock Shell — render breadcrumbs and children so breadcrumb text is testable
 vi.mock("../../../layouts/shell", () => ({
-	default: ({ children, breadcrumbs }: AnyProps) =>
+	default: ({
+		children,
+		breadcrumbs,
+	}: {
+		children: React.ReactNode;
+		breadcrumbs?: React.ReactNode;
+	}) =>
 		React.createElement(
 			LocaleProvider,
-			{ locale: "us" } as any,
+			{ locale: "us" },
 			React.createElement(
 				"div",
 				{ "data-testid": "shell" },
@@ -111,7 +139,7 @@ vi.mock("../../../layouts/shell", () => ({
 
 // Mock Breadcrumbs — render active.text so locale-dependent text is visible
 vi.mock("../../../components/breadcrumbs", () => ({
-	default: ({ active }: AnyProps) =>
+	default: ({ active }: { active?: { text?: string } }) =>
 		React.createElement(
 			"nav",
 			{ "aria-label": "breadcrumbs" },
@@ -134,7 +162,7 @@ vi.mock("../../create-meeting/components/help-panel-home", () => ({
 
 // RequireAuth is exercised in its own unit tests; pass-through here so locale assertions can run.
 vi.mock("../../../components/require-auth", () => ({
-	RequireAuth: ({ children }: AnyProps) =>
+	RequireAuth: ({ children }: MockProps) =>
 		React.createElement(React.Fragment, null, children),
 }));
 

--- a/src/pages/meetings/components/__tests__/jitsi-embed.test.tsx
+++ b/src/pages/meetings/components/__tests__/jitsi-embed.test.tsx
@@ -39,11 +39,14 @@ function installFakeExternalApi(): {
 		const api: FakeApi = {
 			listeners: {},
 			addListener(ev, fn) {
-				(api.listeners[ev] ??= []).push(fn);
+				api.listeners[ev] ??= [];
+				api.listeners[ev].push(fn);
 			},
 			dispose: vi.fn(),
 			__fire(ev) {
-				(api.listeners[ev] ?? []).forEach((fn) => fn());
+				(api.listeners[ev] ?? []).forEach((fn) => {
+					fn();
+				});
 			},
 		};
 		latest = api;
@@ -59,9 +62,9 @@ describe("JitsiEmbed", () => {
 	beforeEach(async () => {
 		vi.useFakeTimers({ shouldAdvanceTime: true });
 		// Remove any prior-loaded script tag between tests.
-		document
-			.querySelectorAll("script[data-cdn-jitsi]")
-			.forEach((el) => el.parentNode?.removeChild(el));
+		document.querySelectorAll("script[data-cdn-jitsi]").forEach((el) => {
+			el.parentNode?.removeChild(el);
+		});
 		// Reset the single shared fetchJitsiToken mock queue without tearing down
 		// the module (tearing down would desync the component's captured import).
 		const { fetchJitsiToken } = await import("../../../../lib/jitsi-token");
@@ -70,8 +73,9 @@ describe("JitsiEmbed", () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
-		delete (window as unknown as { JitsiMeetExternalAPI?: unknown })
-			.JitsiMeetExternalAPI;
+		(
+			window as unknown as { JitsiMeetExternalAPI?: unknown }
+		).JitsiMeetExternalAPI = undefined;
 	});
 
 	it("happy path: fetches token, instantiates API with roomName+jwt, reaches live", async () => {
@@ -143,9 +147,10 @@ describe("JitsiEmbed", () => {
 		const { ctor, latest } = installFakeExternalApi();
 		const { unmount } = render(<JitsiEmbed roomName="room-z" />);
 		await waitFor(() => expect(ctor).toHaveBeenCalled());
-		const api = latest()!;
+		const api = latest();
+		expect(api).not.toBeNull();
 		unmount();
-		expect(api.dispose).toHaveBeenCalled();
+		expect(api?.dispose).toHaveBeenCalled();
 	});
 
 	it("readyToClose event → onClose callback fires", async () => {

--- a/src/pages/meetings/components/__tests__/meetings-table.test.tsx
+++ b/src/pages/meetings/components/__tests__/meetings-table.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthState } from "../../../../contexts/auth-context";
 import { AuthContext } from "../../../../contexts/auth-context";
 
-type AnyProps = Record<string, any>;
+type MockProps = { [key: string]: React.ReactNode };
 
 class ResizeObserverMock {
 	observe() {}
@@ -15,11 +15,11 @@ globalThis.ResizeObserver =
 	ResizeObserverMock as unknown as typeof ResizeObserver;
 
 vi.mock("@cloudscape-design/components/table", () => ({
-	default: ({ header }: AnyProps) =>
+	default: ({ header }: MockProps) =>
 		React.createElement("div", { "data-testid": "table" }, header),
 }));
 vi.mock("@cloudscape-design/components/header", () => ({
-	default: ({ children, actions }: AnyProps) =>
+	default: ({ children, actions }: MockProps) =>
 		React.createElement(
 			"div",
 			null,
@@ -28,18 +28,38 @@ vi.mock("@cloudscape-design/components/header", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/button", () => ({
-	default: ({ children, onClick, href }: AnyProps) =>
-		React.createElement("button", { onClick, "data-href": href }, children),
+	default: ({
+		children,
+		onClick,
+		href,
+	}: {
+		children?: React.ReactNode;
+		onClick?: () => void;
+		href?: string;
+	}) =>
+		React.createElement(
+			"button",
+			{ type: "button", onClick, "data-href": href },
+			children,
+		),
 }));
 vi.mock("@cloudscape-design/components/space-between", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/components/pagination", () => ({
 	default: () => React.createElement("div", { "data-testid": "pagination" }),
 }));
 vi.mock("@cloudscape-design/components/modal", () => ({
-	default: ({ children, visible, header }: AnyProps) =>
+	default: ({
+		children,
+		visible,
+		header,
+	}: {
+		children?: React.ReactNode;
+		visible?: boolean;
+		header?: React.ReactNode;
+	}) =>
 		visible
 			? React.createElement(
 					"div",
@@ -50,7 +70,7 @@ vi.mock("@cloudscape-design/components/modal", () => ({
 			: null,
 }));
 vi.mock("../jitsi-embed", () => ({
-	default: ({ roomName }: AnyProps) =>
+	default: ({ roomName }: { roomName?: string }) =>
 		React.createElement("div", {
 			"data-testid": "jitsi-embed-stub",
 			"data-room": roomName,
@@ -64,11 +84,11 @@ vi.mock("@cloudscape-design/components/collection-preferences", () => ({
 		React.createElement("div", { "data-testid": "collection-preferences" }),
 }));
 vi.mock("@cloudscape-design/components/box", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", null, children),
 }));
 vi.mock("@cloudscape-design/collection-hooks", () => ({
-	useCollection: (_items: unknown[], _opts: AnyProps) => ({
+	useCollection: (_items: unknown[], _opts: Record<string, unknown>) => ({
 		items: [],
 		filterProps: { filteringText: "", onChange: vi.fn() },
 		actions: { setFiltering: vi.fn() },

--- a/src/pages/meetings/components/jitsi-embed.tsx
+++ b/src/pages/meetings/components/jitsi-embed.tsx
@@ -15,8 +15,17 @@ export interface JitsiEmbedProps {
 // Window global exposed by external_api.js once loaded.
 declare global {
 	interface Window {
-		JitsiMeetExternalAPI?: any;
+		JitsiMeetExternalAPI?: new (
+			domain: string,
+			options: Record<string, unknown>,
+		) => JitsiApi;
 	}
+}
+
+interface JitsiApi {
+	addListener: (event: string, handler: () => void) => void;
+	executeCommand: (command: string, ...args: unknown[]) => void;
+	dispose?: () => void;
 }
 
 // Loads the jitsi external_api.js script once per page and resolves when ready.
@@ -95,7 +104,7 @@ export default function JitsiEmbed({
 	onClose,
 }: JitsiEmbedProps) {
 	const hostRef = useRef<HTMLDivElement | null>(null);
-	const apiRef = useRef<any>(null);
+	const apiRef = useRef<JitsiApi | null>(null);
 	const [status, setStatus] = useState<Status>("loading");
 	const [errorMsg, setErrorMsg] = useState<string>("");
 	const [retryKey, setRetryKey] = useState(0);
@@ -155,7 +164,7 @@ export default function JitsiEmbed({
 					if (!cancelled) setStatus("unreachable");
 				}, UNREACHABLE_MS);
 
-				const api: any = new window.JitsiMeetExternalAPI(domain, {
+				const api = new window.JitsiMeetExternalAPI(domain, {
 					roomName,
 					jwt: token,
 					password: roomPassword,

--- a/src/pages/meetings/main.tsx
+++ b/src/pages/meetings/main.tsx
@@ -9,7 +9,9 @@ import "./styles.css";
 
 import App from "./app";
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+const root = ReactDOM.createRoot(container);
 
 root.render(
 	<React.StrictMode>

--- a/src/pages/plans/main.tsx
+++ b/src/pages/plans/main.tsx
@@ -4,7 +4,9 @@ import "@cloudscape-design/global-styles/index.css";
 import "../../styles/tokens.css";
 import App from "./app";
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+const root = ReactDOM.createRoot(container);
 root.render(
 	<React.StrictMode>
 		<App />

--- a/src/pages/roadmap/__tests__/app.test.tsx
+++ b/src/pages/roadmap/__tests__/app.test.tsx
@@ -3,12 +3,12 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../contexts/locale-context";
 
-type AnyProps = Record<string, any>;
+type MockProps = { [key: string]: React.ReactNode };
 
 // --- Mock Cloudscape components (they hang in jsdom without mocking) ---
 
 vi.mock("@cloudscape-design/components/content-layout", () => ({
-	default: ({ children, header }: AnyProps) =>
+	default: ({ children, header }: MockProps) =>
 		React.createElement(
 			"div",
 			{ "data-testid": "content-layout" },
@@ -17,23 +17,23 @@ vi.mock("@cloudscape-design/components/content-layout", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/header", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("h2", { "data-testid": "header" }, children),
 }));
 vi.mock("@cloudscape-design/components/space-between", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", { "data-testid": "space-between" }, children),
 }));
 vi.mock("@cloudscape-design/components/box", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", { "data-testid": "box" }, children),
 }));
 vi.mock("@cloudscape-design/components/grid", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("div", { "data-testid": "grid" }, children),
 }));
 vi.mock("@cloudscape-design/components/container", () => ({
-	default: ({ children, header }: AnyProps) =>
+	default: ({ children, header }: MockProps) =>
 		React.createElement(
 			"div",
 			{ "data-testid": "container" },
@@ -42,7 +42,7 @@ vi.mock("@cloudscape-design/components/container", () => ({
 		),
 }));
 vi.mock("@cloudscape-design/components/badge", () => ({
-	default: ({ children }: AnyProps) =>
+	default: ({ children }: MockProps) =>
 		React.createElement("span", { "data-testid": "badge" }, children),
 }));
 
@@ -58,7 +58,7 @@ vi.mock("../../../layouts/shell", () => ({
 	}) =>
 		React.createElement(
 			LocaleProvider,
-			{ locale: "us" } as any,
+			{ locale: "us" },
 			React.createElement(
 				"div",
 				{ "data-testid": "shell" },

--- a/src/pages/roadmap/app.tsx
+++ b/src/pages/roadmap/app.tsx
@@ -59,8 +59,10 @@ function AppContent() {
 					</a>
 				))}
 			</nav>
+			{/* biome-ignore lint/a11y/useSemanticElements: CSS grid layout on .cdn-roadmap-board requires div; converting to ul would introduce default list-style/padding/margin breaking the kanban grid */}
 			<div className="cdn-roadmap-board" role="list">
 				{boardColumns.map((column) => (
+					// biome-ignore lint/a11y/useSemanticElements: CSS grid layout requires section for kanban columns; list semantics provided via role
 					<section
 						key={column.key}
 						id={`cdn-roadmap-col-${column.key}`}

--- a/src/pages/roadmap/main.tsx
+++ b/src/pages/roadmap/main.tsx
@@ -4,7 +4,9 @@ import "@cloudscape-design/global-styles/index.css";
 import "../../styles/tokens.css";
 import App from "./app";
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+const root = ReactDOM.createRoot(container);
 root.render(
 	<React.StrictMode>
 		<App />

--- a/src/pages/theme/main.tsx
+++ b/src/pages/theme/main.tsx
@@ -6,7 +6,9 @@ import "@cloudscape-design/global-styles/index.css";
 import "../../styles/tokens.css";
 import App from "./app";
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+const root = ReactDOM.createRoot(container);
 root.render(
 	<React.StrictMode>
 		<App />

--- a/src/sites/auth/_layout/CodeInput.tsx
+++ b/src/sites/auth/_layout/CodeInput.tsx
@@ -110,6 +110,7 @@ export default function CodeInput({
 	}
 
 	return (
+		// biome-ignore lint/a11y/useSemanticElements: OTP code input row, not a form fieldset; group semantics provided via role
 		<div className="cdn-auth-code-row" role="group" aria-label={ariaLabel}>
 			{cells.map((ch, i) => (
 				<input

--- a/src/sites/auth/forgot-password/main.tsx
+++ b/src/sites/auth/forgot-password/main.tsx
@@ -5,7 +5,9 @@ import ReactDOM from "react-dom/client";
 import "@cloudscape-design/global-styles/index.css";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+ReactDOM.createRoot(container).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,

--- a/src/sites/auth/login/app.tsx
+++ b/src/sites/auth/login/app.tsx
@@ -127,16 +127,20 @@ function LoginForm() {
 				"[passkey] initiatePasskeyAuth succeeded, credentials keys:",
 				Object.keys(credentials),
 			);
-			const publicKey = (credentials as any).publicKey ?? credentials;
-			publicKey.challenge = base64urlToBuffer(publicKey.challenge);
+			const publicKey =
+				((credentials as Record<string, unknown>).publicKey as Record<
+					string,
+					unknown
+				>) ?? (credentials as Record<string, unknown>);
+			publicKey.challenge = base64urlToBuffer(publicKey.challenge as string);
 			if (publicKey.allowCredentials) {
-				publicKey.allowCredentials = publicKey.allowCredentials.map(
-					(c: any) => ({ ...c, id: base64urlToBuffer(c.id) }),
-				);
+				publicKey.allowCredentials = (
+					publicKey.allowCredentials as Array<Record<string, unknown>>
+				).map((c) => ({ ...c, id: base64urlToBuffer(c.id as string) }));
 			}
 			console.log("[passkey] calling navigator.credentials.get");
 			const assertion = (await navigator.credentials.get({
-				publicKey,
+				publicKey: publicKey as unknown as PublicKeyCredentialRequestOptions,
 			})) as PublicKeyCredential;
 			if (!assertion) throw new AuthError("passkey cancelled");
 			console.log("[passkey] got assertion, calling completePasskeyAuth");

--- a/src/sites/auth/login/main.tsx
+++ b/src/sites/auth/login/main.tsx
@@ -5,7 +5,9 @@ import ReactDOM from "react-dom/client";
 import "@cloudscape-design/global-styles/index.css";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+ReactDOM.createRoot(container).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,

--- a/src/sites/auth/passkeys/app.tsx
+++ b/src/sites/auth/passkeys/app.tsx
@@ -15,10 +15,21 @@ import {
 	deleteWebAuthnCredential,
 	getAccessToken,
 	listWebAuthnCredentials,
+	type RegistrationResponseJSON,
 	startWebAuthnRegistration,
 } from "../../../lib/cognito";
 import AuthLayout from "../_layout";
 import "./styles.css";
+
+/** Cognito creation options shape — may arrive as string or nested object. */
+interface CreationOptionsPayload {
+	publicKey?: Record<string, unknown>;
+	challenge?: string;
+	user?: { id: string };
+	excludeCredentials?: Array<{ id: string; type: string }>;
+	authenticatorSelection?: Record<string, unknown>;
+	[key: string]: unknown;
+}
 
 function PasskeyManager() {
 	const [credentials, setCredentials] = useState<
@@ -54,37 +65,52 @@ function PasskeyManager() {
 		setSuccess("");
 		try {
 			const options = await startWebAuthnRegistration();
-			let creationOptions = (options.CredentialCreationOptions ??
-				(options as any).credentialCreationOptions) as any;
+			let creationOptions: CreationOptionsPayload | string | undefined =
+				(options.CredentialCreationOptions ??
+					(options as Record<string, unknown>).credentialCreationOptions) as
+					| CreationOptionsPayload
+					| string
+					| undefined;
 			if (!creationOptions)
 				throw new AuthError(
 					"WebAuthn registration not available — check pool configuration",
 				);
 			if (typeof creationOptions === "string")
-				creationOptions = JSON.parse(creationOptions);
+				creationOptions = JSON.parse(creationOptions) as CreationOptionsPayload;
 			// Cognito returns the publicKey options directly (no .publicKey wrapper)
-			const publicKey = creationOptions.publicKey ?? creationOptions;
-			publicKey.challenge = base64urlToBuffer(publicKey.challenge);
-			publicKey.user.id = base64urlToBuffer(publicKey.user.id);
-			if (publicKey.excludeCredentials) {
-				publicKey.excludeCredentials = publicKey.excludeCredentials.map(
-					(c: any) => ({
-						...c,
-						id: base64urlToBuffer(c.id),
-					}),
-				);
+			const publicKey =
+				(creationOptions as CreationOptionsPayload).publicKey ??
+				(creationOptions as Record<string, unknown>);
+			(publicKey as Record<string, unknown>).challenge = base64urlToBuffer(
+				(publicKey as Record<string, unknown>).challenge as string,
+			);
+			(
+				publicKey as Record<string, unknown> & { user: { id: string } }
+			).user.id = base64urlToBuffer(
+				(publicKey as Record<string, unknown> & { user: { id: string } }).user
+					.id,
+			) as unknown as string;
+			if ((publicKey as Record<string, unknown>).excludeCredentials) {
+				(publicKey as Record<string, unknown>).excludeCredentials = (
+					(publicKey as Record<string, unknown>).excludeCredentials as Array<
+						Record<string, unknown>
+					>
+				).map((c) => ({
+					...c,
+					id: base64urlToBuffer(c.id as string),
+				}));
 			}
 			const credential = (await navigator.credentials.create({
-				publicKey,
-			})) as PublicKeyCredential;
+				publicKey: publicKey as unknown as PublicKeyCredentialCreationOptions,
+			})) as PublicKeyCredential | null;
 			if (!credential) throw new AuthError("registration cancelled");
 			const attestation =
 				credential.response as AuthenticatorAttestationResponse;
 
 			// Use toJSON() if available (WebAuthn L3) — Cognito expects this format
-			const credentialData =
-				typeof (credential as any).toJSON === "function"
-					? (credential as any).toJSON()
+			const credentialData: RegistrationResponseJSON =
+				"toJSON" in credential && typeof credential.toJSON === "function"
+					? (credential.toJSON() as unknown as RegistrationResponseJSON)
 					: {
 							id: credential.id,
 							rawId: bufferToBase64url(credential.rawId),
@@ -132,33 +158,49 @@ function PasskeyManager() {
 		setSuccess("");
 		try {
 			const options = await startWebAuthnRegistration();
-			let creationOptions = (options.CredentialCreationOptions ??
-				(options as any).credentialCreationOptions) as any;
+			let creationOptions: CreationOptionsPayload | string | undefined =
+				(options.CredentialCreationOptions ??
+					(options as Record<string, unknown>).credentialCreationOptions) as
+					| CreationOptionsPayload
+					| string
+					| undefined;
 			if (!creationOptions) throw new AuthError("WebAuthn not available");
 			if (typeof creationOptions === "string")
-				creationOptions = JSON.parse(creationOptions);
-			const publicKey = creationOptions.publicKey ?? creationOptions;
-			publicKey.challenge = base64urlToBuffer(publicKey.challenge);
-			publicKey.user.id = base64urlToBuffer(publicKey.user.id);
-			if (publicKey.excludeCredentials) {
-				publicKey.excludeCredentials = publicKey.excludeCredentials.map(
-					(c: any) => ({ ...c, id: base64urlToBuffer(c.id) }),
-				);
+				creationOptions = JSON.parse(creationOptions) as CreationOptionsPayload;
+			const publicKey =
+				(creationOptions as CreationOptionsPayload).publicKey ??
+				(creationOptions as Record<string, unknown>);
+			(publicKey as Record<string, unknown>).challenge = base64urlToBuffer(
+				(publicKey as Record<string, unknown>).challenge as string,
+			);
+			(
+				publicKey as Record<string, unknown> & { user: { id: string } }
+			).user.id = base64urlToBuffer(
+				(publicKey as Record<string, unknown> & { user: { id: string } }).user
+					.id,
+			) as unknown as string;
+			if ((publicKey as Record<string, unknown>).excludeCredentials) {
+				(publicKey as Record<string, unknown>).excludeCredentials = (
+					(publicKey as Record<string, unknown>).excludeCredentials as Array<
+						Record<string, unknown>
+					>
+				).map((c) => ({ ...c, id: base64urlToBuffer(c.id as string) }));
 			}
 			// Force cross-platform — triggers QR code for phone/tablet
 			publicKey.authenticatorSelection = {
-				...publicKey.authenticatorSelection,
+				...((publicKey.authenticatorSelection as Record<string, unknown>) ??
+					{}),
 				authenticatorAttachment: "cross-platform",
 			};
 			const credential = (await navigator.credentials.create({
-				publicKey,
-			})) as PublicKeyCredential;
+				publicKey: publicKey as unknown as PublicKeyCredentialCreationOptions,
+			})) as PublicKeyCredential | null;
 			if (!credential) throw new AuthError("registration cancelled");
 			const attestation =
 				credential.response as AuthenticatorAttestationResponse;
-			const credentialData =
-				typeof (credential as any).toJSON === "function"
-					? (credential as any).toJSON()
+			const credentialData: RegistrationResponseJSON =
+				"toJSON" in credential && typeof credential.toJSON === "function"
+					? (credential.toJSON() as unknown as RegistrationResponseJSON)
 					: {
 							id: credential.id,
 							rawId: bufferToBase64url(credential.rawId),

--- a/src/sites/auth/passkeys/main.tsx
+++ b/src/sites/auth/passkeys/main.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+ReactDOM.createRoot(container).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,

--- a/src/sites/auth/signup/main.tsx
+++ b/src/sites/auth/signup/main.tsx
@@ -5,7 +5,9 @@ import ReactDOM from "react-dom/client";
 import "@cloudscape-design/global-styles/index.css";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+ReactDOM.createRoot(container).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,

--- a/src/sites/auth/verification-setup/main.tsx
+++ b/src/sites/auth/verification-setup/main.tsx
@@ -3,7 +3,9 @@ import ReactDOM from "react-dom/client";
 import "@cloudscape-design/global-styles/index.css";
 import App from "./index";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+ReactDOM.createRoot(container).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,

--- a/src/sites/auth/verify/main.tsx
+++ b/src/sites/auth/verify/main.tsx
@@ -5,7 +5,9 @@ import ReactDOM from "react-dom/client";
 import "@cloudscape-design/global-styles/index.css";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+ReactDOM.createRoot(container).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,

--- a/src/sites/awsug/_shared/auth.ts
+++ b/src/sites/awsug/_shared/auth.ts
@@ -88,7 +88,9 @@ export function storeTokensFromFragment(
 
 export function clearTokens(): void {
 	[KEY_ID_TOKEN, KEY_ACCESS_TOKEN, KEY_REFRESH_TOKEN, KEY_EXPIRES_AT].forEach(
-		(k) => sessionStorage.removeItem(k),
+		(k) => {
+			sessionStorage.removeItem(k);
+		},
 	);
 }
 

--- a/src/sites/awsug/admin/main.tsx
+++ b/src/sites/awsug/admin/main.tsx
@@ -6,7 +6,9 @@ import "@cloudscape-design/global-styles/index.css";
 import "../../../styles/tokens.css";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+ReactDOM.createRoot(container).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,

--- a/src/sites/awsug/auth/callback/main.tsx
+++ b/src/sites/awsug/auth/callback/main.tsx
@@ -6,7 +6,9 @@ import "@cloudscape-design/global-styles/index.css";
 import "../../../../styles/tokens.css";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+ReactDOM.createRoot(container).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,

--- a/src/sites/awsug/auth/redeem/main.tsx
+++ b/src/sites/awsug/auth/redeem/main.tsx
@@ -6,7 +6,9 @@ import "@cloudscape-design/global-styles/index.css";
 import "../../../../styles/tokens.css";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+ReactDOM.createRoot(container).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,

--- a/src/sites/awsug/create-meeting/main.tsx
+++ b/src/sites/awsug/create-meeting/main.tsx
@@ -6,7 +6,9 @@ import "@cloudscape-design/global-styles/index.css";
 import "../../../styles/tokens.css";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+ReactDOM.createRoot(container).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,

--- a/src/sites/awsug/main.tsx
+++ b/src/sites/awsug/main.tsx
@@ -6,7 +6,9 @@ import "@cloudscape-design/global-styles/index.css";
 import "../../styles/tokens.css";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+ReactDOM.createRoot(container).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,

--- a/src/sites/awsug/meetings/app.tsx
+++ b/src/sites/awsug/meetings/app.tsx
@@ -26,7 +26,6 @@ const MEETUP_URL = "https://www.meetup.com/cloud-del-norte/";
 const ROOM_NAME = "cloud-del-norte-awsug";
 
 function MeetingsContent({ auth }: { auth: AuthState }) {
-	const { t } = useTranslation();
 	const [inCall, setInCall] = useState(false);
 
 	return (

--- a/src/sites/awsug/meetings/main.tsx
+++ b/src/sites/awsug/meetings/main.tsx
@@ -6,7 +6,9 @@ import "@cloudscape-design/global-styles/index.css";
 import "../../../styles/tokens.css";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+ReactDOM.createRoot(container).render(
 	<React.StrictMode>
 		<App />
 	</React.StrictMode>,

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -61,10 +61,8 @@ export function createNavigationMock(_importDepth: number) {
  * @param importDepth - Number of "../" needed to reach src/ from test file location
  */
 export function createBreadcrumbsMock(_importDepth: number) {
-	type AnyProps = Record<string, any>;
-
 	return {
-		default: ({ active }: AnyProps) =>
+		default: ({ active }: { active?: { text?: string } }) =>
 			React.createElement(
 				"nav",
 				{ "aria-label": "breadcrumbs" },

--- a/src/utils/__tests__/wave-71-perf-contrast.test.ts
+++ b/src/utils/__tests__/wave-71-perf-contrast.test.ts
@@ -36,7 +36,8 @@ describe("Wave 71 — Bug 1: no transition:all on cdn-viz-active", () => {
 			/\.cdn-viz-active\s*\{[^}]*transition:[^}]*\}/,
 		);
 		expect(vizBlock).not.toBeNull();
-		const block = vizBlock![0];
+		if (!vizBlock) return;
+		const block = vizBlock[0];
 		expect(block).toMatch(/background-color/);
 		expect(block).toMatch(/color/);
 		expect(block).not.toMatch(/transition:\s*all/);
@@ -94,14 +95,16 @@ describe("Wave 71 — Bug 2: backdrop-filter capped at 4px", () => {
 		const css = readCss("pages/create-meeting/components/help-panel.css");
 		const roleCardBlock = css.match(/\.hp-role-card\s*\{[^}]*\}/);
 		expect(roleCardBlock).not.toBeNull();
-		expect(roleCardBlock![0]).not.toMatch(/backdrop-filter/);
+		if (!roleCardBlock) return;
+		expect(roleCardBlock[0]).not.toMatch(/backdrop-filter/);
 	});
 
 	it("hp-leader has no backdrop-filter", () => {
 		const css = readCss("pages/create-meeting/components/help-panel.css");
 		const leaderBlock = css.match(/\.hp-leader\s*\{[^}]*\}/);
 		expect(leaderBlock).not.toBeNull();
-		expect(leaderBlock![0]).not.toMatch(/backdrop-filter/);
+		if (!leaderBlock) return;
+		expect(leaderBlock[0]).not.toMatch(/backdrop-filter/);
 	});
 });
 
@@ -136,13 +139,15 @@ describe("Wave 71 — Bug 4: next-meetup spacing uses token grid", () => {
 	it("feed-mini-card__link uses var(--cdn-space-*) for padding", () => {
 		const block = feedCss.match(/\.feed-mini-card__link\s*\{[^}]*\}/s);
 		expect(block).not.toBeNull();
-		expect(block![0]).toMatch(/padding:.*var\(--cdn-space-/);
+		if (!block) return;
+		expect(block[0]).toMatch(/padding:.*var\(--cdn-space-/);
 	});
 
 	it("feed-mini-card__link uses var(--cdn-space-*) for gap", () => {
 		const block = feedCss.match(/\.feed-mini-card__link\s*\{[^}]*\}/s);
 		expect(block).not.toBeNull();
-		expect(block![0]).toMatch(/gap:.*var\(--cdn-space-/);
+		if (!block) return;
+		expect(block[0]).toMatch(/gap:.*var\(--cdn-space-/);
 	});
 });
 
@@ -154,7 +159,7 @@ describe("Wave 71 — Bonus: version bump", () => {
 		);
 		const versionMatch = footerTsx.match(/0\.0\.0(\d+)/);
 		expect(versionMatch).not.toBeNull();
-		const versionNum = Number.parseInt(versionMatch![1], 10);
+		const versionNum = Number.parseInt(versionMatch?.[1] ?? "0", 10);
 		expect(versionNum).toBeGreaterThanOrEqual(147);
 	});
 });


### PR DESCRIPTION
Clears ALL 165 remaining biome warnings to zero:
- noNonNullAssertion (54)
- noExplicitAny (42)
- a11y useSemanticElements/useButtonType (18)
- noStaticOnlyClass, noUnusedFunctionParameters, useHookAtTopLevel, noDelete, useIterableCallbackReturn, useExhaustiveDependencies, etc.

**Approach:** precise types + null-guards + semantic elements; justified inline suppressions only where the ARIA-role pattern is intentional (styled marquee headings) or test-mocks instantiate class-based APIs.

**Verification:** tsc clean. 88 files changed (all under src/). Pre-commit hook passed.

**Pre-existing test failures (unchanged, verified on clean main):**
- `maintenance-calendar/build-output.test` — needs a built `lib/` directory
- `wave-71-perf-contrast.test` — asserts `backdrop-filter<=4px` which is stale vs shipped glassmorphism

These 6 test failures are NOT introduced by this PR.

Closes #261