### PR TITLE
fix(weather): glassmorphic card, remove time-of-day sky for legibility

### DIFF
--- a/src/components/weather/__tests__/weather-stable-key.test.tsx
+++ b/src/components/weather/__tests__/weather-stable-key.test.tsx
@@ -1,116 +1,48 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CITIES } from "../cities";
+import Weather from "../index";
 
-// ── Babylon stub ─────────────────────────────────────────────────────────────
-vi.mock("@babylonjs/core", () => ({
-	Engine: vi.fn().mockImplementation(() => ({
-		runRenderLoop: vi.fn(),
-		stopRenderLoop: vi.fn(),
-		dispose: vi.fn(),
-		resize: vi.fn(),
-	})),
-	Scene: vi.fn().mockImplementation(() => ({
-		clearColor: null,
-		render: vi.fn(),
-		beginAnimation: vi.fn(),
-		ambientColor: null,
-	})),
-	Color4: vi.fn(),
-	Color3: vi.fn().mockImplementation(() => ({})),
-	Vector3: vi.fn().mockImplementation(() => ({})),
-	ArcRotateCamera: vi.fn().mockImplementation(() => ({
-		inputs: { clear: vi.fn() },
-		animations: [],
-	})),
-	HemisphericLight: vi.fn().mockImplementation(() => ({ intensity: 1 })),
-	DirectionalLight: vi.fn().mockImplementation(() => ({ intensity: 1 })),
-	StandardMaterial: vi.fn().mockImplementation(() => ({
-		emissiveColor: null,
-		disableLighting: false,
-	})),
-	Animation: vi.fn().mockImplementation(() => ({ setKeys: vi.fn() })),
-	MeshBuilder: {
-		CreateSphere: vi.fn().mockReturnValue({
-			material: null,
-			animations: [],
-			position: {},
-		}),
-		CreateCylinder: vi.fn().mockReturnValue({
-			material: null,
-			animations: [],
-			position: { y: 0 },
-		}),
-		CreateLines: vi.fn().mockReturnValue({
-			color: null,
-			animations: [],
-		}),
-	},
-}));
+const city = CITIES[0];
+const key = `cdn-weather-cache-v2-${city.key}`;
 
-// ── babylon-shared-engine stub ─────────────────────────────────────────────────
-vi.mock("../../lib/babylon-shared-engine", () => ({
-	getOrCreateSharedEngine: vi.fn(() => ({
-		resize: vi.fn(),
-		dispose: vi.fn(),
-		runRenderLoop: vi.fn(),
-		stopRenderLoop: vi.fn(),
-		registerView: vi.fn(),
-		unRegisterView: vi.fn(),
-	})),
-	registerSceneView: vi.fn(),
-	unregisterSceneView: vi.fn(),
-	pauseSceneView: vi.fn(),
-	resumeSceneView: vi.fn(),
-}));
-
-// ── IntersectionObserver stub ─────────────────────────────────────────────────
-class IntersectionObserverMock {
-	observe = vi.fn();
-	disconnect = vi.fn();
-}
-
-// ── Spy on AtmosphereScene to track mount count ───────────────────────────────
-// We directly test the key stability by tracking how many canvas elements
-// are created across prop changes. A stable-key component reuses the same
-// canvas node; an unstable-key component creates a new one.
-let _mountCount = 0;
-
-vi.mock("./atmosphere-scene", async (importOriginal) => {
-	const mod = await importOriginal<typeof import("../atmosphere-scene")>();
-	return {
-		...mod,
-		default: (props: import("../atmosphere-scene").AtmosphereSceneProps) => {
-			_mountCount++;
-			return mod.default(props);
+const freshCache = () =>
+	JSON.stringify({
+		ts: Date.now(),
+		forecast: {
+			current: {
+				temperature_2m: 85,
+				wind_speed_10m: 7,
+				wind_direction_10m: 180,
+				precipitation: 0,
+				weather_code: 0,
+			},
+			daily: {
+				time: ["2026-05-31", "2026-06-01"],
+				temperature_2m_max: [90, 88],
+				temperature_2m_min: [65, 63],
+				precipitation_probability_max: [10, 20],
+			},
 		},
-	};
-});
+		air: { current: { us_aqi: 42, uv_index: 7 } },
+	});
 
-beforeEach(() => {
-	_mountCount = 0;
-	vi.stubGlobal("IntersectionObserver", IntersectionObserverMock);
-});
+describe("Weather card — glassmorphic surface, no time-of-day sky canvas", () => {
+	beforeEach(() => {
+		localStorage.setItem(key, freshCache());
+	});
 
-afterEach(() => {
-	vi.clearAllMocks();
-	vi.unstubAllGlobals();
-});
+	afterEach(() => {
+		localStorage.clear();
+	});
 
-describe("Weather — AtmosphereScene stable key across city cycles", () => {
-	it("AtmosphereScene does not have a city-dependent key in the weather component source", async () => {
-		// Read the weather component source and verify no key={city.key} or key={cityIndex}
-		// is attached to AtmosphereScene or its BabylonGate wrapper.
-		// This is a static analysis test — if a city-dependent key were added it would
-		// appear as key={city...} or key={cityIndex} adjacent to AtmosphereScene.
-		const src = await import("../index?raw").catch(() => null);
-		if (!src) return; // Vite ?raw not available in test env — skip gracefully
+	it("renders the city label when cache is fresh", () => {
+		render(<Weather />);
+		expect(screen.getByText(city.label)).toBeTruthy();
+	});
 
-		// Ensure no cityIndex/city.key adjacent to AtmosphereScene
-		const text = (src as unknown as { default: string }).default;
-		const atmosphereBlock = text.slice(
-			text.indexOf("<BabylonGate"),
-			text.indexOf("</BabylonGate>") + 14,
-		);
-		expect(atmosphereBlock).not.toMatch(/key=\{city/);
-		expect(atmosphereBlock).not.toMatch(/key=\{cityIndex/);
+	it("does NOT render a Babylon canvas element", () => {
+		const { container } = render(<Weather />);
+		expect(container.querySelector("canvas")).toBeNull();
 	});
 });

--- a/src/components/weather/index.tsx
+++ b/src/components/weather/index.tsx
@@ -1,28 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import { lazy, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { getBandBass } from "../../lib/background-viz/audio";
-import BabylonGate from "../babylon-gate";
 import { CITIES, type City } from "./cities";
 import "./styles.css";
-
-const AtmosphereScene = lazy(() => import("./atmosphere-scene"));
-
-/** Extract the current local hour (0–23) in the given IANA timezone. */
-function localHour(timezone: string): number {
-	try {
-		const parts = new Intl.DateTimeFormat("en-US", {
-			timeZone: timezone,
-			hour: "numeric",
-			hour12: false,
-		}).formatToParts(new Date());
-		const h = parts.find((p) => p.type === "hour");
-		return h ? Number(h.value) % 24 : new Date().getHours();
-	} catch {
-		return new Date().getHours();
-	}
-}
 
 const CACHE_TTL_MS = 10 * 60 * 1000;
 const AUTO_ADVANCE_MS = 4000;
@@ -286,7 +268,6 @@ export default function Weather() {
 	const tomorrowLoF = Math.round(tomorrow.lo);
 	const tomorrowLoC = Math.round(fToC(tomorrow.lo));
 
-	const currentHour = localHour(city.timezone);
 	const weatherContent = (
 		<>
 			<header className="cdn-weather__head">
@@ -383,15 +364,7 @@ export default function Weather() {
 			onMouseEnter={onMouseEnter}
 			onMouseLeave={onMouseLeave}
 			onKeyDown={onKeyDown}
-			style={{ position: "relative", overflow: "hidden" }}
 		>
-			<BabylonGate tier="medium" fallback={null}>
-				<AtmosphereScene
-					weatherCode={cur.weather_code}
-					timezone={city.timezone}
-					hour={currentHour}
-				/>
-			</BabylonGate>
 			{weatherContent}
 		</button>
 	);


### PR DESCRIPTION
The weather card rendered a Babylon time-of-day sky (saturated blue) behind the data, hurting legibility on all screens. Removed the AtmosphereScene+BabylonGate so the card shows only its glassmorphic surface with data primary.

Time-of-day already lives in the footer AtmosphereRibbon. `atmosphere-scene.tsx` retained (own unit test).

New render test asserts data renders + zero canvas.

**Verified:** tsc clean, 23 weather tests pass, biome clean.