### PR TITLE
fix(ops): correct ECS alarm metric name and make SNS subscription declarative

### DIFF
--- a/infra/jitsi-ops-alarms.cfn.yaml
+++ b/infra/jitsi-ops-alarms.cfn.yaml
@@ -136,6 +136,11 @@ Resources:
 
   # ---------------------------------------------------------------------------
   # Email subscription — SNS sends email directly (NOT via SES)
+  # SES in account 170473530355 is sandboxed with production access DENIED
+  # (case 177826280100472). This does NOT block SNS email subscriptions.
+  # SNS has its own SMTP infrastructure and bypasses SES entirely.
+  # Confirmation email and all subsequent notifications route through SNS
+  # directly — verified working regardless of SES sandbox state.
   # ---------------------------------------------------------------------------
   EmailSubscription:
     Type: AWS::SNS::Subscription
@@ -162,6 +167,17 @@ Resources:
   # Fires when the ECS service has zero running tasks for 1 minute.
   # TreatMissingData: breaching — if CloudWatch stops receiving data, that
   # itself means the service is gone.
+  #
+  # METRIC CHOICE: LiveTaskCount (AWS/ECS namespace).
+  # RunningTaskCount DOES NOT EXIST in the AWS/ECS namespace for this account
+  # (Container Insights publishes RunningTaskCount to ECS/ContainerInsights
+  # instead). Using RunningTaskCount here causes INSUFFICIENT_DATA — the alarm
+  # silently never fires, reproducing the exact failure it is meant to detect.
+  # LiveTaskCount is the native AWS/ECS metric for running tasks when Container
+  # Insights is enabled. Verified via:
+  #   aws cloudwatch list-metrics --namespace AWS/ECS --profile jitsi-video-hosting
+  # which returns LiveTaskCount with dimensions ServiceName + ClusterName.
+  # DO NOT revert to RunningTaskCount without re-verifying list-metrics output.
   # ---------------------------------------------------------------------------
   EcsZeroTasksAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -171,7 +187,7 @@ Resources:
         P0 — ECS service has zero running tasks. meet.clouddelnorte.org is
         completely down. Immediate action required.
       Namespace: AWS/ECS
-      MetricName: RunningTaskCount
+      MetricName: LiveTaskCount
       Dimensions:
         - Name: ClusterName
           Value: !Ref ClusterName


### PR DESCRIPTION
## Summary

Fixes two defects in the jitsi-ops-alarms CloudFormation template deployed tonight.

### Defect 1 — ECS alarm metric name (the important one)

The template specified `MetricName: RunningTaskCount` in the `AWS/ECS` namespace. That metric **does not exist** in this namespace for account 170473530355 — Container Insights publishes `RunningTaskCount` to the `ECS/ContainerInsights` namespace instead. The `AWS/ECS` namespace only carries `LiveTaskCount`.

The alarm deployed in `INSUFFICIENT_DATA`, meaning it would **never fire** — silently reproducing the exact failure mode it exists to prevent.

**Fix:** Changed `MetricName` from `RunningTaskCount` to `LiveTaskCount` (keeping `Namespace: AWS/ECS`). Added a detailed template comment explaining the metric choice and warning against reverting without re-verifying `list-metrics` output.

The live alarm was already hand-corrected via `put-metric-alarm` and is currently in OK state. This PR reconciles the template to match reality so a re-deploy doesn't revert the fix.

### Defect 2 — SNS subscription documentation

The template already had `NotificationEmail` and `NtfyEndpoint` parameters with conditional resources (the subscription design was correct). Added explicit documentation that **SNS email does NOT depend on SES** — the SES sandbox (case 177826280100472) does not block SNS notifications.

### Verification

All four alarms verified against live `list-metrics` output:

| Alarm | Namespace | MetricName | Dimensions | Live State |
|-------|-----------|------------|------------|-----------|
| jitsi-ecs-zero-tasks | AWS/ECS | LiveTaskCount | ClusterName=jitsi-cluster, ServiceName=jitsi-service | OK ✓ |
| jitsi-web-tg-unhealthy | AWS/ApplicationELB | HealthyHostCount | TargetGroup=targetgroup/jitsi-video-platform-web-tg/7b90ced35c6a251e, LoadBalancer=app/jitsi-video-platform-web-alb/eb20589340b9b170 | OK ✓ |
| jitsi-jvb-tcp-tg-unhealthy | AWS/NetworkELB | HealthyHostCount | TargetGroup=targetgroup/jitsi-video-platform-jvb-tcp-tg/bbccb8e61372091d, LoadBalancer=net/jitsi-video-platform-jvb-nlb/ab7e771c87580a1d | OK ✓ |
| jitsi-jvb-udp-tg-unhealthy | AWS/NetworkELB | HealthyHostCount | TargetGroup=targetgroup/jitsi-video-platform-jvb-udp-tg/ba46f9fe4d4c79b6, LoadBalancer=net/jitsi-video-platform-jvb-nlb/ab7e771c87580a1d | OK ✓ |

### Gates

- `aws cloudformation validate-template`: ✅ PASS
- `npx @biomejs/biome ci .`: 14 errors / 4 warnings — all **pre-existing** on main (same count, same files). Zero new errors introduced.

### Operator command to subscribe

```bash
# Email subscription (deployed with stack):
AWS_PROFILE=jitsi-video-hosting aws cloudformation deploy \
  --template-file infra/jitsi-ops-alarms.cfn.yaml \
  --stack-name jitsi-ops-alarms \
  --region us-west-2 \
  --parameter-overrides NotificationEmail=your@email.com \
  ...other params...

# Or add subscription to existing topic via CLI:
aws sns subscribe \
  --topic-arn arn:aws:sns:us-west-2:170473530355:jitsi-ops-alerts \
  --protocol email \
  --notification-endpoint your@email.com \
  --profile jitsi-video-hosting \
  --region us-west-2

# HTTPS (ntfy.sh):
aws sns subscribe \
  --topic-arn arn:aws:sns:us-west-2:170473530355:jitsi-ops-alerts \
  --protocol https \
  --notification-endpoint https://ntfy.sh/cdn-jitsi-ops-RANDOM8 \
  --profile jitsi-video-hosting \
  --region us-west-2
```

Refs #469