### PR TITLE
fix(cognito): capture SES email + auto-verify config as IaC

### DIFF
--- a/infra/cognito-apply-email-config.sh
+++ b/infra/cognito-apply-email-config.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply Cognito email verification config (non-clobber pattern) as IaC.
+# Pool: us-west-2_cyPQF4F3r | Account: 170473530355 | Region: us-west-2
+# Profile default: jitsi-video-hosting
+# chmod +x before first run.
+#
+# WARNING: aws cognito-idp update-user-pool RESETS any field you omit.
+# This script reads the live config first and merges changes to avoid clobber.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+POOL="us-west-2_cyPQF4F3r"
+REGION="us-west-2"
+PROFILE="${AWS_PROFILE:-jitsi-video-hosting}"
+
+require() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 is required but not found" >&2; exit 1; }; }
+require aws
+require jq
+
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+echo "=== Fetching live pool config ==="
+aws cognito-idp describe-user-pool \
+  --user-pool-id "$POOL" \
+  --region "$REGION" \
+  --profile "$PROFILE" \
+  --query 'UserPool' > "$TMPFILE"
+
+echo "=== Building update payload (non-clobber merge) ==="
+PAYLOAD=$(jq --arg pool "$POOL" '{
+  UserPoolId: $pool,
+  Policies: .Policies,
+  DeletionProtection: .DeletionProtection,
+  LambdaConfig: .LambdaConfig,
+  AutoVerifiedAttributes: ["email"],
+  UserAttributeUpdateSettings: .UserAttributeUpdateSettings,
+  MfaConfiguration: .MfaConfiguration,
+  AdminCreateUserConfig: .AdminCreateUserConfig,
+  AccountRecoverySetting: .AccountRecoverySetting,
+  VerificationMessageTemplate: .VerificationMessageTemplate,
+  EmailConfiguration: {
+    SourceArn: "arn:aws:ses:us-west-2:170473530355:identity/clouddelnorte.org",
+    EmailSendingAccount: "DEVELOPER",
+    From: "Cloud del Norte <no-reply@clouddelnorte.org>"
+  }
+} | with_entries(select(.value != null and .value != {} and .value != []))' "$TMPFILE")
+
+echo "=== Applying update-user-pool ==="
+echo "$PAYLOAD" | aws cognito-idp update-user-pool \
+  --cli-input-json file:///dev/stdin \
+  --region "$REGION" \
+  --profile "$PROFILE"
+
+echo "=== Post-apply verification ==="
+VERIFY=$(aws cognito-idp describe-user-pool \
+  --user-pool-id "$POOL" \
+  --region "$REGION" \
+  --profile "$PROFILE" \
+  --query 'UserPool')
+
+FAIL=0
+check() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "FAIL: $label = '$actual', expected '$expected'" >&2
+    FAIL=1
+  else
+    echo "OK: $label = $actual"
+  fi
+}
+
+check "$(echo "$VERIFY" | jq -r '.EmailConfiguration.EmailSendingAccount')" "DEVELOPER" "EmailSendingAccount"
+check "$(echo "$VERIFY" | jq -r '.AutoVerifiedAttributes | contains(["email"])')" "true" "AutoVerifiedAttributes contains email"
+check "$(echo "$VERIFY" | jq -r '.DeletionProtection')" "ACTIVE" "DeletionProtection"
+check "$(echo "$VERIFY" | jq -r '.MfaConfiguration')" "OPTIONAL" "MfaConfiguration"
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "ERROR: Post-apply verification failed" >&2
+  exit 1
+fi
+echo "=== All checks passed ==="

--- a/infra/cognito-auth.md
+++ b/infra/cognito-auth.md
@@ -62,10 +62,18 @@ user authentication for cloud del norte via amazon cognito user pools.
 
 ## email verification
 
-- auto-verified attributes: email
+- auto-verified attributes: email (re-asserted 2026-05-31 after being found null)
 - verification method: CONFIRM_WITH_CODE (6-digit code)
-- email sender: COGNITO_DEFAULT (no-reply@verificationemail.com)
-- delivery: email sent on SignUp, user confirms via ConfirmSignUp API
+- email sender: SES DEVELOPER mode via verified domain identity clouddelnorte.org, From 'Cloud del Norte <no-reply@clouddelnorte.org>'
+- delivery: code sent on SignUp, confirmed via ConfirmSignUp API
+
+> **WARNING:** `update-user-pool` resets any omitted field — always use `infra/cognito-apply-email-config.sh`.
+
+**2026-05-31 fix note:** Two root causes were found and corrected:
+1. `AutoVerifiedAttributes` had been clobbered to null (likely by an earlier `update-user-pool` call that omitted the field), causing the UNCONFIRMED user backlog — no verification codes were sent.
+2. `EmailSendingAccount` was `COGNITO_DEFAULT` (generic no-reply@verificationemail.com) — switched to SES DEVELOPER mode for deliverability via the verified clouddelnorte.org domain.
+
+IaC apply path: `infra/cognito-apply-email-config.sh`.
 
 ## admin operations
 

--- a/infra/cognito-email-config.json
+++ b/infra/cognito-email-config.json
@@ -1,0 +1,20 @@
+{
+	"UserPoolId": "us-west-2_cyPQF4F3r",
+	"Region": "us-west-2",
+	"Account": "170473530355",
+	"EmailConfiguration": {
+		"SourceArn": "arn:aws:ses:us-west-2:170473530355:identity/clouddelnorte.org",
+		"EmailSendingAccount": "DEVELOPER",
+		"From": "Cloud del Norte <no-reply@clouddelnorte.org>"
+	},
+	"AutoVerifiedAttributes": [
+		"email"
+	],
+	"VerificationMessageTemplate": {
+		"DefaultEmailOption": "CONFIRM_WITH_CODE"
+	},
+	"UsernameAttributes": [
+		"email"
+	],
+	"MfaConfiguration": "OPTIONAL"
+}


### PR DESCRIPTION
## Summary

Captures the live Cognito email-verification fix as infrastructure-as-code.

### Root causes of signup verification failure

1. **AutoVerifiedAttributes was null** — Cognito never triggered verification code delivery on signup.
2. **EmailSendingAccount was COGNITO_DEFAULT** — emails were not routed through the verified SES identity, causing silent send failures.

### Live fix already applied & proven

The configuration was corrected in the AWS console. CloudWatch SES metrics confirm:
- Send = 1, Delivery = 1, Bounce = 0

Signup verification emails now arrive reliably.

### What this PR adds

- `infra/cognito-apply-email-config.sh` — idempotent apply script for the corrected user-pool config
- `infra/cognito-email-config.json` — config snapshot (AutoVerifiedAttributes + SES sender)
- `infra/cognito-auth.md` — updated documentation reflecting the fix

**Infra/docs only — no application code changes, no deploy required.**