### PR TITLE
fix(feed): remove on-site RSVP CTA — signup flow unproven

### DIFF
--- a/src/pages/feed/components/__tests__/featured-event.test.tsx
+++ b/src/pages/feed/components/__tests__/featured-event.test.tsx
@@ -40,10 +40,11 @@ afterEach(() => {
 });
 
 describe("FeaturedEvent", () => {
-	it("renders the v2 event title with link to auth.clouddelnorte.org signup with rsvp return_to", () => {
+	it("renders the v2 event title linking to the Meetup RSVP URL", () => {
 		renderWithLocale("us");
 		const link = screen.getByText("Community Happy Hour & Networking Night");
-		const expected = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent("/rsvp/index.html?event=happy-hour-2026-06-03")}`;
+		const expected =
+			"https://www.meetup.com/awsugclouddelnorte/events/314839263/rsvp/";
 		expect(link.closest("a")).toHaveAttribute("href", expected);
 	});
 
@@ -98,13 +99,12 @@ describe("FeaturedEvent", () => {
 
 	// ---------- Wave 33c — clickable image RSVP link ----------
 
-	it("wave 33c — wraps the image-area in an anchor pointing at the speakeasy /signup?return_to=/rsvp/ flow with the new aria-label locale key", () => {
+	it("wave 33c — wraps the image-area in an anchor pointing at the Meetup RSVP URL with the aria-label locale key", () => {
 		const { container } = renderWithLocale("us");
 		const link = container.querySelector(".feed-featured-event__image-link");
 		expect(link).not.toBeNull();
-		// href matches the same speakeasy CTA URL the primary RSVP button
-		// uses (encoded /rsvp/index.html?event=happy-hour-2026-06-03 return path).
-		const expectedHref = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent("/rsvp/index.html?event=happy-hour-2026-06-03")}`;
+		const expectedHref =
+			"https://www.meetup.com/awsugclouddelnorte/events/314839263/rsvp/";
 		expect(link?.getAttribute("href")).toBe(expectedHref);
 		// aria-label resolves through the new feedPage.featuredEventImageLinkLabel
 		// locale key — describes the link action; the inner <img> alt text
@@ -210,13 +210,11 @@ describe("FeaturedEvent", () => {
 		expect(actual).toEqual(expected);
 	});
 
-	it("renders the shortened primary speakeasy RSVP button label", () => {
+	it("no longer renders the on-site CloudDelNorte.org RSVP button (signup flow unproven)", () => {
 		renderWithLocale("us");
-		const primary = screen.getByRole("link", {
-			name: /RSVP on CloudDelNorte\.org/i,
-		});
-		const expected = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent("/rsvp/index.html?event=happy-hour-2026-06-03")}`;
-		expect(primary).toHaveAttribute("href", expected);
+		expect(
+			screen.queryByRole("link", { name: /RSVP on CloudDelNorte\.org/i }),
+		).toBeNull();
 	});
 
 	it("renders the limited-space CTA", async () => {

--- a/src/pages/feed/components/featured-event.tsx
+++ b/src/pages/feed/components/featured-event.tsx
@@ -15,7 +15,6 @@ import {
 	useState,
 } from "react";
 import MeetupRsvpButton from "../../../components/brand-button/meetup-rsvp";
-import SpeakeasyRsvpButton from "../../../components/brand-button/speakeasy-rsvp";
 import { useTranslation } from "../../../hooks/useTranslation";
 import { getEvent, spotsRemaining } from "../../../lib/rsvp";
 import AsciiSmirk from "./ascii-smirk";
@@ -23,8 +22,6 @@ import AsciiSmirk from "./ascii-smirk";
 const EVENT_ID = "happy-hour-2026-06-03";
 const EVENT_IMAGE_LIGHT = "/events/featured-2026-06-03.webp";
 const EVENT_IMAGE_DARK = "/events/featured-2026-06-03-dark.webp";
-const RSVP_RETURN_PATH = `/rsvp/index.html?event=${EVENT_ID}`;
-const RSVP_PAGE_URL = `https://auth.clouddelnorte.org/signup/index.html?return_to=${encodeURIComponent(RSVP_RETURN_PATH)}`;
 /** Anchor inside the description string after which the inline smirk renders. */
 const SMIRK_ANCHOR = "game";
 /** Wave 32a — bulb count traced around the marquee perimeter. 16 spaces evenly
@@ -185,7 +182,7 @@ function FeaturedEventInner() {
 					    aria-label describes the link action via a new locale
 					    key so screen readers announce both axes correctly. */}
 					<a
-						href={RSVP_PAGE_URL}
+						href={meetupUrl}
 						aria-label={t("feedPage.featuredEventImageLinkLabel")}
 						className="feed-featured-event__image-link"
 					>
@@ -225,7 +222,7 @@ function FeaturedEventInner() {
 						fontSize="heading-m"
 						className="feed-featured-event__title"
 					>
-						<Link href={RSVP_PAGE_URL}>{t("feedPage.featuredEventTitle")}</Link>
+						<Link href={meetupUrl}>{t("feedPage.featuredEventTitle")}</Link>
 					</Box>
 					{/* Date VFX — pure HTML/Intl output wrapped in a backplate that
 					    carries the tungsten/indigo gradient + shimmer pseudo-element.
@@ -274,10 +271,6 @@ function FeaturedEventInner() {
 						</Box>
 					)}
 					<div className="cdn-brand-btn-stack">
-						<SpeakeasyRsvpButton
-							href={RSVP_PAGE_URL}
-							label={t("feedPage.featuredEventRsvpPrimary")}
-						/>
 						<MeetupRsvpButton
 							href={meetupUrl}
 							label={t("feedPage.featuredEventRsvpMeetup")}


### PR DESCRIPTION
Removed the 'RSVP on CloudDelNorte.org' on-site RSVP button and re-pointed the featured-event image + title links to the working Meetup RSVP URL, because the on-site signup→RSVP→membership pipeline is not proven end-to-end (no PostConfirmation trigger; confirmed users never reach a Cognito group). Meetup RSVP remains the working path.

3 featured-event tests updated to assert Meetup links + absence of the on-site button.

tsc clean, 194 feed tests pass, biome clean.