### PR TITLE
fix(ui): footer transition + weather card + nav overflow

### DIFF
--- a/src/components/footer/atmosphere-ribbon.css
+++ b/src/components/footer/atmosphere-ribbon.css
@@ -10,19 +10,21 @@
 	z-index: 0;
 	opacity: 0;
 	transition: opacity 600ms ease-in;
+	/* Asymmetric mask: gentle fade-in at top, stronger fade-out at bottom
+	   so the ribbon melts into the footer's accent line without a hard seam */
 	-webkit-mask-image: linear-gradient(
 		to bottom,
 		transparent 0%,
-		#000 35%,
-		#000 65%,
-		transparent 100%
+		#000 25%,
+		#000 55%,
+		transparent 92%
 	);
 	mask-image: linear-gradient(
 		to bottom,
 		transparent 0%,
-		#000 35%,
-		#000 65%,
-		transparent 100%
+		#000 25%,
+		#000 55%,
+		transparent 92%
 	);
 }
 
@@ -36,10 +38,12 @@
 	inset: 0;
 	pointer-events: none;
 	z-index: 1;
+	/* Stronger bottom fade to blend seamlessly into footer glass */
 	background: linear-gradient(
 		to bottom,
 		rgba(237, 229, 212, 0) 0%,
-		rgba(237, 229, 212, 0.35) 100%
+		rgba(237, 229, 212, 0.15) 50%,
+		rgba(237, 229, 212, 0.6) 100%
 	);
 }
 
@@ -47,7 +51,8 @@
 	background: linear-gradient(
 		to bottom,
 		rgba(14, 18, 28, 0) 0%,
-		rgba(14, 18, 28, 0.55) 100%
+		rgba(14, 18, 28, 0.25) 50%,
+		rgba(14, 18, 28, 0.75) 100%
 	);
 }
 
@@ -57,24 +62,53 @@
 	}
 }
 
-/* CSS-only fallback strip — same dimensions, gradient applied via JS */
+/* Tablet: slightly reduce ribbon height */
+@media (min-width: 601px) and (max-width: 900px) {
+	.cdn-atmosphere-ribbon {
+		height: 34px;
+	}
+}
+
+/* CSS-only fallback strip — warm gradient that reads as intentional sky band */
 .cdn-footer-atmosphere-fallback {
 	width: 100%;
 	height: 100%;
-	background: linear-gradient(90deg, #87ceeb 0%, #d0eeff 50%, #87ceeb 100%);
+	background: linear-gradient(
+		90deg,
+		rgba(135, 206, 235, 0.4) 0%,
+		rgba(255, 220, 160, 0.35) 35%,
+		rgba(208, 238, 255, 0.4) 65%,
+		rgba(135, 206, 235, 0.4) 100%
+	);
 	transition:
 		background 2s ease,
 		filter 2s ease,
 		opacity 2s ease;
-	filter: saturate(0.55) brightness(0.95);
-	opacity: 0.5;
+	filter: saturate(0.6) brightness(0.95);
+	opacity: 0.6;
 }
 
 .awsui-dark-mode .cdn-footer-atmosphere-fallback {
-	opacity: 0.32;
-	filter: saturate(0.4) brightness(0.6);
+	background: linear-gradient(
+		90deg,
+		rgba(48, 0, 106, 0.3) 0%,
+		rgba(20, 30, 60, 0.35) 35%,
+		rgba(90, 60, 160, 0.25) 65%,
+		rgba(48, 0, 106, 0.3) 100%
+	);
+	opacity: 0.4;
+	filter: saturate(0.5) brightness(0.7);
 }
 
 body.cdn-auth-subdomain .cdn-atmosphere-ribbon {
 	display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.cdn-atmosphere-ribbon {
+		transition: none;
+	}
+	.cdn-footer-atmosphere-fallback {
+		transition: none;
+	}
 }

--- a/src/components/footer/styles.css
+++ b/src/components/footer/styles.css
@@ -456,8 +456,12 @@ body.cdn-nav-open.cdn-tools-open .cdn-footer {
 
 .cdn-version {
 	font-size: 11px;
-	opacity: 0.5;
+	color: rgb(140, 75, 0);
 	margin-top: 4px;
+}
+
+.awsui-dark-mode .cdn-version {
+	color: rgb(199, 184, 232);
 }
 
 /* "Go Build" call-to-action — gradient text effect */
@@ -563,9 +567,10 @@ body.cdn-nav-open.cdn-tools-open .cdn-footer {
 .cdn-footer-clock {
 	font-family: "Amazon Ember Mono", "Courier New", monospace;
 	font-size: var(--cdn-text-sm, 0.8125rem);
+	font-weight: 500;
 	font-variant-numeric: tabular-nums;
 	letter-spacing: 0.06em;
-	color: var(--cdn-amber, #8b5a2b);
+	color: var(--cdn-aws-orange-text, rgb(140, 75, 0));
 }
 
 .awsui-dark-mode .cdn-footer-clock {
@@ -594,16 +599,31 @@ body.cdn-nav-open.cdn-tools-open .cdn-footer {
 /* Compact single-row layout when weather card is inside footer */
 .cdn-footer-weather .cdn-weather {
 	flex-direction: row;
-	align-items: center;
-	gap: 8px;
+	align-items: baseline;
+	gap: 10px;
 	margin: 0;
 	padding: 4px 12px;
 	max-width: none;
 }
+.cdn-footer-weather .cdn-weather__head {
+	gap: 6px;
+}
+.cdn-footer-weather .cdn-weather__city {
+	font-size: 14px;
+	letter-spacing: 0.04em;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 160px;
+}
+.cdn-footer-weather .cdn-weather__glyph {
+	font-size: 18px;
+	align-self: center;
+}
 .cdn-footer-weather .cdn-weather__now {
 	flex-direction: row;
-	align-items: center;
-	gap: 8px;
+	align-items: baseline;
+	gap: 6px;
 }
 .cdn-footer-weather .cdn-weather__tomorrow,
 .cdn-footer-weather .cdn-weather__dots,
@@ -612,7 +632,17 @@ body.cdn-nav-open.cdn-tools-open .cdn-footer {
 }
 .cdn-footer-weather .cdn-weather__temp {
 	flex-direction: row;
+	align-items: baseline;
 	gap: 6px;
+}
+.cdn-footer-weather .cdn-weather__temp-f {
+	font-size: 16px;
+}
+.cdn-footer-weather .cdn-weather__temp-c {
+	font-size: 12px;
+}
+.cdn-footer-weather .cdn-weather__temp-rule {
+	display: none;
 }
 
 /* Version pushed to end */
@@ -661,5 +691,21 @@ body.cdn-nav-open.cdn-tools-open .cdn-footer-bar .cdn-version {
 	.cdn-footer-bar .cdn-version {
 		margin-left: 0;
 		text-align: center;
+	}
+}
+
+/* Tablet: keep row but tighten weather + gaps */
+@media (min-width: 601px) and (max-width: 900px) {
+	.cdn-footer-bar {
+		gap: var(--cdn-space-sm, 8px);
+	}
+
+	.cdn-footer-weather {
+		max-width: 220px;
+		min-width: 120px;
+	}
+
+	.cdn-footer-weather .cdn-weather__city {
+		max-width: 110px;
 	}
 }

--- a/src/layouts/shell/styles.css
+++ b/src/layouts/shell/styles.css
@@ -1753,8 +1753,8 @@ nav[class*="awsui_navigation_"]:not(
 	width: fit-content;
 	font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 	font-size: 11px;
-	opacity: 0.65;
-	color: rgba(139, 90, 43, 0.6);
+	opacity: 1;
+	color: rgb(140, 75, 0);
 	pointer-events: none;
 	user-select: none;
 	background: rgba(255, 255, 255, 0.06);
@@ -1764,7 +1764,7 @@ nav[class*="awsui_navigation_"]:not(
 }
 
 .awsui-dark-mode .cdn-version {
-	color: rgba(215, 199, 238, 0.65);
+	color: rgb(199, 184, 232);
 	background: rgba(144, 96, 240, 0.08);
 }
 
@@ -1897,6 +1897,41 @@ nav[class*="awsui_navigation_"]:not(
 	overflow: visible;
 	text-overflow: clip;
 	min-width: max-content;
+}
+
+/* ── Mobile ≤400px: eliminate horizontal overflow at 375px ───────────────
+   The combined intrinsic width of padding-left (logo clearance) + utilities
+   row exceeds 375px. Fix: hide decorative tagline, shrink logo clearance,
+   tighten utility padding/gap. :not(#\9) boosts specificity to override
+   Cloudscape's scoped styles. */
+@media (max-width: 400px) {
+	.cdn-ugtag {
+		display: none;
+	}
+	#top-nav [class*="awsui_top-navigation"]:not(#\9) {
+		padding-left: 56px;
+		padding-right: 0 !important;
+	}
+	#top-nav [class*="awsui_utilities"]:not(#\9) {
+		padding-right: 2px !important;
+		gap: 4px !important;
+	}
+	#top-nav [class*="awsui_utility-wrapper"]:not(#\9) {
+		padding-left: 0 !important;
+		padding-right: 0 !important;
+		margin-left: 0 !important;
+		margin-right: 0 !important;
+	}
+	#top-nav [class*="awsui_utility-button_"]:not(#\9) {
+		padding-left: 4px !important;
+		padding-right: 4px !important;
+	}
+	#top-nav
+		[class*="awsui_utility-button_"]:last-child:not(#\9)
+		[class*="awsui_utility-button-text_"],
+	#top-nav [class*="awsui_utility-button_"]:last-child:not(#\9) span {
+		min-width: 0;
+	}
 }
 
 /* ── Audio reactivity — Phase A ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

**Footer refinement:**
- Footer clock contrast raised to WCAG AA (rgb(140,75,0) weight 500 = 5.37:1 light, lavender 12.21:1 dark)
- `.cdn-version` build-stamp contrast fixed (was 1.68:1 light due to cascade conflict — now opacity:1 with solid colors = 5.46:1 light / 9.59:1 dark)
- Weather compact footer card one-row legibility improved
- Atmosphere-ribbon transition seam blended (heights 28px mobile / 34px tablet / 40px desktop)
- Tablet 768px footer-bar row layout tuned

**Mobile nav overflow fix:**
- At 375px the Cloudscape top-nav utilities row pushed sign-in 17px past viewport
- Trimmed utilities row inter-item gap (40px→4px) + right padding (→2px) inside `@media(max-width:400px)`
- Sign-in right edge now 369px (6px inside viewport); flag+theme+sign-in all visible, not collapsed

## What was tested

Headless-verified (ghost-liora-headless-verifier) across the following matrix:
- **Viewports:** 375px / 768px / 1920px
- **Modes:** light + dark
- **Checks:** footer readability, weather card layout, ribbon transition seam, responsive integrity, nav overflow
- **Contrast ratios verified:** clock 5.37:1 light / 12.21:1 dark; version label 5.46:1 light / 9.59:1 dark
- **Result:** all PASS, no regressions

Working artifacts are local screenshots in `tests/visual-rehab/` (not committed).