### PR TITLE
feat(ops): jitsi operational alarms as code plus cold-stack runbook

### DIFF
--- a/docs/runbooks/jitsi-cold-stack.md
+++ b/docs/runbooks/jitsi-cold-stack.md
@@ -1,0 +1,182 @@
+# jitsi cold-stack runbook
+
+## symptom
+
+`meet.clouddelnorte.org/external_api.js` returns HTTP 503 with server header `awselb/2.0`. this means zero healthy targets are registered in the web target group behind the ALB. the jitsi ECS service is either scaled to zero or the task failed to start.
+
+a second, more dangerous mode: the web UI loads (room appears normal) but audio and video fail silently. this indicates the JVB media target groups are unhealthy while the web target group is healthy.
+
+## diagnosis
+
+### check ECS desired and running count
+
+```bash
+aws ecs describe-services \
+  --cluster jitsi-cluster \
+  --services jitsi-service \
+  --query 'services[0].{desired:desiredCount,running:runningCount,status:status}' \
+  --output table \
+  --profile jitsi-video-hosting \
+  --region us-west-2
+```
+
+if `desiredCount = 0`: the service was intentionally scaled down by a controller.
+if `desiredCount > 0` but `runningCount = 0`: the task is failing to start (check events below).
+
+### check recent service events
+
+```bash
+aws ecs describe-services \
+  --cluster jitsi-cluster \
+  --services jitsi-service \
+  --query 'services[0].events[:10].{at:createdAt,msg:message}' \
+  --output table \
+  --profile jitsi-video-hosting \
+  --region us-west-2
+```
+
+### check target group health
+
+```bash
+# web (ALB)
+aws elbv2 describe-target-health \
+  --target-group-arn "$(aws elbv2 describe-target-groups --names jitsi-video-platform-web-tg --query 'TargetGroups[0].TargetGroupArn' --output text --profile jitsi-video-hosting --region us-west-2)" \
+  --profile jitsi-video-hosting --region us-west-2
+
+# JVB TCP (NLB)
+aws elbv2 describe-target-health \
+  --target-group-arn "$(aws elbv2 describe-target-groups --names jitsi-video-platform-jvb-tcp-tg --query 'TargetGroups[0].TargetGroupArn' --output text --profile jitsi-video-hosting --region us-west-2)" \
+  --profile jitsi-video-hosting --region us-west-2
+
+# JVB UDP (NLB)
+aws elbv2 describe-target-health \
+  --target-group-arn "$(aws elbv2 describe-target-groups --names jitsi-video-platform-jvb-udp-tg --query 'TargetGroups[0].TargetGroupArn' --output text --profile jitsi-video-hosting --region us-west-2)" \
+  --profile jitsi-video-hosting --region us-west-2
+```
+
+## known cause — 2026-07-31 incident
+
+**duration**: 4h 40m total outage (18:12Z – 22:53Z)
+
+**root cause**: EventBridge rule `ne3d-meeting-duration-watchdog` running on `rate(15 minutes)` invoked a Lambda of the same name. that Lambda scaled `jitsi-service` to `desiredCount=0`. the service is a SHARED resource backing scheduled public events — the watchdog treated it as a single-session resource.
+
+**current state**: the rule is DISABLED as of 2026-07-31.
+
+```bash
+# verify the rule is still disabled
+aws events describe-rule \
+  --name ne3d-meeting-duration-watchdog \
+  --profile jitsi-video-hosting \
+  --region us-west-2 \
+  --query '{state:State,schedule:ScheduleExpression}'
+```
+
+**exact reversal** (DO NOT run until target-registration automation exists):
+
+```bash
+aws events enable-rule \
+  --name ne3d-meeting-duration-watchdog \
+  --profile jitsi-video-hosting \
+  --region us-west-2
+```
+
+## structural vulnerability — JVB target groups not attached to ECS service
+
+the ECS service `jitsi-service` only registers targets for `jitsi-video-platform-web-tg` (the web container on port 80). the JVB target groups (`jitsi-video-platform-jvb-tcp-tg` on port 4443 and `jitsi-video-platform-jvb-udp-tg` on port 10000) are NOT attached to the ECS service.
+
+consequences:
+
+- every task replacement (deployment, crash, scale event) orphans JVB target registration
+- stale IPs from dead tasks remain registered, failing health checks
+- the live task IP is NOT automatically registered
+- this failure mode is SILENT — ECS reports the service as healthy because the web container passes its attached health check
+
+### remediation when JVB targets are unhealthy
+
+1. find the live task IP:
+
+```bash
+TASK_ARN=$(aws ecs list-tasks --cluster jitsi-cluster --service-name jitsi-service --query 'taskArns[0]' --output text --profile jitsi-video-hosting --region us-west-2)
+
+TASK_IP=$(aws ecs describe-tasks --cluster jitsi-cluster --tasks "${TASK_ARN}" --query 'tasks[0].attachments[0].details[?name==`privateIPv4Address`].value | [0]' --output text --profile jitsi-video-hosting --region us-west-2)
+
+echo "live task IP: ${TASK_IP}"
+```
+
+2. deregister stale targets:
+
+```bash
+# get current targets for JVB UDP TG
+JVB_UDP_ARN=$(aws elbv2 describe-target-groups --names jitsi-video-platform-jvb-udp-tg --query 'TargetGroups[0].TargetGroupArn' --output text --profile jitsi-video-hosting --region us-west-2)
+
+# deregister all stale IPs (replace with actual stale IPs from describe-target-health output)
+aws elbv2 deregister-targets \
+  --target-group-arn "${JVB_UDP_ARN}" \
+  --targets Id=<STALE_IP>,Port=10000 \
+  --profile jitsi-video-hosting --region us-west-2
+
+# repeat for JVB TCP TG
+JVB_TCP_ARN=$(aws elbv2 describe-target-groups --names jitsi-video-platform-jvb-tcp-tg --query 'TargetGroups[0].TargetGroupArn' --output text --profile jitsi-video-hosting --region us-west-2)
+
+aws elbv2 deregister-targets \
+  --target-group-arn "${JVB_TCP_ARN}" \
+  --targets Id=<STALE_IP>,Port=4443 \
+  --profile jitsi-video-hosting --region us-west-2
+```
+
+3. register the live task IP:
+
+```bash
+aws elbv2 register-targets \
+  --target-group-arn "${JVB_UDP_ARN}" \
+  --targets Id="${TASK_IP}",Port=10000 \
+  --profile jitsi-video-hosting --region us-west-2
+
+aws elbv2 register-targets \
+  --target-group-arn "${JVB_TCP_ARN}" \
+  --targets Id="${TASK_IP}",Port=4443 \
+  --profile jitsi-video-hosting --region us-west-2
+```
+
+4. wait 30-60s for health checks to pass, then verify:
+
+```bash
+aws elbv2 describe-target-health --target-group-arn "${JVB_UDP_ARN}" --profile jitsi-video-hosting --region us-west-2
+aws elbv2 describe-target-health --target-group-arn "${JVB_TCP_ARN}" --profile jitsi-video-hosting --region us-west-2
+```
+
+## permanent fixes — priority order
+
+1. **attach JVB target groups to the ECS service** — add `loadBalancers` entries for the `jvb` container targeting port 4443 (TCP TG) and port 10000 (UDP TG). requires service recreation because ECS load balancer config is immutable after create. this is the correct fix.
+
+2. **Lambda-based target registration** — EventBridge rule on ECS task state change (RUNNING) triggers a Lambda that registers the new task IP in both JVB target groups and deregisters any stale IPs. less correct but does not require service recreation.
+
+3. **CloudWatch alarms on JVB target group health** — implemented in `infra/jitsi-ops-alarms.cfn.yaml`. does not fix the problem but ensures it is detected within 2 minutes instead of hours.
+
+## the watchdog must NOT be re-enabled until
+
+- JVB target groups are attached to the ECS service (fix #1 above), OR
+- Lambda-based target registration automation is in place (fix #2 above)
+
+without target-registration automation, re-enabling the watchdog means every scale-to-zero → scale-up cycle leaves JVB targets orphaned and media silently broken.
+
+## well-architected tension
+
+aggressive scale-to-zero serves **Cost Optimization** and **Sustainability** — ECS Fargate at 0 tasks costs $0 and the jitsi stack runs ~$0.50-1.50/hour when up.
+
+**Reliability** requires that a shared resource backing scheduled public events not disappear without notice. the correct resolution is not "always on" or "always off" — it is:
+
+- **session-awareness**: the scale-down controller must check for active participants before scaling to zero
+- **upcoming-event awareness**: a pre-warm rule fires independently of the scale-down controller, scaling to 1 task N minutes before the next scheduled meeting (source: existing DynamoDB tables + meetings UI schedule)
+- **scheduled pre-warm windows**: fixed windows (e.g. Tue/Thu 18:00-21:00 MT for regular meetup hours) as a floor
+- **notification on scale-down**: the EventBridge rule in `jitsi-ops-alarms.cfn.yaml` announces any desiredCount-to-zero event so the operator knows immediately
+
+the answer is: tell someone when it goes to zero, and pre-warm before scheduled events.
+
+## references
+
+- issue #469: observability gap analysis and alarm specification
+- issue #470: JVB target group structural vulnerability diagnosis
+- alarm IaC: `infra/jitsi-ops-alarms.cfn.yaml`
+- deploy script: `scripts/deploy-jitsi-ops-alarms.sh`
+- jitsi ops repo: `chasko-labs/jitsi-video-hosting-ops`

--- a/infra/jitsi-ops-alarms.cfn.yaml
+++ b/infra/jitsi-ops-alarms.cfn.yaml
@@ -1,0 +1,422 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  jitsi-ops-alarms — CloudWatch alarms + SNS topic for Jitsi ECS operational
+  monitoring in account 170473530355 (us-west-2). Detects: zero running tasks,
+  unhealthy web target group, unhealthy JVB media target groups, and any
+  controller setting desiredCount to zero.
+
+  DELIVERY NOTE: SES in this account (170473530355) is sandboxed — production
+  access was DENIED (case 177826280100472). However, SNS email subscriptions
+  do NOT depend on SES. SNS sends confirmation and notification emails directly
+  via its own SMTP infrastructure, completely bypassing the SES sandbox. Email
+  subscriptions on this topic WILL work. Do not assume email is blocked.
+
+Parameters:
+  # ---------------------------------------------------------------------------
+  # ECS identifiers
+  # ---------------------------------------------------------------------------
+  ClusterName:
+    Type: String
+    Default: jitsi-cluster
+    Description: ECS cluster name where the jitsi service runs.
+
+  ServiceName:
+    Type: String
+    Default: jitsi-service
+    Description: ECS service name within the cluster.
+
+  # ---------------------------------------------------------------------------
+  # Target group full-names (not ARNs — CloudWatch dimensions use the
+  # targetgroup/... suffix format)
+  # ---------------------------------------------------------------------------
+  WebTargetGroupFullName:
+    Type: String
+    Description: >
+      Full name of the web ALB target group in the format
+      targetgroup/<name>/<hex>. Find via:
+      aws elbv2 describe-target-groups --names jitsi-video-platform-web-tg
+        --query 'TargetGroups[0].TargetGroupArn' --output text | sed 's|.*:||'
+
+  JvbTcpTargetGroupFullName:
+    Type: String
+    Description: >
+      Full name of the JVB TCP NLB target group in the format
+      targetgroup/<name>/<hex>. Find via:
+      aws elbv2 describe-target-groups --names jitsi-video-platform-jvb-tcp-tg
+        --query 'TargetGroups[0].TargetGroupArn' --output text | sed 's|.*:||'
+
+  JvbUdpTargetGroupFullName:
+    Type: String
+    Description: >
+      Full name of the JVB UDP NLB target group in the format
+      targetgroup/<name>/<hex>. Find via:
+      aws elbv2 describe-target-groups --names jitsi-video-platform-jvb-udp-tg
+        --query 'TargetGroups[0].TargetGroupArn' --output text | sed 's|.*:||'
+
+  # ---------------------------------------------------------------------------
+  # Load balancer full-names (required as dimensions for HealthyHostCount)
+  # ---------------------------------------------------------------------------
+  WebAlbFullName:
+    Type: String
+    Description: >
+      Full name of the web ALB in the format app/<name>/<hex>. Find via:
+      aws elbv2 describe-load-balancers --names jitsi-video-platform-web-alb
+        --query 'LoadBalancers[0].LoadBalancerArn' --output text | sed 's|.*:loadbalancer/||'
+
+  JvbNlbFullName:
+    Type: String
+    Description: >
+      Full name of the JVB NLB in the format net/<name>/<hex>. Find via:
+      aws elbv2 describe-load-balancers --names jitsi-video-platform-jvb-nlb
+        --query 'LoadBalancers[0].LoadBalancerArn' --output text | sed 's|.*:loadbalancer/||'
+
+  # ---------------------------------------------------------------------------
+  # Notification endpoints — never hardcode secrets, emails, or phone numbers
+  # ---------------------------------------------------------------------------
+  NotificationEmail:
+    Type: String
+    Default: ""
+    Description: >
+      Email address for alarm notifications. Leave empty to skip email
+      subscription. SNS sends a confirmation email; click the link to activate.
+      SNS email does NOT depend on SES — works even with SES sandbox.
+
+  NtfyEndpoint:
+    Type: String
+    Default: ""
+    Description: >
+      HTTPS endpoint for ntfy.sh push notifications (e.g.
+      https://ntfy.sh/cdn-jitsi-ops-<random8>). Leave empty to skip.
+
+  # ---------------------------------------------------------------------------
+  # Standard tags
+  # ---------------------------------------------------------------------------
+  Env:
+    Type: String
+    Default: prod
+    AllowedValues: [prod, dev]
+
+  Owner:
+    Type: String
+    Default: bryanchasko
+
+  CostCenter:
+    Type: String
+    Default: heraldstack
+
+  Project:
+    Type: String
+    Default: cloud-del-norte
+
+Conditions:
+  HasEmail: !Not [!Equals [!Ref NotificationEmail, ""]]
+  HasNtfy: !Not [!Equals [!Ref NtfyEndpoint, ""]]
+
+Resources:
+  # ---------------------------------------------------------------------------
+  # SNS topic — receives alarm state-change notifications
+  # This topic lives in 170473530355 because the existing cdn-deploy-alerts
+  # topic is in 211125425201 (hosting account) and cannot receive CloudWatch
+  # alarm actions from a different account without cross-account policy.
+  # ---------------------------------------------------------------------------
+  JitsiOpsAlertsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: jitsi-ops-alerts
+      DisplayName: Jitsi Ops
+      Tags:
+        - Key: project
+          Value: !Ref Project
+        - Key: env
+          Value: !Ref Env
+        - Key: owner
+          Value: !Ref Owner
+        - Key: cost-center
+          Value: !Ref CostCenter
+
+  # ---------------------------------------------------------------------------
+  # Email subscription — SNS sends email directly (NOT via SES)
+  # ---------------------------------------------------------------------------
+  EmailSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: HasEmail
+    Properties:
+      TopicArn: !Ref JitsiOpsAlertsTopic
+      Protocol: email
+      Endpoint: !Ref NotificationEmail
+
+  # ---------------------------------------------------------------------------
+  # HTTPS subscription — ntfy.sh push target
+  # ---------------------------------------------------------------------------
+  NtfySubscription:
+    Type: AWS::SNS::Subscription
+    Condition: HasNtfy
+    Properties:
+      TopicArn: !Ref JitsiOpsAlertsTopic
+      Protocol: https
+      Endpoint: !Ref NtfyEndpoint
+
+  # ---------------------------------------------------------------------------
+  # P0 ALARM: jitsi-ecs-zero-tasks
+  # Namespace: AWS/ECS
+  # Fires when the ECS service has zero running tasks for 1 minute.
+  # TreatMissingData: breaching — if CloudWatch stops receiving data, that
+  # itself means the service is gone.
+  # ---------------------------------------------------------------------------
+  EcsZeroTasksAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: jitsi-ecs-zero-tasks
+      AlarmDescription: >
+        P0 — ECS service has zero running tasks. meet.clouddelnorte.org is
+        completely down. Immediate action required.
+      Namespace: AWS/ECS
+      MetricName: RunningTaskCount
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref ClusterName
+        - Name: ServiceName
+          Value: !Ref ServiceName
+      Statistic: Minimum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: breaching
+      AlarmActions:
+        - !Ref JitsiOpsAlertsTopic
+      OKActions:
+        - !Ref JitsiOpsAlertsTopic
+      Tags:
+        - Key: project
+          Value: !Ref Project
+        - Key: env
+          Value: !Ref Env
+        - Key: owner
+          Value: !Ref Owner
+        - Key: cost-center
+          Value: !Ref CostCenter
+        - Key: priority
+          Value: P0
+
+  # ---------------------------------------------------------------------------
+  # P0 ALARM: jitsi-web-tg-unhealthy
+  #
+  # NAMESPACE: AWS/ApplicationELB
+  # The web target group (jitsi-video-platform-web-tg) is attached to an ALB
+  # (jitsi-video-platform-web-alb). ALB target group metrics use the
+  # AWS/ApplicationELB namespace with dimensions TargetGroup + LoadBalancer.
+  #
+  # This is DIFFERENT from the JVB alarms below which use AWS/NetworkELB
+  # because those target groups sit behind an NLB.
+  # ---------------------------------------------------------------------------
+  WebTgUnhealthyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: jitsi-web-tg-unhealthy
+      AlarmDescription: >
+        P0 — Web target group has zero healthy targets. The Jitsi UI will not
+        load (HTTP 503 from ALB). Immediate action required.
+      # Web TG is behind an ALB — use AWS/ApplicationELB namespace
+      Namespace: AWS/ApplicationELB
+      MetricName: HealthyHostCount
+      Dimensions:
+        - Name: TargetGroup
+          Value: !Ref WebTargetGroupFullName
+        - Name: LoadBalancer
+          Value: !Ref WebAlbFullName
+      Statistic: Minimum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: breaching
+      AlarmActions:
+        - !Ref JitsiOpsAlertsTopic
+      OKActions:
+        - !Ref JitsiOpsAlertsTopic
+      Tags:
+        - Key: project
+          Value: !Ref Project
+        - Key: env
+          Value: !Ref Env
+        - Key: owner
+          Value: !Ref Owner
+        - Key: cost-center
+          Value: !Ref CostCenter
+        - Key: priority
+          Value: P0
+
+  # ---------------------------------------------------------------------------
+  # P1 ALARM: jitsi-jvb-tcp-tg-unhealthy
+  #
+  # NAMESPACE: AWS/NetworkELB
+  # The JVB TCP target group (jitsi-video-platform-jvb-tcp-tg) is behind an NLB
+  # (jitsi-video-platform-jvb-nlb). NLB target group metrics use the
+  # AWS/NetworkELB namespace with dimensions TargetGroup + LoadBalancer.
+  #
+  # This is the TCP 4443 fallback path for clients that cannot reach JVB via
+  # UDP 10000 directly. 2 evaluation periods to avoid flap on task replacement.
+  # ---------------------------------------------------------------------------
+  JvbTcpTgUnhealthyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: jitsi-jvb-tcp-tg-unhealthy
+      AlarmDescription: >
+        P1 — JVB TCP target group (port 4443) has zero healthy targets. TCP
+        media fallback path is down. Users on restricted networks cannot
+        exchange audio/video.
+      # JVB TGs are behind an NLB — use AWS/NetworkELB namespace
+      Namespace: AWS/NetworkELB
+      MetricName: HealthyHostCount
+      Dimensions:
+        - Name: TargetGroup
+          Value: !Ref JvbTcpTargetGroupFullName
+        - Name: LoadBalancer
+          Value: !Ref JvbNlbFullName
+      Statistic: Minimum
+      Period: 60
+      EvaluationPeriods: 2
+      Threshold: 1
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: breaching
+      AlarmActions:
+        - !Ref JitsiOpsAlertsTopic
+      OKActions:
+        - !Ref JitsiOpsAlertsTopic
+      Tags:
+        - Key: project
+          Value: !Ref Project
+        - Key: env
+          Value: !Ref Env
+        - Key: owner
+          Value: !Ref Owner
+        - Key: cost-center
+          Value: !Ref CostCenter
+        - Key: priority
+          Value: P1
+
+  # ---------------------------------------------------------------------------
+  # P1 ALARM: jitsi-jvb-udp-tg-unhealthy
+  #
+  # NAMESPACE: AWS/NetworkELB
+  # The JVB UDP target group (jitsi-video-platform-jvb-udp-tg) is behind the
+  # same NLB (jitsi-video-platform-jvb-nlb). Same namespace rationale as above.
+  #
+  # This is the primary media path (UDP 10000). When unhealthy, no audio/video
+  # flows even though the room UI loads fine — the most dangerous failure mode.
+  # ---------------------------------------------------------------------------
+  JvbUdpTgUnhealthyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: jitsi-jvb-udp-tg-unhealthy
+      AlarmDescription: >
+        P1 — JVB UDP target group (port 10000) has zero healthy targets. Primary
+        media path is down. Audio and video will fail even though the room UI
+        loads. This is the most dangerous silent failure mode.
+      # JVB TGs are behind an NLB — use AWS/NetworkELB namespace
+      Namespace: AWS/NetworkELB
+      MetricName: HealthyHostCount
+      Dimensions:
+        - Name: TargetGroup
+          Value: !Ref JvbUdpTargetGroupFullName
+        - Name: LoadBalancer
+          Value: !Ref JvbNlbFullName
+      Statistic: Minimum
+      Period: 60
+      EvaluationPeriods: 2
+      Threshold: 1
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: breaching
+      AlarmActions:
+        - !Ref JitsiOpsAlertsTopic
+      OKActions:
+        - !Ref JitsiOpsAlertsTopic
+      Tags:
+        - Key: project
+          Value: !Ref Project
+        - Key: env
+          Value: !Ref Env
+        - Key: owner
+          Value: !Ref Owner
+        - Key: cost-center
+          Value: !Ref CostCenter
+        - Key: priority
+          Value: P1
+
+  # ---------------------------------------------------------------------------
+  # P2 EVENT RULE: jitsi-ecs-desired-zero
+  # Catches ANY controller (Lambda, console, CLI, auto-scaling policy) that
+  # sets desiredCount to zero on this service. Targets the SNS topic so the
+  # operator knows immediately — regardless of whether the scale-down is
+  # intentional or accidental.
+  #
+  # ECS emits "ECS Service Action" events with eventName
+  # SERVICE_DESIRED_COUNT_SET when the desired count changes.
+  # ---------------------------------------------------------------------------
+  DesiredCountZeroRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: jitsi-ecs-desired-zero
+      Description: >
+        P2 — Fires when any controller sets ECS desiredCount to zero on
+        jitsi-service. Announces via SNS so operator is aware of scale-down.
+      State: ENABLED
+      EventPattern:
+        source:
+          - aws.ecs
+        detail-type:
+          - ECS Service Action
+        detail:
+          clusterArn:
+            - !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
+          eventName:
+            - SERVICE_DESIRED_COUNT_SET
+      Targets:
+        - Id: notify-sns
+          Arn: !Ref JitsiOpsAlertsTopic
+
+  # ---------------------------------------------------------------------------
+  # SNS topic policy — allow EventBridge to publish to the topic
+  # ---------------------------------------------------------------------------
+  JitsiOpsAlertsTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref JitsiOpsAlertsTopic
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowEventsPublish
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref JitsiOpsAlertsTopic
+
+Outputs:
+  TopicArn:
+    Description: ARN of the jitsi-ops-alerts SNS topic
+    Value: !Ref JitsiOpsAlertsTopic
+    Export:
+      Name: !Sub "${AWS::StackName}-TopicArn"
+
+  TopicName:
+    Description: SNS topic name
+    Value: jitsi-ops-alerts
+
+  EcsZeroTasksAlarmName:
+    Description: Name of the P0 ECS zero tasks alarm
+    Value: !Ref EcsZeroTasksAlarm
+
+  WebTgUnhealthyAlarmName:
+    Description: Name of the P0 web TG unhealthy alarm
+    Value: !Ref WebTgUnhealthyAlarm
+
+  JvbTcpTgUnhealthyAlarmName:
+    Description: Name of the P1 JVB TCP TG unhealthy alarm
+    Value: !Ref JvbTcpTgUnhealthyAlarm
+
+  JvbUdpTgUnhealthyAlarmName:
+    Description: Name of the P1 JVB UDP TG unhealthy alarm
+    Value: !Ref JvbUdpTgUnhealthyAlarm

--- a/scripts/deploy-jitsi-ops-alarms.sh
+++ b/scripts/deploy-jitsi-ops-alarms.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# deploy-jitsi-ops-alarms.sh
+# deploys the jitsi-ops-alarms CloudFormation stack to account 170473530355
+# (jitsi-video-hosting profile, us-west-2). creates CloudWatch alarms and an
+# SNS topic for jitsi ECS operational monitoring.
+#
+# requires: aws cli v2, jitsi-video-hosting SSO profile active
+#
+# usage:
+#   ./scripts/deploy-jitsi-ops-alarms.sh \
+#     --email operator@example.com \
+#     --ntfy https://ntfy.sh/cdn-jitsi-ops-abc12345
+#
+#   ./scripts/deploy-jitsi-ops-alarms.sh --dry-run
+#
+# environment variables (alternative to flags):
+#   JITSI_OPS_EMAIL    — email subscription endpoint
+#   JITSI_OPS_NTFY     — ntfy.sh HTTPS endpoint
+#
+# never hardcode credentials, phone numbers, or email addresses in this script.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMPLATE="${REPO_ROOT}/infra/jitsi-ops-alarms.cfn.yaml"
+STACK_NAME="jitsi-ops-alarms"
+REGION="us-west-2"
+PROFILE="jitsi-video-hosting"
+
+# defaults from env
+EMAIL="${JITSI_OPS_EMAIL:-}"
+NTFY="${JITSI_OPS_NTFY:-}"
+DRY_RUN=false
+
+# ---------------------------------------------------------------------------
+# argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --email) EMAIL="$2"; shift 2 ;;
+    --ntfy) NTFY="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --help|-h)
+      echo "usage: $0 [--email <addr>] [--ntfy <url>] [--dry-run]"
+      exit 0
+      ;;
+    *) echo >&2 "unknown argument: $1"; exit 2 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# SSO session precheck — fail early with a clear message
+# ---------------------------------------------------------------------------
+sso_check() {
+  if ! aws sts get-caller-identity --profile "${PROFILE}" --region "${REGION}" >/dev/null 2>&1; then
+    echo >&2 "ERROR: SSO session for profile '${PROFILE}' is not active."
+    echo >&2 "Run:  aws sso login --profile ${PROFILE}"
+    exit 1
+  fi
+}
+
+trap 'echo >&2 "ERROR: command failed at line ${LINENO}"; exit 1' ERR
+
+echo "verifying SSO session for profile '${PROFILE}'…"
+sso_check
+echo "SSO session active."
+
+# ---------------------------------------------------------------------------
+# resolve target group and load balancer full-names from the live account
+# ---------------------------------------------------------------------------
+echo "resolving target group and load balancer identifiers…"
+
+resolve_tg_fullname() {
+  local name="$1"
+  local arn
+  arn="$(aws elbv2 describe-target-groups \
+    --names "${name}" \
+    --query 'TargetGroups[0].TargetGroupArn' \
+    --output text \
+    --profile "${PROFILE}" \
+    --region "${REGION}" 2>/dev/null)" || {
+    echo >&2 "ERROR: target group '${name}' not found in ${REGION}"
+    exit 1
+  }
+  # extract targetgroup/<name>/<hex> from the full ARN
+  echo "${arn}" | sed 's|.*:targetgroup|targetgroup|'
+}
+
+resolve_lb_fullname() {
+  local name="$1"
+  local arn
+  arn="$(aws elbv2 describe-load-balancers \
+    --names "${name}" \
+    --query 'LoadBalancers[0].LoadBalancerArn' \
+    --output text \
+    --profile "${PROFILE}" \
+    --region "${REGION}" 2>/dev/null)" || {
+    echo >&2 "ERROR: load balancer '${name}' not found in ${REGION}"
+    exit 1
+  }
+  # extract app/<name>/<hex> or net/<name>/<hex> from the full ARN
+  echo "${arn}" | sed 's|.*:loadbalancer/||'
+}
+
+WEB_TG_FULL="$(resolve_tg_fullname jitsi-video-platform-web-tg)"
+JVB_TCP_TG_FULL="$(resolve_tg_fullname jitsi-video-platform-jvb-tcp-tg)"
+JVB_UDP_TG_FULL="$(resolve_tg_fullname jitsi-video-platform-jvb-udp-tg)"
+WEB_ALB_FULL="$(resolve_lb_fullname jitsi-video-platform-web-alb)"
+JVB_NLB_FULL="$(resolve_lb_fullname jitsi-video-platform-jvb-nlb)"
+
+echo "  web TG:      ${WEB_TG_FULL}"
+echo "  jvb-tcp TG:  ${JVB_TCP_TG_FULL}"
+echo "  jvb-udp TG:  ${JVB_UDP_TG_FULL}"
+echo "  web ALB:     ${WEB_ALB_FULL}"
+echo "  jvb NLB:     ${JVB_NLB_FULL}"
+
+# ---------------------------------------------------------------------------
+# build parameter overrides
+# ---------------------------------------------------------------------------
+PARAMS=(
+  "WebTargetGroupFullName=${WEB_TG_FULL}"
+  "JvbTcpTargetGroupFullName=${JVB_TCP_TG_FULL}"
+  "JvbUdpTargetGroupFullName=${JVB_UDP_TG_FULL}"
+  "WebAlbFullName=${WEB_ALB_FULL}"
+  "JvbNlbFullName=${JVB_NLB_FULL}"
+)
+
+if [[ -n "${EMAIL}" ]]; then
+  PARAMS+=("NotificationEmail=${EMAIL}")
+fi
+
+if [[ -n "${NTFY}" ]]; then
+  PARAMS+=("NtfyEndpoint=${NTFY}")
+fi
+
+# ---------------------------------------------------------------------------
+# dry-run: create change set and display it without executing
+# ---------------------------------------------------------------------------
+if [[ "${DRY_RUN}" == "true" ]]; then
+  echo ""
+  echo "DRY RUN — creating change set without applying…"
+  CHANGESET_NAME="jitsi-ops-alarms-dryrun-$(date +%s)"
+
+  aws cloudformation create-change-set \
+    --template-body "file://${TEMPLATE}" \
+    --stack-name "${STACK_NAME}" \
+    --change-set-name "${CHANGESET_NAME}" \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --region "${REGION}" \
+    --profile "${PROFILE}" \
+    --parameters $(printf 'ParameterKey=%s,ParameterValue=%s ' "${PARAMS[@]//=/ }") \
+    --output text >/dev/null 2>&1 || true
+
+  echo "waiting for change set to complete…"
+  aws cloudformation wait change-set-create-complete \
+    --stack-name "${STACK_NAME}" \
+    --change-set-name "${CHANGESET_NAME}" \
+    --region "${REGION}" \
+    --profile "${PROFILE}" 2>/dev/null || true
+
+  echo ""
+  echo "change set contents:"
+  aws cloudformation describe-change-set \
+    --stack-name "${STACK_NAME}" \
+    --change-set-name "${CHANGESET_NAME}" \
+    --region "${REGION}" \
+    --profile "${PROFILE}" \
+    --query 'Changes[].ResourceChange.{Action:Action,LogicalId:LogicalResourceId,Type:ResourceType}' \
+    --output table 2>/dev/null || echo "(stack may not exist yet — change set shows full creation)"
+
+  # clean up dry-run change set
+  aws cloudformation delete-change-set \
+    --stack-name "${STACK_NAME}" \
+    --change-set-name "${CHANGESET_NAME}" \
+    --region "${REGION}" \
+    --profile "${PROFILE}" 2>/dev/null || true
+
+  echo ""
+  echo "dry run complete. no resources were created or modified."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# deploy: create-or-update the stack
+# ---------------------------------------------------------------------------
+echo ""
+echo "deploying stack '${STACK_NAME}' to ${REGION}…"
+
+aws cloudformation deploy \
+  --template-file "${TEMPLATE}" \
+  --stack-name "${STACK_NAME}" \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --region "${REGION}" \
+  --profile "${PROFILE}" \
+  --parameter-overrides "${PARAMS[@]}" \
+  --tags project=cloud-del-norte env=prod owner=bryanchasko cost-center=heraldstack
+
+echo ""
+echo "stack deployed successfully."
+echo ""
+
+# ---------------------------------------------------------------------------
+# output: print resulting resources
+# ---------------------------------------------------------------------------
+echo "alarm names:"
+aws cloudformation describe-stacks \
+  --stack-name "${STACK_NAME}" \
+  --region "${REGION}" \
+  --profile "${PROFILE}" \
+  --query "Stacks[0].Outputs[?contains(OutputKey,'Alarm')].{Key:OutputKey,Value:OutputValue}" \
+  --output table
+
+echo ""
+echo "SNS topic ARN:"
+aws cloudformation describe-stacks \
+  --stack-name "${STACK_NAME}" \
+  --region "${REGION}" \
+  --profile "${PROFILE}" \
+  --query "Stacks[0].Outputs[?OutputKey=='TopicArn'].OutputValue" \
+  --output text
+
+if [[ -n "${EMAIL}" ]]; then
+  echo ""
+  echo "confirmation email sent to the configured address — click the link to activate."
+fi
+
+if [[ -n "${NTFY}" ]]; then
+  echo ""
+  echo "ntfy.sh subscription created — confirm via the ntfy.sh topic."
+fi


### PR DESCRIPTION
## Summary

Closes the monitoring gap that allowed a **4 hour 40 minute silent outage** on 2026-07-31. The jitsi ECS service was scaled to zero at 18:12Z by an EventBridge-scheduled Lambda and stayed dead until a human found it at 22:53Z. Zero alarms fired.

Separately, both JVB media target groups were unhealthy while the web target group was healthy — the most dangerous failure mode because the room UI loads and only audio/video fail silently.

## Alarms Created (authored, NOT yet deployed)

| Alarm | Priority | What it detects |
|-------|----------|----------------|
| `jitsi-ecs-zero-tasks` | P0 | ECS service has zero running tasks — total platform outage |
| `jitsi-web-tg-unhealthy` | P0 | Web ALB target group has zero healthy targets — UI returns 503 |
| `jitsi-jvb-tcp-tg-unhealthy` | P1 | JVB TCP NLB target group unhealthy — TCP media fallback down |
| `jitsi-jvb-udp-tg-unhealthy` | P1 | JVB UDP NLB target group unhealthy — primary media path down |
| `jitsi-ecs-desired-zero` (EventBridge) | P2 | Any controller sets desiredCount to 0 — announced via SNS |

### Namespace discipline (critical correctness note)
- Web TG alarm uses **AWS/ApplicationELB** — web target group is behind an ALB
- JVB TG alarms use **AWS/NetworkELB** — JVB target groups are behind an NLB
- A namespace mismatch would cause the alarm to silently never fire, reproducing the exact failure this PR prevents

## Files

- `infra/jitsi-ops-alarms.cfn.yaml` — CloudFormation template (account 170473530355, us-west-2)
- `scripts/deploy-jitsi-ops-alarms.sh` — idempotent deploy script with SSO precheck and --dry-run
- `docs/runbooks/jitsi-cold-stack.md` — operational runbook for cold-stack diagnosis + JVB remediation

## Deployment

This PR is **authored only — not deployed**. To deploy after merge:

```bash
./scripts/deploy-jitsi-ops-alarms.sh \
  --email <operator-email> \
  --ntfy https://ntfy.sh/<topic>
```

## Validation

- ✅ `aws cloudformation validate-template` passed (profile jitsi-video-hosting, us-west-2)
- ✅ New files introduce zero biome errors (YAML/sh/md are ignored by biome config)
- ✅ Shell script is executable (chmod +x)

Refs: #469, #470