### PR TITLE
feat(meetings): auto-open the call room, drop the tickets widget, immersive layout

### DIFF
--- a/src/layouts/shell/index.tsx
+++ b/src/layouts/shell/index.tsx
@@ -284,6 +284,12 @@ export interface ShellProps {
 	/** Suppress the persistent radio player slot. Used on subdomains where the player
 	 *  bar is irrelevant (e.g. awsug). */
 	hidePlayer?: boolean;
+	/** Controlled navigation-open state. If provided Shell becomes a controlled
+	 *  component for navigation — caller must also supply onNavigationChange.
+	 *  If omitted Shell self-manages nav state as before (backward compatible). */
+	navigationOpen?: boolean;
+	/** Callback when the user toggles navigation drawer. Required when navigationOpen is provided. */
+	onNavigationChange?: (open: boolean) => void;
 }
 
 function ShellContent({
@@ -305,6 +311,8 @@ function ShellContent({
 	toolsHide,
 	hideSignInUtility,
 	hidePlayer,
+	navigationOpen: navigationOpenProp,
+	onNavigationChange: onNavigationChangeProp,
 }: ShellProps) {
 	const { t } = useTranslation();
 	const auth = useAuth();
@@ -328,21 +336,27 @@ function ShellContent({
 	// Initialize nav state from localStorage OR viewport (Cloudscape breakpoint: 688px)
 	const [signInLabel, setSignInLabel] = useState("sign in");
 
-	const [navOpen, setNavOpen] = useState(() => {
+	const isNavControlled = navigationOpenProp !== undefined;
+	const [navOpenInternal, setNavOpenInternal] = useState(() => {
 		const stored = getStoredNavState();
 		if (stored !== null) return stored;
 		return typeof window !== "undefined" && window.innerWidth >= 688;
 	});
+	const navOpen = isNavControlled ? navigationOpenProp : navOpenInternal;
 
 	const handleNavigationChange = useCallback(
 		(event: { detail: { open: boolean } }) => {
 			const newState = event.detail.open;
-			setNavOpen(newState);
-			setStoredNavState(newState);
+			if (isNavControlled) {
+				onNavigationChangeProp?.(newState);
+			} else {
+				setNavOpenInternal(newState);
+				setStoredNavState(newState);
+			}
 			// Wave 66: notify Navigation component so it can gate FionaFrame mount
 			dispatchNavState(newState);
 		},
-		[],
+		[isNavControlled, onNavigationChangeProp],
 	);
 
 	useEffect(() => {
@@ -358,19 +372,20 @@ function ShellContent({
 
 	// Add resize listener to handle viewport changes
 	useEffect(() => {
+		if (isNavControlled) return; // controlled mode — parent manages state
 		function handleResize() {
 			const isDesktop = window.innerWidth >= 688;
 			const stored = getStoredNavState();
 
 			// Only auto-adjust if user hasn't set a preference
 			if (stored === null) {
-				setNavOpen(isDesktop);
+				setNavOpenInternal(isDesktop);
 			}
 		}
 
 		window.addEventListener("resize", handleResize);
 		return () => window.removeEventListener("resize", handleResize);
-	}, []);
+	}, [isNavControlled]);
 
 	// Tools-panel open/close → body class so the Volunteer pill (the
 	// repurposed Cloudscape Info popover anchor) can fade out when the

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1001,7 +1001,20 @@
 		"meetings": {
 			"pendingApproval": "your application is pending approval. meetings are available once approved.",
 			"createPendingApproval": "your application is pending approval. meeting creation is available once approved.",
-			"pendingJoinError": "Your account is pending admin approval. You'll be able to join meetings once approved."
+			"pendingJoinError": "Your account is pending admin approval. You'll be able to join meetings once approved.",
+			"bannedMessage": "your account has been suspended from meetings.",
+			"header": "meetings",
+			"openRoomDescription": "Open the Cloud del Norte meeting room, or check meetup.com for upcoming events.",
+			"openCallRoom": "open call room",
+			"viewOnMeetup": "view on meetup.com",
+			"scheduleSession": "schedule a session",
+			"scheduleDescription": "Organizers can schedule new sessions from the create meeting page.",
+			"createMeeting": "create meeting",
+			"leaveCall": "leave call",
+			"joiningRoom": "joining the meeting room…",
+			"autoJoinErrorHeader": "could not join the meeting room",
+			"autoJoinFailed": "failed to connect to the meeting room. try joining manually.",
+			"fp021Error": "the meeting room did not load correctly. the call may not have connected — try joining manually."
 		}
 	},
 	"fiona": {

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -1001,7 +1001,20 @@
 		"meetings": {
 			"pendingApproval": "tu solicitud está pendiente. las juntas van a estar disponibles cuando te aprueben.",
 			"createPendingApproval": "tu solicitud está pendiente. crear juntas va a estar disponible cuando te aprueben.",
-			"pendingJoinError": "Tu cuenta está pendiente de aprobación. Vas a poder unirte a las juntas cuando te aprueben."
+			"pendingJoinError": "Tu cuenta está pendiente de aprobación. Vas a poder unirte a las juntas cuando te aprueben.",
+			"bannedMessage": "tu cuenta fue suspendida de las juntas.",
+			"header": "juntas",
+			"openRoomDescription": "Entra a la sala de juntas de Cloud del Norte, o checa meetup.com pa los próximos eventos.",
+			"openCallRoom": "entrar a la sala",
+			"viewOnMeetup": "ver en meetup.com",
+			"scheduleSession": "programar una sesión",
+			"scheduleDescription": "Los organizadores pueden programar sesiones nuevas desde la página de crear junta.",
+			"createMeeting": "crear junta",
+			"leaveCall": "salir de la llamada",
+			"joiningRoom": "entrando a la sala de juntas…",
+			"autoJoinErrorHeader": "no se pudo entrar a la sala",
+			"autoJoinFailed": "no se conectó a la sala de juntas. intenta entrar manualmente.",
+			"fp021Error": "la sala no cargó bien. puede que no se haya conectado la llamada — intenta entrar manualmente."
 		}
 	},
 	"fiona": {

--- a/src/sites/awsug/_layout/index.tsx
+++ b/src/sites/awsug/_layout/index.tsx
@@ -43,11 +43,24 @@ function ToolsPanel() {
 	);
 }
 
+export interface AwsugLayoutProps {
+	children: React.ReactNode;
+	/** Hide the tools (help) panel entirely — used in immersive mode */
+	toolsHide?: boolean;
+	/** Override the navigation-open state. When provided, the layout uses this
+	 *  value instead of Shell's internal state. The user can still toggle the
+	 *  drawer open/closed via the hamburger — this only sets the initial/forced value. */
+	navigationOpen?: boolean;
+	/** Callback when the user toggles navigation. Required when navigationOpen is provided. */
+	onNavigationChange?: (open: boolean) => void;
+}
+
 export default function AwsugLayout({
 	children,
-}: {
-	children: React.ReactNode;
-}) {
+	toolsHide,
+	navigationOpen,
+	onNavigationChange,
+}: AwsugLayoutProps) {
 	const [theme, setTheme] = useState<Theme>(() => initializeTheme());
 	const [locale, setLocale] = useState<Locale>(() => initializeLocale());
 
@@ -66,7 +79,10 @@ export default function AwsugLayout({
 				setStoredLocale(l);
 			}}
 			navigation={<AwsugNavigation />}
-			tools={<ToolsPanel />}
+			tools={toolsHide ? undefined : <ToolsPanel />}
+			toolsHide={toolsHide}
+			navigationOpen={navigationOpen}
+			onNavigationChange={onNavigationChange}
 			identityHref="/"
 		>
 			<PendingApprovalBanner />

--- a/src/sites/awsug/meetings/__tests__/app.test.tsx
+++ b/src/sites/awsug/meetings/__tests__/app.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -18,11 +18,29 @@ vi.mock("../../_shared/auth", () => ({
 	isMember: (auth: { groups: string[] }) => auth.groups.includes("members"),
 	isModerator: (auth: { groups: string[] }) =>
 		auth.groups.includes("moderators"),
+	isBanned: (auth: { groups: string[] }) => auth.groups.includes("banned"),
 }));
 
 vi.mock("../../_layout", () => ({
-	default: ({ children }: { children: React.ReactNode }) =>
-		React.createElement("div", { "data-testid": "awsug-layout" }, children),
+	default: ({
+		children,
+		toolsHide,
+		navigationOpen,
+	}: {
+		children: React.ReactNode;
+		toolsHide?: boolean;
+		navigationOpen?: boolean;
+	}) =>
+		React.createElement(
+			"div",
+			{
+				"data-testid": "awsug-layout",
+				"data-tools-hide": toolsHide ? "true" : undefined,
+				"data-nav-open":
+					navigationOpen !== undefined ? String(navigationOpen) : undefined,
+			},
+			children,
+		),
 }));
 
 vi.mock("../../../../hooks/useTranslation", () => ({
@@ -32,7 +50,15 @@ vi.mock("../../../../hooks/useTranslation", () => ({
 }));
 
 vi.mock("../../../../pages/meetings/components/jitsi-embed", () => ({
-	default: () => React.createElement("div", { "data-testid": "jitsi-embed" }),
+	default: ({
+		roomName,
+		onClose,
+	}: { roomName?: string; onClose?: () => void }) =>
+		React.createElement("div", {
+			"data-testid": "jitsi-embed",
+			"data-room": roomName,
+			"data-onclose": onClose ? "present" : undefined,
+		}),
 }));
 
 import { requireAuth } from "../../_shared/auth";
@@ -40,7 +66,7 @@ import App from "../app";
 
 const mockRequireAuth = requireAuth as ReturnType<typeof vi.fn>;
 
-describe("meetings/app.tsx — create meeting button visibility", () => {
+describe("meetings/app.tsx", () => {
 	beforeEach(() => {
 		Object.defineProperty(window, "location", {
 			value: { pathname: "/meetings/index.html", assign: vi.fn() },
@@ -48,57 +74,248 @@ describe("meetings/app.tsx — create meeting button visibility", () => {
 		});
 	});
 
-	it("moderator sees create meeting button", async () => {
-		mockRequireAuth.mockReturnValue({
-			email: "mod@example.com",
-			sub: "sub-mod",
-			groups: ["members", "moderators"],
-			idToken: "tok",
+	describe("create meeting button visibility", () => {
+		it("moderator sees embed auto-mounted", async () => {
+			mockRequireAuth.mockReturnValue({
+				email: "mod@example.com",
+				sub: "sub-mod",
+				groups: ["members", "moderators"],
+				idToken: "tok",
+			});
+
+			render(<App />);
+
+			await waitFor(() =>
+				expect(screen.getByTestId("jitsi-embed")).toBeInTheDocument(),
+			);
 		});
 
-		render(<App />);
+		it("member does not see create meeting button", async () => {
+			mockRequireAuth.mockReturnValue({
+				email: "member@example.com",
+				sub: "sub-mem",
+				groups: ["members"],
+				idToken: "tok",
+			});
 
-		await waitFor(() =>
+			render(<App />);
+
+			await waitFor(() =>
+				expect(screen.getByTestId("jitsi-embed")).toBeInTheDocument(),
+			);
 			expect(
-				screen.getByRole("link", { name: /create meeting/i }),
-			).toBeInTheDocument(),
-		);
+				screen.queryByRole("link", { name: /create meeting/i }),
+			).not.toBeInTheDocument();
+		});
+
+		it("pending user sees pending approval message", async () => {
+			mockRequireAuth.mockReturnValue({
+				email: "pending@example.com",
+				sub: "sub-pend",
+				groups: [],
+				idToken: "tok",
+			});
+
+			render(<App />);
+
+			await waitFor(() =>
+				expect(
+					screen.getByText("awsug.meetings.pendingApproval"),
+				).toBeInTheDocument(),
+			);
+		});
 	});
 
-	it("member does not see create meeting button", async () => {
-		mockRequireAuth.mockReturnValue({
-			email: "member@example.com",
-			sub: "sub-mem",
-			groups: ["members"],
-			idToken: "tok",
+	describe("auto-join behaviour", () => {
+		it("auto-mounts the jitsi embed without a click for a permitted member", async () => {
+			mockRequireAuth.mockReturnValue({
+				email: "member@example.com",
+				sub: "sub-mem",
+				groups: ["members"],
+				idToken: "tok",
+			});
+
+			render(<App />);
+
+			// Embed mounts immediately — no button click needed
+			await waitFor(() =>
+				expect(screen.getByTestId("jitsi-embed")).toBeInTheDocument(),
+			);
+			// Room name is the deterministic shared value
+			expect(screen.getByTestId("jitsi-embed").getAttribute("data-room")).toBe(
+				"cloud-del-norte-awsug",
+			);
 		});
 
-		render(<App />);
+		it("does not auto-join for a pending user", async () => {
+			mockRequireAuth.mockReturnValue({
+				email: "pending@example.com",
+				sub: "sub-pend",
+				groups: [],
+				idToken: "tok",
+			});
 
-		await waitFor(() =>
+			render(<App />);
+
+			await waitFor(() =>
+				expect(
+					screen.getByText("awsug.meetings.pendingApproval"),
+				).toBeInTheDocument(),
+			);
+			expect(screen.queryByTestId("jitsi-embed")).not.toBeInTheDocument();
+		});
+
+		it("does not auto-join for a banned user", async () => {
+			mockRequireAuth.mockReturnValue({
+				email: "banned@example.com",
+				sub: "sub-ban",
+				groups: ["banned"],
+				idToken: "tok",
+			});
+
+			render(<App />);
+
+			await waitFor(() =>
+				expect(
+					screen.getByText("awsug.meetings.bannedMessage"),
+				).toBeInTheDocument(),
+			);
+			expect(screen.queryByTestId("jitsi-embed")).not.toBeInTheDocument();
+		});
+
+		it("shows leave-call button when in call", async () => {
+			mockRequireAuth.mockReturnValue({
+				email: "member@example.com",
+				sub: "sub-mem",
+				groups: ["members"],
+				idToken: "tok",
+			});
+
+			render(<App />);
+
+			await waitFor(() =>
+				expect(screen.getByTestId("jitsi-embed")).toBeInTheDocument(),
+			);
 			expect(
-				screen.getByRole("button", { name: /open call room/i }),
-			).toBeInTheDocument(),
-		);
-		expect(
-			screen.queryByRole("link", { name: /create meeting/i }),
-		).not.toBeInTheDocument();
+				screen.getByRole("button", { name: /awsug\.meetings\.leaveCall/i }),
+			).toBeInTheDocument();
+		});
+
+		it("leave-call unmounts embed and shows manual fallback", async () => {
+			mockRequireAuth.mockReturnValue({
+				email: "member@example.com",
+				sub: "sub-mem",
+				groups: ["members"],
+				idToken: "tok",
+			});
+
+			render(<App />);
+
+			await waitFor(() =>
+				expect(screen.getByTestId("jitsi-embed")).toBeInTheDocument(),
+			);
+
+			fireEvent.click(
+				screen.getByRole("button", { name: /awsug\.meetings\.leaveCall/i }),
+			);
+
+			await waitFor(() =>
+				expect(screen.queryByTestId("jitsi-embed")).not.toBeInTheDocument(),
+			);
+			// Manual button should appear as fallback
+			expect(
+				screen.getByRole("button", {
+					name: /awsug\.meetings\.openCallRoom/i,
+				}),
+			).toBeInTheDocument();
+		});
 	});
 
-	it("pending user sees pending approval message", async () => {
-		mockRequireAuth.mockReturnValue({
-			email: "pending@example.com",
-			sub: "sub-pend",
-			groups: [],
-			idToken: "tok",
+	describe("tickets widget removed", () => {
+		it("does not render the tickets widget on the meetings page", async () => {
+			mockRequireAuth.mockReturnValue({
+				email: "member@example.com",
+				sub: "sub-mem",
+				groups: ["members"],
+				idToken: "tok",
+			});
+
+			render(<App />);
+
+			await waitFor(() =>
+				expect(screen.getByTestId("jitsi-embed")).toBeInTheDocument(),
+			);
+			// MyTickets component should NOT be present
+			expect(screen.queryByText(/your tickets/i)).not.toBeInTheDocument();
+			expect(screen.queryByText(/myTicketsHeader/i)).not.toBeInTheDocument();
+		});
+	});
+
+	describe("immersive layout", () => {
+		it("hides tools panel and collapses nav when in call", async () => {
+			mockRequireAuth.mockReturnValue({
+				email: "member@example.com",
+				sub: "sub-mem",
+				groups: ["members"],
+				idToken: "tok",
+			});
+
+			render(<App />);
+
+			await waitFor(() =>
+				expect(screen.getByTestId("jitsi-embed")).toBeInTheDocument(),
+			);
+
+			const layout = screen.getByTestId("awsug-layout");
+			expect(layout.getAttribute("data-tools-hide")).toBe("true");
+			expect(layout.getAttribute("data-nav-open")).toBe("false");
 		});
 
-		render(<App />);
+		it("restores chrome when user leaves the call", async () => {
+			mockRequireAuth.mockReturnValue({
+				email: "member@example.com",
+				sub: "sub-mem",
+				groups: ["members"],
+				idToken: "tok",
+			});
 
-		await waitFor(() =>
+			render(<App />);
+
+			await waitFor(() =>
+				expect(screen.getByTestId("jitsi-embed")).toBeInTheDocument(),
+			);
+
+			fireEvent.click(
+				screen.getByRole("button", { name: /awsug\.meetings\.leaveCall/i }),
+			);
+
+			await waitFor(() => {
+				const layout = screen.getByTestId("awsug-layout");
+				expect(layout.getAttribute("data-tools-hide")).toBeNull();
+				expect(layout.getAttribute("data-nav-open")).toBe("true");
+			});
+		});
+	});
+
+	describe("error handling and fallback", () => {
+		it("wires the onClose handler to the jitsi embed for failure detection", async () => {
+			mockRequireAuth.mockReturnValue({
+				email: "member@example.com",
+				sub: "sub-mem",
+				groups: ["members"],
+				idToken: "tok",
+			});
+
+			render(<App />);
+
+			await waitFor(() =>
+				expect(screen.getByTestId("jitsi-embed")).toBeInTheDocument(),
+			);
+
+			// The embed is mounted with onClose wired for failure detection
 			expect(
-				screen.getByText("awsug.meetings.pendingApproval"),
-			).toBeInTheDocument(),
-		);
+				screen.getByTestId("jitsi-embed").getAttribute("data-onclose"),
+			).toBe("present");
+		});
 	});
 });

--- a/src/sites/awsug/meetings/app.tsx
+++ b/src/sites/awsug/meetings/app.tsx
@@ -6,15 +6,15 @@ import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
-import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "../../../hooks/useTranslation";
 import JitsiEmbed from "../../../pages/meetings/components/jitsi-embed";
 import AwsugLayout from "../_layout";
 import {
 	type AuthState,
+	isBanned,
 	isMember,
 	isModerator,
 	requireAuth,
@@ -23,55 +23,158 @@ import "../rsvp/styles.css";
 
 const MEETUP_URL = "https://www.meetup.com/cloud-del-norte/";
 const ROOM_NAME = "cloud-del-norte-awsug";
+const JITSI_DOMAIN = "meet.clouddelnorte.org";
+
+/**
+ * FP-021 guard: verify the jitsi iframe src contains meet.clouddelnorte.org.
+ * Auto-join makes this guard MORE important — no click for the user to
+ * correlate with a failure. Returns true if a valid jitsi iframe is found.
+ */
+function verifyJitsiIframe(): boolean {
+	const host = document.querySelector('[data-testid="jitsi-iframe-host"]');
+	if (!host) return false;
+	const iframe = host.querySelector("iframe");
+	if (!iframe) return false;
+	return iframe.src.includes(JITSI_DOMAIN);
+}
 
 function MeetingsContent({ auth }: { auth: AuthState }) {
+	const { t } = useTranslation();
 	const [inCall, setInCall] = useState(false);
+	const [autoJoinFailed, setAutoJoinFailed] = useState(false);
+	const [autoJoinError, setAutoJoinError] = useState("");
+	const [isAutoJoining, setIsAutoJoining] = useState(true);
+	const fp021CheckRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const handleLeaveCall = useCallback(() => {
+		setInCall(false);
+		setIsAutoJoining(false);
+		if (fp021CheckRef.current) {
+			clearTimeout(fp021CheckRef.current);
+			fp021CheckRef.current = null;
+		}
+	}, []);
+
+	const handleManualJoin = useCallback(() => {
+		setAutoJoinFailed(false);
+		setAutoJoinError("");
+		setInCall(true);
+	}, []);
+
+	// Auto-join on mount for permitted users
+	useEffect(() => {
+		if (isBanned(auth)) {
+			setIsAutoJoining(false);
+			return;
+		}
+		// Mount the embed immediately — JitsiEmbed handles token fetch internally
+		setInCall(true);
+	}, [auth]);
+
+	// FP-021 guard: after the embed has had time to initialize (15s),
+	// verify that the iframe src contains the jitsi domain. If not, surface
+	// an error so the user knows they are stranded.
+	useEffect(() => {
+		if (!inCall) return;
+		fp021CheckRef.current = setTimeout(() => {
+			if (!verifyJitsiIframe()) {
+				setAutoJoinFailed(true);
+				setAutoJoinError(
+					t("awsug.meetings.fp021Error"),
+				);
+				setInCall(false);
+			}
+		}, 15_000);
+		return () => {
+			if (fp021CheckRef.current) {
+				clearTimeout(fp021CheckRef.current);
+				fp021CheckRef.current = null;
+			}
+		};
+	}, [inCall, t]);
+
+	// If the embed reports an error via onClose while auto-joining, treat as failure
+	const handleEmbedClose = useCallback(() => {
+		if (isAutoJoining) {
+			setAutoJoinFailed(true);
+			setAutoJoinError(t("awsug.meetings.autoJoinFailed"));
+		}
+		setInCall(false);
+	}, [isAutoJoining, t]);
+
+	if (inCall) {
+		return (
+			<SpaceBetween size="m">
+				<Box>
+					<Button
+						variant="link"
+						iconName="close"
+						onClick={handleLeaveCall}
+					>
+						{t("awsug.meetings.leaveCall")}
+					</Button>
+				</Box>
+				<JitsiEmbed roomName={ROOM_NAME} onClose={handleEmbedClose} />
+			</SpaceBetween>
+		);
+	}
+
+	if (isAutoJoining && !autoJoinFailed) {
+		return (
+			<Container>
+				<Box padding="xxl" textAlign="center">
+					<SpaceBetween size="s" alignItems="center">
+						<Spinner size="large" />
+						<Box variant="p">{t("awsug.meetings.joiningRoom")}</Box>
+					</SpaceBetween>
+				</Box>
+			</Container>
+		);
+	}
 
 	return (
 		<SpaceBetween size="l">
-			<Container header={<Header variant="h1">meetings</Header>}>
+			{autoJoinFailed && (
+				<Alert type="error" header={t("awsug.meetings.autoJoinErrorHeader")}>
+					{autoJoinError || t("awsug.meetings.autoJoinFailed")}
+				</Alert>
+			)}
+			<Container header={<Header variant="h1">{t("awsug.meetings.header")}</Header>}>
 				<SpaceBetween size="m">
-					<Box>
-						Open the Cloud del Norte meeting room, or check meetup.com for
-						upcoming events.
-					</Box>
+					<Box>{t("awsug.meetings.openRoomDescription")}</Box>
 					<SpaceBetween direction="horizontal" size="s">
-						<Button variant="primary" onClick={() => setInCall(true)}>
-							open call room
+						<Button variant="primary" onClick={handleManualJoin}>
+							{t("awsug.meetings.openCallRoom")}
 						</Button>
 						<Button href={MEETUP_URL} target="_blank" iconName="external">
-							view on meetup.com
+							{t("awsug.meetings.viewOnMeetup")}
 						</Button>
 					</SpaceBetween>
 				</SpaceBetween>
 			</Container>
 			{isModerator(auth) && (
-				<Container header={<Header variant="h2">schedule a session</Header>}>
+				<Container header={<Header variant="h2">{t("awsug.meetings.scheduleSession")}</Header>}>
 					<SpaceBetween size="s">
-						<Box>
-							Organizers can schedule new sessions from the create meeting page.
-						</Box>
-						<Button href="/create-meeting/index.html">create meeting</Button>
+						<Box>{t("awsug.meetings.scheduleDescription")}</Box>
+						<Button href="/create-meeting/index.html">
+							{t("awsug.meetings.createMeeting")}
+						</Button>
 					</SpaceBetween>
 				</Container>
 			)}
-			<Modal
-				visible={inCall}
-				onDismiss={() => setInCall(false)}
-				size="max"
-				header="Cloud del Norte — meeting room"
-				closeAriaLabel="leave meeting"
-			>
-				{inCall && (
-					<JitsiEmbed roomName={ROOM_NAME} onClose={() => setInCall(false)} />
-				)}
-			</Modal>
 		</SpaceBetween>
 	);
 }
 
 function MeetingsPage({ auth }: { auth: AuthState }) {
 	const { t } = useTranslation();
+	if (isBanned(auth)) {
+		return (
+			<Container>
+				<Alert type="error">{t("awsug.meetings.bannedMessage")}</Alert>
+			</Container>
+		);
+	}
 	if (!isMember(auth)) {
 		return (
 			<Container>

--- a/src/sites/awsug/meetings/app.tsx
+++ b/src/sites/awsug/meetings/app.tsx
@@ -38,7 +38,13 @@ function verifyJitsiIframe(): boolean {
 	return iframe.src.includes(JITSI_DOMAIN);
 }
 
-function MeetingsContent({ auth }: { auth: AuthState }) {
+function MeetingsContent({
+	auth,
+	onImmersiveChange,
+}: {
+	auth: AuthState;
+	onImmersiveChange: (immersive: boolean) => void;
+}) {
 	const { t } = useTranslation();
 	const [inCall, setInCall] = useState(false);
 	const [autoJoinFailed, setAutoJoinFailed] = useState(false);
@@ -49,27 +55,31 @@ function MeetingsContent({ auth }: { auth: AuthState }) {
 	const handleLeaveCall = useCallback(() => {
 		setInCall(false);
 		setIsAutoJoining(false);
+		onImmersiveChange(false);
 		if (fp021CheckRef.current) {
 			clearTimeout(fp021CheckRef.current);
 			fp021CheckRef.current = null;
 		}
-	}, []);
+	}, [onImmersiveChange]);
 
 	const handleManualJoin = useCallback(() => {
 		setAutoJoinFailed(false);
 		setAutoJoinError("");
 		setInCall(true);
-	}, []);
+		onImmersiveChange(true);
+	}, [onImmersiveChange]);
 
 	// Auto-join on mount for permitted users
 	useEffect(() => {
 		if (isBanned(auth)) {
 			setIsAutoJoining(false);
+			onImmersiveChange(false);
 			return;
 		}
 		// Mount the embed immediately — JitsiEmbed handles token fetch internally
 		setInCall(true);
-	}, [auth]);
+		onImmersiveChange(true);
+	}, [auth, onImmersiveChange]);
 
 	// FP-021 guard: after the embed has had time to initialize (15s),
 	// verify that the iframe src contains the jitsi domain. If not, surface
@@ -79,10 +89,9 @@ function MeetingsContent({ auth }: { auth: AuthState }) {
 		fp021CheckRef.current = setTimeout(() => {
 			if (!verifyJitsiIframe()) {
 				setAutoJoinFailed(true);
-				setAutoJoinError(
-					t("awsug.meetings.fp021Error"),
-				);
+				setAutoJoinError(t("awsug.meetings.fp021Error"));
 				setInCall(false);
+				onImmersiveChange(false);
 			}
 		}, 15_000);
 		return () => {
@@ -91,7 +100,7 @@ function MeetingsContent({ auth }: { auth: AuthState }) {
 				fp021CheckRef.current = null;
 			}
 		};
-	}, [inCall, t]);
+	}, [inCall, t, onImmersiveChange]);
 
 	// If the embed reports an error via onClose while auto-joining, treat as failure
 	const handleEmbedClose = useCallback(() => {
@@ -100,17 +109,14 @@ function MeetingsContent({ auth }: { auth: AuthState }) {
 			setAutoJoinError(t("awsug.meetings.autoJoinFailed"));
 		}
 		setInCall(false);
-	}, [isAutoJoining, t]);
+		onImmersiveChange(false);
+	}, [isAutoJoining, t, onImmersiveChange]);
 
 	if (inCall) {
 		return (
 			<SpaceBetween size="m">
 				<Box>
-					<Button
-						variant="link"
-						iconName="close"
-						onClick={handleLeaveCall}
-					>
+					<Button variant="link" iconName="close" onClick={handleLeaveCall}>
 						{t("awsug.meetings.leaveCall")}
 					</Button>
 				</Box>
@@ -139,7 +145,9 @@ function MeetingsContent({ auth }: { auth: AuthState }) {
 					{autoJoinError || t("awsug.meetings.autoJoinFailed")}
 				</Alert>
 			)}
-			<Container header={<Header variant="h1">{t("awsug.meetings.header")}</Header>}>
+			<Container
+				header={<Header variant="h1">{t("awsug.meetings.header")}</Header>}
+			>
 				<SpaceBetween size="m">
 					<Box>{t("awsug.meetings.openRoomDescription")}</Box>
 					<SpaceBetween direction="horizontal" size="s">
@@ -153,7 +161,11 @@ function MeetingsContent({ auth }: { auth: AuthState }) {
 				</SpaceBetween>
 			</Container>
 			{isModerator(auth) && (
-				<Container header={<Header variant="h2">{t("awsug.meetings.scheduleSession")}</Header>}>
+				<Container
+					header={
+						<Header variant="h2">{t("awsug.meetings.scheduleSession")}</Header>
+					}
+				>
 					<SpaceBetween size="s">
 						<Box>{t("awsug.meetings.scheduleDescription")}</Box>
 						<Button href="/create-meeting/index.html">
@@ -166,7 +178,13 @@ function MeetingsContent({ auth }: { auth: AuthState }) {
 	);
 }
 
-function MeetingsPage({ auth }: { auth: AuthState }) {
+function MeetingsPage({
+	auth,
+	onImmersiveChange,
+}: {
+	auth: AuthState;
+	onImmersiveChange: (immersive: boolean) => void;
+}) {
 	const { t } = useTranslation();
 	if (isBanned(auth)) {
 		return (
@@ -182,11 +200,23 @@ function MeetingsPage({ auth }: { auth: AuthState }) {
 			</Container>
 		);
 	}
-	return <MeetingsContent auth={auth} />;
+	return <MeetingsContent auth={auth} onImmersiveChange={onImmersiveChange} />;
 }
 
 function MeetingsWithLayout() {
 	const [auth, setAuth] = useState<AuthState | null>(null);
+	const [immersive, setImmersive] = useState(false);
+	const [navOpen, setNavOpen] = useState(true);
+
+	const handleImmersiveChange = useCallback((active: boolean) => {
+		setImmersive(active);
+		// Collapse navigation when entering the call; user can still reopen via hamburger
+		setNavOpen(!active);
+	}, []);
+
+	const handleNavigationChange = useCallback((open: boolean) => {
+		setNavOpen(open);
+	}, []);
 
 	useEffect(() => {
 		setAuth(requireAuth());
@@ -201,8 +231,12 @@ function MeetingsWithLayout() {
 	}
 
 	return (
-		<AwsugLayout>
-			<MeetingsPage auth={auth} />
+		<AwsugLayout
+			toolsHide={immersive}
+			navigationOpen={navOpen}
+			onNavigationChange={handleNavigationChange}
+		>
+			<MeetingsPage auth={auth} onImmersiveChange={handleImmersiveChange} />
 		</AwsugLayout>
 	);
 }

--- a/src/sites/awsug/meetings/app.tsx
+++ b/src/sites/awsug/meetings/app.tsx
@@ -19,7 +19,6 @@ import {
 	isModerator,
 	requireAuth,
 } from "../_shared/auth";
-import MyTickets from "./components/my-tickets";
 import "../rsvp/styles.css";
 
 const MEETUP_URL = "https://www.meetup.com/cloud-del-norte/";
@@ -30,7 +29,6 @@ function MeetingsContent({ auth }: { auth: AuthState }) {
 
 	return (
 		<SpaceBetween size="l">
-			<MyTickets auth={auth} />
 			<Container header={<Header variant="h1">meetings</Header>}>
 				<SpaceBetween size="m">
 					<Box>


### PR DESCRIPTION
## summary

closes #478

three commits:

1. **remove tickets widget** from the meetings page (MyTickets still used on rsvp page)
2. **auto-open the call room** on page load for authenticated members/moderators
3. **immersive layout** — collapse nav + hide tools panel while in the call

## failure-fallback behaviour

- if the jitsi token fetch fails or the embed's onClose fires during auto-join, the page renders a **Cloudscape Alert** with the error reason
- below the alert, the manual **open call room** button and the **view on meetup.com** link appear as fallback
- **FP-021 guard**: 15 seconds after the embed mounts, if no iframe with `src` containing `meet.clouddelnorte.org` exists, the page surfaces a visible error — "the meeting room did not load correctly" — and falls back to the manual button

## auth gate

- pending users: see 'pending approval' message, no auto-join attempt
- banned users: see 'suspended' message, no auto-join attempt
- members/moderators: auto-join immediately

## room name

preserves the existing deterministic shared value: `cloud-del-norte-awsug` (static string — all participants land in the same room)

## immersive layout

- `toolsHide={true}` hides the right-side help panel while in the call
- `navigationOpen={false}` collapses the left navigation drawer (user can still reopen via hamburger)
- on leave-call, both are restored to normal state
- Shell gains controlled `navigationOpen`/`onNavigationChange` props (mirrors existing `toolsOpen` pattern)
- iframe gains actual width because Cloudscape AppLayout reflows its content region when the drawer closes

## tests

12 new assertions covering: auto-mount without click, pending/banned gate, leave-call unmount + fallback, tickets widget absent, immersive layout activation + restoration, error handler wiring