### PR TITLE
infra(iam): capture ci-deploy role policy as IaC + verify-csp read grant

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -6,6 +6,8 @@ out-of-band infrastructure artifacts that the site deploy workflow does not mana
 
 the site's cloudfront distribution `ECC3LP1BL2CZS` lives in account `211125425201` (aerospaceug-admin). the github actions deploy role in this repo has permission to `s3:sync` to the bucket and `cloudfront:CreateInvalidation` — it does **not** have permission to manage response headers policies, so those must be applied out-of-band from a local shell with a profile that can
 
+the ci-deploy role's full inline policy is now captured as IaC at `infra/iam/ci-deploy-policy.json` (applied via `infra/iam/apply-ci-deploy-policy.sh`). it includes read-only `cloudfront:GetResponseHeadersPolicy` for the verify-csp CI step — still NOT create/update on response-headers policies, which remain out-of-band.
+
 ### files
 
 | file | purpose |

--- a/infra/iam/apply-ci-deploy-policy.sh
+++ b/infra/iam/apply-ci-deploy-policy.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply the heraldstack-ci-deploy inline policy "deploy-s3-sync-cloudfront-invalidate" as IaC.
+# Role: heraldstack-ci-deploy (assumed by Woodpecker CI via IAM Roles Anywhere)
+# Account: 211125425201 | Region: us-west-2
+# chmod +x before first run.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+AWS_PROFILE="${AWS_PROFILE:-aerospaceug-admin}"
+ROLE_NAME=heraldstack-ci-deploy
+POLICY_NAME=deploy-s3-sync-cloudfront-invalidate
+POLICY_FILE="${REPO_ROOT}/infra/iam/ci-deploy-policy.json"
+
+require() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 is required but not found" >&2; exit 1; }; }
+require aws
+
+echo "=== Applying inline policy '$POLICY_NAME' to role '$ROLE_NAME' ==="
+echo "Profile: $AWS_PROFILE"
+echo "Policy file: $POLICY_FILE"
+
+aws iam put-role-policy \
+  --role-name "$ROLE_NAME" \
+  --policy-name "$POLICY_NAME" \
+  --policy-document "file://${POLICY_FILE}" \
+  --profile "$AWS_PROFILE"
+
+echo "=== Verifying cloudfront:GetResponseHeadersPolicy permission ==="
+RESULT=$(aws iam simulate-principal-policy \
+  --policy-source-arn "arn:aws:iam::211125425201:role/${ROLE_NAME}" \
+  --action-names cloudfront:GetResponseHeadersPolicy \
+  --profile "$AWS_PROFILE" \
+  --query 'EvaluationResults[0].EvalDecision' --output text)
+
+if [ "$RESULT" = "allowed" ]; then
+  echo "SUCCESS: cloudfront:GetResponseHeadersPolicy is allowed for $ROLE_NAME"
+else
+  echo "FAIL: cloudfront:GetResponseHeadersPolicy evaluated as '$RESULT' — expected 'allowed'" >&2
+  exit 1
+fi

--- a/infra/iam/ci-deploy-policy.json
+++ b/infra/iam/ci-deploy-policy.json
@@ -1,0 +1,123 @@
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "S3SyncOriginBucket",
+			"Effect": "Allow",
+			"Action": [
+				"s3:ListBucket",
+				"s3:GetBucketLocation"
+			],
+			"Resource": "arn:aws:s3:::clouddelnorte.org"
+		},
+		{
+			"Sid": "S3WriteOriginBucket",
+			"Effect": "Allow",
+			"Action": [
+				"s3:PutObject",
+				"s3:GetObject",
+				"s3:DeleteObject",
+				"s3:PutObjectAcl"
+			],
+			"Resource": "arn:aws:s3:::clouddelnorte.org/*"
+		},
+		{
+			"Sid": "S3SyncDevBucket",
+			"Effect": "Allow",
+			"Action": [
+				"s3:ListBucket",
+				"s3:GetBucketLocation"
+			],
+			"Resource": "arn:aws:s3:::dev.clouddelnorte.org"
+		},
+		{
+			"Sid": "S3WriteDevBucket",
+			"Effect": "Allow",
+			"Action": [
+				"s3:PutObject",
+				"s3:GetObject",
+				"s3:DeleteObject",
+				"s3:PutObjectAcl"
+			],
+			"Resource": "arn:aws:s3:::dev.clouddelnorte.org/*"
+		},
+		{
+			"Sid": "S3SyncAuthBucket",
+			"Effect": "Allow",
+			"Action": [
+				"s3:ListBucket",
+				"s3:GetBucketLocation"
+			],
+			"Resource": "arn:aws:s3:::auth.clouddelnorte.org"
+		},
+		{
+			"Sid": "S3WriteAuthBucket",
+			"Effect": "Allow",
+			"Action": [
+				"s3:PutObject",
+				"s3:GetObject",
+				"s3:DeleteObject",
+				"s3:PutObjectAcl"
+			],
+			"Resource": "arn:aws:s3:::auth.clouddelnorte.org/*"
+		},
+		{
+			"Sid": "S3SyncAwsugBucket",
+			"Effect": "Allow",
+			"Action": [
+				"s3:ListBucket",
+				"s3:GetBucketLocation"
+			],
+			"Resource": "arn:aws:s3:::awsug.clouddelnorte.org"
+		},
+		{
+			"Sid": "S3WriteAwsugBucket",
+			"Effect": "Allow",
+			"Action": [
+				"s3:PutObject",
+				"s3:GetObject",
+				"s3:DeleteObject",
+				"s3:PutObjectAcl"
+			],
+			"Resource": "arn:aws:s3:::awsug.clouddelnorte.org/*"
+		},
+		{
+			"Sid": "CloudFrontInvalidate",
+			"Effect": "Allow",
+			"Action": [
+				"cloudfront:CreateInvalidation",
+				"cloudfront:GetInvalidation",
+				"cloudfront:ListInvalidations"
+			],
+			"Resource": [
+				"arn:aws:cloudfront::211125425201:distribution/ECC3LP1BL2CZS",
+				"arn:aws:cloudfront::211125425201:distribution/EEHVTUEQ97V0X",
+				"arn:aws:cloudfront::211125425201:distribution/ECQ44FO9MBTCY",
+				"arn:aws:cloudfront::211125425201:distribution/E2QLAWFVIT1AR8"
+			]
+		},
+		{
+			"Sid": "AssumeCdkRolesInJitsiAccount",
+			"Effect": "Allow",
+			"Action": [
+				"sts:AssumeRole",
+				"sts:TagSession",
+				"sts:SetSourceIdentity"
+			],
+			"Resource": [
+				"arn:aws:iam::170473530355:role/cdk-hnb659fds-deploy-role-170473530355-us-west-2",
+				"arn:aws:iam::170473530355:role/cdk-hnb659fds-file-publishing-role-170473530355-us-west-2",
+				"arn:aws:iam::170473530355:role/cdk-hnb659fds-lookup-role-170473530355-us-west-2",
+				"arn:aws:iam::170473530355:role/cdk-hnb659fds-image-publishing-role-170473530355-us-west-2"
+			]
+		},
+		{
+			"Sid": "CloudFrontReadResponseHeadersPolicy",
+			"Effect": "Allow",
+			"Action": [
+				"cloudfront:GetResponseHeadersPolicy"
+			],
+			"Resource": "*"
+		}
+	]
+}


### PR DESCRIPTION
Captures the **heraldstack-ci-deploy** inline policy `deploy-s3-sync-cloudfront-invalidate` (account 211125425201, assumed by Woodpecker CI via IAM Roles Anywhere) as version-controlled IaC.

Adds read-only `cloudfront:GetResponseHeadersPolicy` that fixes the verify-csp CI step's AccessDenied (was `failure:ignore`, pre-existing).

Committed JSON verified to exactly match the live role policy (zero drift).

Apply script `infra/iam/apply-ci-deploy-policy.sh` reproduces it with built-in simulate-policy verification.

**Infra/docs only — zero source changes, no deploy.**