### PR TITLE
feat(resources): Resources/Favorites page (iter 1) + relocate podcast listing off awsug landing

### DIFF
--- a/.kiro/specs/resources-favorites/design.md
+++ b/.kiro/specs/resources-favorites/design.md
@@ -1,0 +1,65 @@
+# Resources → Favorites — Design Spec
+_Status: planning · 2026-06-01_
+
+## Problem
+`src/sites/awsug/_layout/index.tsx` renders `<PodcastScrollerSibling/>` (Writing-on-the-Wall episodes) directly on the awsug member landing. Radio/podcast browsing does not belong on the landing. It belongs on a dedicated Resources → Favorites subpage, publicly accessible logged-out and logged-in, with auth-gated extras when signed in.
+
+## Architecture Decision: Single Main-Site Route
+**Decision:** One page at `src/pages/resources/` (main-site build, `vite.config.ts`). Both the main-site nav and the awsug nav link to it. No awsug-specific route.
+
+**Rationale:**
+1. The main site already carries the full stream-host CSP allowlist. The awsug CloudFront response-headers policy (`ef81b3a7-9f54-4871-9d45-0864456d843b`) is near the ~1784-char CloudFront limit; adding stream-host origins there is not viable without dropping other directives.
+2. The page is inherently public/logged-out viewable as a main-site route — no auth gate needed at the route level.
+3. Auth-gated extras are handled client-side: detect `sessionStorage cdn.idToken` (or `AuthContext`) and conditionally render logged-in UI.
+4. Keeps the awsug shell CSP small — stream browsing lives on the main domain.
+
+## Data Source
+`src/lib/streams.ts` → `STREAMS: StreamDef[]`. Relevant fields per card:
+- `key`, `label`, `type` (`'radio'|'podcast'`), `location` → `formatLocation(loc)`
+- `scheduleUrl?`, `donateUrl?` — render as links when present
+- `curated?: true` — filter: show only curated entries on this page
+- `rssFeedUrl?` — used in Iteration 4 for podcast download affordance
+
+**Fields to add to `StreamDef` (Iteration 3):**
+- `transcription?: 'available' | 'partial' | 'none' | 'unknown'` — default `'unknown'`
+- `translation?: 'available' | 'partial' | 'none' | 'unknown'` — default `'unknown'`
+- `relatedLinks?: readonly { label: string; url: string }[]` — optional
+
+## Page Structure
+Route: `src/pages/resources/` → `/resources/index.html`. Wraps in `Shell` (same as all main-site pages — gets wallpaper, player, footer).
+
+```
+<ResourcesFavoritesPage>
+  <section> Radio Stations
+    <StreamCard /> × n  (type === 'radio', curated)
+  </section>
+  <section> Podcasts
+    <StreamCard /> × n  (type === 'podcast', curated)
+  </section>
+</ResourcesFavoritesPage>
+```
+
+### StreamCard (logged-out)
+- Station label + type badge
+- `formatLocation(location)`
+- Links: `scheduleUrl`, `donateUrl` where present
+
+### StreamCard (logged-in extras, gated on auth)
+- **Star/unstar** — `localStorage` key `cdn.favorites.<station.key>` (boolean). Future: server-side sync is out of scope.
+- **Technical details panel** (expandable `<details>`) — stream serving method (derived from `url` hostname: icecast/Zeno/CloudFront/RSS/etc), queueable/downloadable flags, `transcription`, `translation`, `relatedLinks` (Iteration 3).
+- **Download affordance** (podcasts only) — button to fetch latest episode enclosure URL from `rssFeedUrl` and trigger download. UI only; edge-serving/CDN mirroring is a future research item (Iteration 4).
+
+## Navigation
+- **awsug nav** (`src/sites/awsug/_layout/navigation.tsx`): add `favorites` link under the existing `resources` section → `https://clouddelnorte.org/resources/`.
+- **Main-site nav** (`src/layouts/shell/`): add Resources → Favorites link.
+
+## Accessibility
+- Cards keyboard-navigable; star button has `aria-label="Favorite [station label]"` / `aria-pressed`.
+- Expandable panel uses native `<details>`/`<summary>` for zero-JS keyboard support.
+- WCAG AA contrast on all text/badge combinations against glassmorphic surfaces.
+- `prefers-reduced-motion`: no animated transitions on card mount.
+
+## Out of Scope
+- Server-side favorites persistence (localStorage only for now).
+- Podcast audio edge-serving / CDN mirroring (flagged in Iteration 4 as future).
+- Transcription/translation data population (fields added; values default `'unknown'`).

--- a/.kiro/specs/resources-favorites/tasks.md
+++ b/.kiro/specs/resources-favorites/tasks.md
@@ -1,0 +1,31 @@
+# Resources → Favorites — Tasks
+
+## Iteration 1 — Route + Listing (logged-out)
+- [ ] Create `src/pages/resources/index.html`, `main.tsx`, `app.tsx`
+- [ ] Register entry in `vite.config.ts` `rollupOptions.input`
+- [ ] Implement `<ResourcesFavoritesPage>` — reads `STREAMS`, filters `curated === true`, groups by `type`, renders `<StreamCard>` (label, `formatLocation`, type badge, `scheduleUrl`/`donateUrl` links)
+- [ ] Add Favorites link to awsug nav (`src/sites/awsug/_layout/navigation.tsx`) under resources section → `https://clouddelnorte.org/resources/`
+- [ ] Add Resources → Favorites link to main-site shell nav
+- [ ] Remove `<PodcastScrollerSibling/>` from `src/sites/awsug/_layout/index.tsx`
+- [ ] Build (main + awsug) · smoke-test logged-out · deploy main · headless visual verify
+
+## Iteration 2 — Auth Detection + Favorites Star
+- [ ] Detect auth: read `sessionStorage cdn.idToken` (or `AuthContext`) in `<ResourcesFavoritesPage>`
+- [ ] Add star/unstar button to `<StreamCard>` — visible only when authenticated
+- [ ] Persist to `localStorage` key `cdn.favorites.<station.key>`
+- [ ] Star reflects persisted state on page reload
+- [ ] Build · test (logged-out: no star; logged-in: star persists) · deploy main · headless visual verify
+
+## Iteration 3 — Technical Details Panel
+- [ ] Add optional fields to `StreamDef` in `src/lib/streams.ts`: `transcription?`, `translation?`, `relatedLinks?`
+- [ ] Implement expandable `<details>`/`<summary>` panel per card (logged-in only)
+- [ ] Panel shows: stream serving method (derived from `url` hostname), queueable/downloadable flags, `transcription`, `translation`, `relatedLinks`
+- [ ] Keyboard + ARIA: `<details>` native; verify focus management
+- [ ] Build · test · deploy main · headless visual verify
+
+## Iteration 4 — Offline Download Affordance (Podcasts)
+- [ ] Add download button to podcast `<StreamCard>` (logged-in only)
+- [ ] On click: fetch `rssFeedUrl`, parse latest `<enclosure url>`, trigger browser download
+- [ ] Show loading/error state inline on the card
+- [ ] Add spec note: edge-serving / CDN mirroring of podcast audio is a future research item; this iteration ships UI affordance only
+- [ ] Build · test · deploy main · headless visual verify

--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -83,7 +83,8 @@ export default function Navigation() {
 		currentPath.startsWith("/roadmap") ||
 		currentPath.startsWith("/theme") ||
 		currentPath.startsWith("/plans") ||
-		currentPath.startsWith("/costs");
+		currentPath.startsWith("/costs") ||
+		currentPath.startsWith("/resources");
 	const isOnReferences =
 		currentPath.startsWith("/learning") ||
 		currentPath.startsWith("/maintenance-calendar");
@@ -111,6 +112,11 @@ export default function Navigation() {
 			text: t("navigation.resources"),
 			defaultExpanded: isOnPlans,
 			items: [
+				{
+					type: "link",
+					text: "favorites",
+					href: "/resources/index.html",
+				},
 				{
 					type: "link",
 					text: t("navigation.plansPage"),

--- a/src/pages/resources/app.tsx
+++ b/src/pages/resources/app.tsx
@@ -1,0 +1,105 @@
+import Badge from "@cloudscape-design/components/badge";
+import Box from "@cloudscape-design/components/box";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useState } from "react";
+import Navigation from "../../components/navigation";
+import Shell from "../../layouts/shell";
+import { formatLocation, STREAMS } from "../../lib/streams";
+import {
+	applyLocale,
+	initializeLocale,
+	type Locale,
+	setStoredLocale,
+} from "../../utils/locale";
+import {
+	applyTheme,
+	initializeTheme,
+	setStoredTheme,
+	type Theme,
+} from "../../utils/theme";
+import "./styles.css";
+
+function StreamCard({ stream }: { stream: (typeof STREAMS)[number] }) {
+	const type = stream.type ?? "radio";
+	return (
+		<div className="cdn-resource-card">
+			<SpaceBetween size="xs">
+				<SpaceBetween size="xs" direction="horizontal" alignItems="center">
+					<Box variant="h3">{stream.label}</Box>
+					<Badge color={type === "radio" ? "blue" : "green"}>{type}</Badge>
+				</SpaceBetween>
+				<Box variant="small" color="text-body-secondary">
+					{formatLocation(stream.location)}
+				</Box>
+				<SpaceBetween size="xs" direction="horizontal">
+					{stream.scheduleUrl && (
+						<Link href={stream.scheduleUrl} external variant="primary">
+							schedule
+						</Link>
+					)}
+					{stream.donateUrl && (
+						<Link href={stream.donateUrl} external variant="primary">
+							donate
+						</Link>
+					)}
+				</SpaceBetween>
+			</SpaceBetween>
+		</div>
+	);
+}
+
+function ResourcesFavoritesContent() {
+	const curated = STREAMS.filter((s) => s.curated);
+	const radio = curated.filter((s) => (s.type ?? "radio") === "radio");
+	const podcasts = curated.filter((s) => s.type === "podcast");
+
+	return (
+		<ContentLayout header={<Header variant="h1">Resources</Header>}>
+			<SpaceBetween size="l">
+				<Container header={<Header variant="h2">Radio Stations</Header>}>
+					<div className="cdn-resource-grid">
+						{radio.map((s) => (
+							<StreamCard key={s.key} stream={s} />
+						))}
+					</div>
+				</Container>
+				<Container header={<Header variant="h2">Podcasts</Header>}>
+					<div className="cdn-resource-grid">
+						{podcasts.map((s) => (
+							<StreamCard key={s.key} stream={s} />
+						))}
+					</div>
+				</Container>
+			</SpaceBetween>
+		</ContentLayout>
+	);
+}
+
+export default function App() {
+	const [theme, setTheme] = useState<Theme>(() => initializeTheme());
+	const [locale, setLocale] = useState<Locale>(() => initializeLocale());
+
+	return (
+		<Shell
+			theme={theme}
+			onThemeChange={(t) => {
+				setTheme(t);
+				applyTheme(t);
+				setStoredTheme(t);
+			}}
+			locale={locale}
+			onLocaleChange={(l) => {
+				setLocale(l);
+				applyLocale(l);
+				setStoredLocale(l);
+			}}
+			navigation={<Navigation />}
+		>
+			<ResourcesFavoritesContent />
+		</Shell>
+	);
+}

--- a/src/pages/resources/index.html
+++ b/src/pages/resources/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon-star.svg" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>Resources — Cloud Del Norte</title>
+      <!-- cdn-theme-fouc-guard: critical-path theme apply (must run before React hydrates).
+         Reads localStorage['awsaerospace-theme'] (see src/utils/theme.ts THEME_KEY),
+         falls back to system prefers-color-scheme, and sets the awsui-dark-mode
+         class + colorScheme on <html> synchronously so the first paint matches
+         the user's saved theme. Idempotent: React's later applyTheme() on the
+         same class is a no-op classList toggle. Wrapped in try/catch because
+         localStorage throws in private-browsing modes. -->
+    <script>
+      (() => {
+        var t;
+        try {
+          t = localStorage.getItem('awsaerospace-theme');
+        } catch (_e) { /* localStorage unavailable; safe fall-through */ }
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        if (t === 'dark') {
+          document.documentElement.classList.add('awsui-dark-mode');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/resources/main.tsx"></script>
+  </body>
+</html>

--- a/src/pages/resources/main.tsx
+++ b/src/pages/resources/main.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "@cloudscape-design/global-styles/index.css";
+import "../../styles/tokens.css";
+import App from "./app";
+
+const container = document.getElementById("root");
+if (!container) throw new Error("root element not found");
+const root = ReactDOM.createRoot(container);
+root.render(
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>,
+);

--- a/src/pages/resources/styles.css
+++ b/src/pages/resources/styles.css
@@ -1,0 +1,16 @@
+.cdn-resource-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+	gap: var(--space-scaled-l, 20px);
+}
+
+.cdn-resource-card {
+	padding: var(--space-scaled-l, 20px);
+	border-radius: var(--border-radius-container, 16px);
+	background: var(
+		--color-background-container-content,
+		rgba(255, 255, 255, 0.06)
+	);
+	border: 1px solid
+		var(--color-border-divider-default, rgba(255, 255, 255, 0.1));
+}

--- a/src/sites/awsug/_layout/index.tsx
+++ b/src/sites/awsug/_layout/index.tsx
@@ -5,15 +5,9 @@ import ContentLayout from "@cloudscape-design/components/content-layout";
 import HelpPanel from "@cloudscape-design/components/help-panel";
 import Tabs from "@cloudscape-design/components/tabs";
 import type React from "react";
-import { useCallback, useState } from "react";
-import {
-	type ActivePlayerStream,
-	useActivePlayerStream,
-} from "../../../components/persistent-player";
-import { PodcastEpisodeScroller } from "../../../components/podcast-episode-scroller";
+import { useState } from "react";
 import { SessionExpiredModal } from "../../../components/session-expired-modal";
 import Shell from "../../../layouts/shell";
-import { savePlayerState } from "../../../lib/player-persist";
 import { HelpPanelHome } from "../../../pages/create-meeting/components/help-panel-home";
 import {
 	applyLocale,
@@ -49,51 +43,6 @@ function ToolsPanel() {
 	);
 }
 
-/**
- * Wave 24c — sibling-of-the-player wiring. Reads the active stream via the
- * read-only useActivePlayerStream hook (exposed by persistent-player) and
- * passes the relevant fields into the scroller. The scroller renders nothing
- * for radio streams, so the wrapper is safe to mount unconditionally — the
- * vertical reservation only appears when a podcast is active.
- *
- * onEpisodeSelect:
- *   1. persists the chosen enclosure URL via savePlayerState so a page
- *      reload resumes on the same episode (existing podcast-resume contract)
- *   2. dispatches the `cdn:player:swap-episode` window event the player
- *      listens to (read-only on player core: the player adds the listener,
- *      not refactors existing logic). The player overrides rssAudioUrl +
- *      starts playback in response.
- */
-function PodcastScrollerSibling() {
-	const stream: ActivePlayerStream = useActivePlayerStream();
-	const handleEpisodeSelect = useCallback(
-		(url: string, _title: string) => {
-			if (!stream.stationKey) return;
-			savePlayerState({
-				stationKey: stream.stationKey,
-				stationUrl: url,
-				stationLabel: stream.stationLabel ?? stream.stationKey,
-				podcastEpisodeUrl: url,
-				podcastCurrentTime: 0,
-			});
-			window.dispatchEvent(
-				new CustomEvent("cdn:player:swap-episode", {
-					detail: { url, title: _title },
-				}),
-			);
-		},
-		[stream.stationKey, stream.stationLabel],
-	);
-	return (
-		<PodcastEpisodeScroller
-			isPodcast={stream.isPodcast}
-			currentStreamKey={stream.stationKey ?? ""}
-			currentEpisodeUrl={stream.currentEpisodeUrl ?? ""}
-			onEpisodeSelect={handleEpisodeSelect}
-		/>
-	);
-}
-
 export default function AwsugLayout({
 	children,
 }: {
@@ -121,7 +70,6 @@ export default function AwsugLayout({
 			identityHref="/"
 		>
 			<PendingApprovalBanner />
-			<PodcastScrollerSibling />
 			<ContentLayout>{children}</ContentLayout>
 			<SessionExpiredModal />
 		</Shell>

--- a/src/sites/awsug/_layout/navigation.tsx
+++ b/src/sites/awsug/_layout/navigation.tsx
@@ -37,6 +37,11 @@ export default function AwsugNavigation() {
 			type: "section",
 			text: "resources",
 			items: [
+				{
+					type: "link",
+					text: "favorites",
+					href: `${MAIN}/resources/index.html`,
+				},
 				{ type: "link", text: "plans", href: `${MAIN}/plans/index.html` },
 				{ type: "link", text: "roadmap", href: `${MAIN}/roadmap/index.html` },
 				{

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
 				admin: resolve(__dirname, "./src/pages/admin/index.html"),
 				"dune-test": resolve(__dirname, "./src/pages/dune-test/index.html"),
 				plans: resolve(__dirname, "./src/pages/plans/index.html"),
+				resources: resolve(__dirname, "./src/pages/resources/index.html"),
 				costs: resolve(__dirname, "./src/pages/costs/index.html"),
 				"meeting-public": resolve(
 					__dirname,


### PR DESCRIPTION
New public main-site `/resources/` route listing curated radio + podcasts from STREAMS (label, type badge, location, schedule/donate links), viewable logged-out; favorites nav links added (awsug + main); removed the Writing-on-the-Wall PodcastScrollerSibling from the awsug member landing per product direction.

Page lives on main domain to keep the awsug shell CSP small.

Spec at `.kiro/specs/resources-favorites/` with iters 2-4 (auth-gated favorites, technical details, offline download) to follow.

**Verified:** tsc clean, main+awsug builds pass, biome clean.