### PR TITLE
fix(footer): subtle AtmosphereRibbon content-to-footer transition

### DIFF
--- a/src/components/footer/atmosphere-ribbon.css
+++ b/src/components/footer/atmosphere-ribbon.css
@@ -10,10 +10,45 @@
 	z-index: 0;
 	opacity: 0;
 	transition: opacity 600ms ease-in;
+	-webkit-mask-image: linear-gradient(
+		to bottom,
+		transparent 0%,
+		#000 35%,
+		#000 65%,
+		transparent 100%
+	);
+	mask-image: linear-gradient(
+		to bottom,
+		transparent 0%,
+		#000 35%,
+		#000 65%,
+		transparent 100%
+	);
 }
 
 .cdn-atmosphere-ribbon.is-loaded {
 	opacity: 1;
+}
+
+.cdn-atmosphere-ribbon::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	z-index: 1;
+	background: linear-gradient(
+		to bottom,
+		rgba(237, 229, 212, 0) 0%,
+		rgba(237, 229, 212, 0.35) 100%
+	);
+}
+
+.awsui-dark-mode .cdn-atmosphere-ribbon::after {
+	background: linear-gradient(
+		to bottom,
+		rgba(14, 18, 28, 0) 0%,
+		rgba(14, 18, 28, 0.55) 100%
+	);
 }
 
 @media (max-width: 688px) {
@@ -27,7 +62,17 @@
 	width: 100%;
 	height: 100%;
 	background: linear-gradient(90deg, #87ceeb 0%, #d0eeff 50%, #87ceeb 100%);
-	transition: background 2s ease;
+	transition:
+		background 2s ease,
+		filter 2s ease,
+		opacity 2s ease;
+	filter: saturate(0.55) brightness(0.95);
+	opacity: 0.5;
+}
+
+.awsui-dark-mode .cdn-footer-atmosphere-fallback {
+	opacity: 0.32;
+	filter: saturate(0.4) brightness(0.6);
 }
 
 body.cdn-auth-subdomain .cdn-atmosphere-ribbon {


### PR DESCRIPTION
The ribbon painted a literal time-of-day sky (bright blue at midday) with hard seams that glared in dark mode; softened it CSS-only to a feathered, desaturated, theme-aware transition (warm-cream veil light / deep-navy veil dark, dark-mode fallback knockdown) so time-of-day reads as a subtle hint. Shared todGradient JS untouched. biome clean, awsug build passes.